### PR TITLE
fix(ci): Update `prepare-commit-msg` to skip when `lerna publish` is running

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+. "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && cz --hook || true
+if [ "$2" != "message" ];then 
+    exec < /dev/tty && cz --hook "$1" "$2" "$3" || true
+fi


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #133 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
