### PR TITLE
ci: Fix release script to use Lerna to version and publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             HUSKY=0 npx lerna version --no-private --conventional-commits --yes
             fi
             
-            HUSKY=0 npx lerna publish from-git --yes
+            HUSKY=0 npx lerna publish from-git --no-private --yes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Notes for Reviewers**

This PR reverts the changes that was using NPM to publish, but NPM publish does not work in a monorepo layout. Using Lerna to version and publish.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
