### PR TITLE
Fix clickaway listner 

### DIFF
--- a/packages/components/src/custom/CustomColumnVisibilityControl.tsx
+++ b/packages/components/src/custom/CustomColumnVisibilityControl.tsx
@@ -22,11 +22,10 @@ export interface CustomColumn {
   label: string;
 }
 
-function CustomColumnVisibilityControl({
-  columns,
-  customToolsProps,
-  style
-}: CustomColumnVisibilityControlProps): JSX.Element {
+const CustomColumnVisibilityControl = React.forwardRef<
+  HTMLDivElement,
+  CustomColumnVisibilityControlProps
+>(({ columns, customToolsProps, style }: CustomColumnVisibilityControlProps, ref) => {
   const [open, setOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -48,7 +47,7 @@ function CustomColumnVisibilityControl({
   };
 
   return (
-    <div>
+    <div ref={ref}>
       <Tooltip title="View Columns" arrow>
         <IconButton
           onClick={handleOpen}
@@ -119,6 +118,6 @@ function CustomColumnVisibilityControl({
       </Popper>
     </div>
   );
-}
+});
 
 export default CustomColumnVisibilityControl;


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #
when using functional components in React with TypeScript, `React.forwardRef` is used to correctly handle and forward the ref attribute. It ensures proper typing and allows functional components to work with ref, which is commonly used for accessing and interacting with the DOM

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
