### PR TITLE
[CI] fix failing workflow: upgrade linter actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         
         steps:
             - name: Checkout code
-              uses: actions/checkout@@v4.1.1
+              uses: actions/checkout@v4.1.1
 
             - name: Set up Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
         
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@@v4.1.1
 
             - name: Set up Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4.0.0
               with:
                 node-version: ${{ matrix.node-version }}
       


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the lint.yaml workflow, which has been failing. This PR eliminates the node12 error message seen while using older version of the Actions. The pre-existing issue with eslint not being available persists, though:

```
Run yarn lint && yarn format:check && yarn lint-staged

Oops! Something went wrong! :(

ESLint: 8.50.0

ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".

(The package "@typescript-eslint/eslint-plugin" was not found when loaded as a Node module from the directory "/home/runner/work/sistent/sistent/apps/design-system".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install @typescript-eslint/eslint-plugin@latest --save-dev

The plugin "@typescript-eslint/eslint-plugin" was referenced from the config file in "apps/design-system/.eslintrc.cjs".

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.

Error: Process completed with exit code 2.
```






- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
