### PR TITLE
[Components] Add sistent naming convention for our components

### DIFF
--- a/packages/components/src/theme/components.ts
+++ b/packages/components/src/theme/components.ts
@@ -1,34 +1,36 @@
 import { Components, Theme } from '@mui/material';
-import { MuiAppBar } from './components/appbar.modifiter';
-import { MuiCard } from './components/card.modifier';
-import { MuiCheckbox } from './components/checkbox.modifier';
-import { MuiCollapse } from './components/collapse.modifier';
-import { MuiCssBaseline } from './components/cssbaseline.modifier';
-import { MuiDrawer } from './components/drawer.modifier';
-import { MuiFormLabel } from './components/formlabel.modifier';
-import { MuiIconButton } from './components/iconbutton.modifier';
-import { MuiLink } from './components/link.modifier';
-import { MuiMenu } from './components/menu.modifier';
-import { MuiMenuItem } from './components/menuitem.modifier';
-import { MuiOutlinedInput } from './components/outlinedinput.modifier';
-import { MuiPagination } from './components/pagination.modifier';
-import { MuiSvgIcon } from './components/svgicon.modifier';
-import { MuiTab } from './components/tab.modifier.ts';
+import { SistentAppBar } from './components/appbar.modifiter';
+import { SistentButton } from './components/button.modifier';
+import { SistentCard } from './components/card.modifier';
+import { SistentCheckbox } from './components/checkbox.modifier';
+import { SistentCollapse } from './components/collapse.modifier';
+import { SistentCssBaseline } from './components/cssbaseline.modifier';
+import { SistentDrawer } from './components/drawer.modifier';
+import { SistentFormLabel } from './components/formlabel.modifier';
+import { SistentIconButton } from './components/iconbutton.modifier';
+import { SistentLink } from './components/link.modifier';
+import { SistentMenu } from './components/menu.modifier';
+import { SistentMenuItem } from './components/menuitem.modifier';
+import { SistentOutlinedInput } from './components/outlinedinput.modifier';
+import { SistentPagination } from './components/pagination.modifier';
+import { SistentSvgIcon } from './components/svgicon.modifier';
+import { SistentTab } from './components/tab.modifier.ts';
 
 export const components: Components<Theme> = {
-  MuiAppBar,
-  MuiCard,
-  MuiCheckbox,
-  MuiCollapse,
-  MuiCssBaseline,
-  MuiDrawer,
-  MuiFormLabel,
-  MuiIconButton,
-  MuiLink,
-  MuiMenu,
-  MuiMenuItem,
-  MuiOutlinedInput,
-  MuiPagination,
-  MuiSvgIcon,
-  MuiTab
+  MuiAppBar: SistentAppBar,
+  MuiCard: SistentCard,
+  MuiCheckbox: SistentCheckbox,
+  MuiCollapse: SistentCollapse,
+  MuiCssBaseline: SistentCssBaseline,
+  MuiDrawer: SistentDrawer,
+  MuiFormLabel: SistentFormLabel,
+  MuiIconButton: SistentIconButton,
+  MuiLink: SistentLink,
+  MuiMenu: SistentMenu,
+  MuiMenuItem: SistentMenuItem,
+  MuiOutlinedInput: SistentOutlinedInput,
+  MuiPagination: SistentPagination,
+  MuiSvgIcon: SistentSvgIcon,
+  MuiTab: SistentTab,
+  MuiButton: SistentButton
 };

--- a/packages/components/src/theme/components/appbar.modifiter.ts
+++ b/packages/components/src/theme/components/appbar.modifiter.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { drawerWidth } from '../theme';
 
-export const MuiAppBar: Components<Theme>['MuiAppBar'] = {
+export const SistentAppBar: Components<Theme>['MuiAppBar'] = {
   styleOverrides: {
     root: ({ theme }) => {
       const {

--- a/packages/components/src/theme/components/button.modifier.ts
+++ b/packages/components/src/theme/components/button.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiButton: Components<Theme>['MuiButton'] = {
+export const SistentButton: Components<Theme>['MuiButton'] = {
   styleOverrides: {
     root: {}
   }

--- a/packages/components/src/theme/components/card.modifier.ts
+++ b/packages/components/src/theme/components/card.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiCard: Components<Theme>['MuiCard'] = {
+export const SistentCard: Components<Theme>['MuiCard'] = {
   styleOverrides: {
     root: {
       backgroundImage:

--- a/packages/components/src/theme/components/checkbox.modifier.ts
+++ b/packages/components/src/theme/components/checkbox.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { CHARCOAL, connected, darkSlateGray } from '../colors';
 
-export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
+export const SistentCheckbox: Components<Theme>['MuiCheckbox'] = {
   styleOverrides: {
     root: {
       color: 'transparent',

--- a/packages/components/src/theme/components/collapse.modifier.ts
+++ b/packages/components/src/theme/components/collapse.modifier.ts
@@ -10,7 +10,7 @@ declare module '@mui/material/Collapse' {
   }
 }
 
-export const MuiCollapse: Components<Theme>['MuiCollapse'] = {
+export const SistentCollapse: Components<Theme>['MuiCollapse'] = {
   styleOverrides: {
     root: {}
   },

--- a/packages/components/src/theme/components/cssbaseline.modifier.ts
+++ b/packages/components/src/theme/components/cssbaseline.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiCssBaseline: Components<Theme>['MuiCssBaseline'] = {
+export const SistentCssBaseline: Components<Theme>['MuiCssBaseline'] = {
   styleOverrides: `
     @font-face {
       font-family: 'Qanelas Soft Regular';

--- a/packages/components/src/theme/components/drawer.modifier.ts
+++ b/packages/components/src/theme/components/drawer.modifier.ts
@@ -2,7 +2,7 @@ import { Components, Theme } from '@mui/material';
 import { DARK_BLUE_GRAY } from '../colors';
 import { drawerWidth } from '../theme';
 
-export const MuiDrawer: Components<Theme>['MuiDrawer'] = {
+export const SistentDrawer: Components<Theme>['MuiDrawer'] = {
   styleOverrides: {
     root: {
       width: drawerWidth,

--- a/packages/components/src/theme/components/formlabel.modifier.ts
+++ b/packages/components/src/theme/components/formlabel.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { connected } from '../colors';
 
-export const MuiFormLabel: Components<Theme>['MuiFormLabel'] = {
+export const SistentFormLabel: Components<Theme>['MuiFormLabel'] = {
   styleOverrides: {
     root: {
       '&.Mui-focused': {

--- a/packages/components/src/theme/components/iconbutton.modifier.ts
+++ b/packages/components/src/theme/components/iconbutton.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiIconButton: Components<Theme>['MuiIconButton'] = {
+export const SistentIconButton: Components<Theme>['MuiIconButton'] = {
   styleOverrides: {
     root: {
       '@media (max-width: 400px)': {

--- a/packages/components/src/theme/components/link.modifier.ts
+++ b/packages/components/src/theme/components/link.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { connected, darkTeal } from '../colors';
 
-export const MuiLink: Components<Theme>['MuiLink'] = {
+export const SistentLink: Components<Theme>['MuiLink'] = {
   styleOverrides: {
     root: {
       fontWeight: '600',

--- a/packages/components/src/theme/components/menu.modifier.ts
+++ b/packages/components/src/theme/components/menu.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiMenu: Components<Theme>['MuiMenu'] = {
+export const SistentMenu: Components<Theme>['MuiMenu'] = {
   styleOverrides: {
     paper: {
       '& .MuiMenuItem-root.Mui-selected': {

--- a/packages/components/src/theme/components/menuitem.modifier.ts
+++ b/packages/components/src/theme/components/menuitem.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { darkTeal } from '../colors';
 
-export const MuiMenuItem: Components<Theme>['MuiMenuItem'] = {
+export const SistentMenuItem: Components<Theme>['MuiMenuItem'] = {
   styleOverrides: {
     root: {
       '&:hover': {

--- a/packages/components/src/theme/components/outlinedinput.modifier.ts
+++ b/packages/components/src/theme/components/outlinedinput.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { defaultPalette } from '../colors';
 
-export const MuiOutlinedInput: Components<Theme>['MuiOutlinedInput'] = {
+export const SistentOutlinedInput: Components<Theme>['MuiOutlinedInput'] = {
   styleOverrides: {
     root: {
       '&:hover $notchedOutline': {

--- a/packages/components/src/theme/components/pagination.modifier.ts
+++ b/packages/components/src/theme/components/pagination.modifier.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { anakiwa, connected, white } from '../colors';
 
-export const MuiPagination: Components<Theme>['MuiPagination'] = {
+export const SistentPagination: Components<Theme>['MuiPagination'] = {
   styleOverrides: {
     root: {
       button: {

--- a/packages/components/src/theme/components/svgicon.modifier.ts
+++ b/packages/components/src/theme/components/svgicon.modifier.ts
@@ -1,6 +1,6 @@
 import { Components, Theme } from '@mui/material';
 
-export const MuiSvgIcon: Components<Theme>['MuiSvgIcon'] = {
+export const SistentSvgIcon: Components<Theme>['MuiSvgIcon'] = {
   styleOverrides: {
     root: {
       height: 24,

--- a/packages/components/src/theme/components/tab.modifier.ts.ts
+++ b/packages/components/src/theme/components/tab.modifier.ts.ts
@@ -1,7 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { actionIcon, white } from '../colors';
 
-export const MuiTab: Components<Theme>['MuiTab'] = {
+export const SistentTab: Components<Theme>['MuiTab'] = {
   styleOverrides: {
     root: {
       '&.Mui-selected': {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

For being consistent we can use the sistent naming convention instead of mui for exporting these  theme based components.


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
