### PR TITLE
Figma design file link update

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,4 +4,4 @@ contact_links:
 - name: 🙋🏾🙋🏼‍Question
   url: https://github.com/layer5io/meshery/discussions/new
   about: Submit your question using GitHub Discussions.
-- 🎨 Wireframes and [designs for Layer5 site](https://www.figma.com/file/5ZwEkSJwUPitURD59YHMEN/Layer5-Designs) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)
+- 🎨 Wireframes and [designs for Sistent site](https://www.figma.com/file/ekm0Hh6M25bSKpP5BcIJom/Sistent-Design-System?type=design&node-id=596%3A5227&mode=design&t=8MExPykHN1vQFCTZ-1) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/qJy1c95qirjgWQODApilR9)


### PR DESCRIPTION
The links to the Figma design file have been updated from the Layer5 link to the Sistent link

**Notes for Reviewers**

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
