### PR TITLE
Refactor and add theme in where missing in components

### DIFF
--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -1,0 +1,9 @@
+| Component   | Dark                                                                              | Light                                                                              |
+| ----------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Paper       | Background: #E8EFF3                                                               | Background: #15272F                                                                |
+| Button      |                                                                                   |                                                                                    |
+| - Contained | Background: #00B39F                                                               | Background: #00B39F                                                                |
+| - Outlined  | Border: #00B39F                                                                   | Border: #00B39F                                                                    |
+| - Disable   | Background: #b0bec5                                                               | Background: #b0bec5                                                                |
+| IconButton  | color: #F6F8F8 <br> hover: #00B39F                                                | color: #607d8b <br> hover: #00B39F                                                 |
+| Checkbox    | checked : <br> color: #00B39F<br><br>Unchecked: <br> SvgIcon bordercolor: #00B39F | color : <br> checked: #294957 <br><br>Unchecked: <br> SvgIcon bordercolor: #3C494F |

--- a/src/theme/README.md
+++ b/src/theme/README.md
@@ -1,9 +1,9 @@
-| Component   | Dark                                                                              | Light                                                                              |
-| ----------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Paper       | Background: #E8EFF3                                                               | Background: #15272F                                                                |
-| Button      |                                                                                   |                                                                                    |
-| - Contained | Background: #00B39F                                                               | Background: #00B39F                                                                |
-| - Outlined  | Border: #00B39F                                                                   | Border: #00B39F                                                                    |
-| - Disable   | Background: #b0bec5                                                               | Background: #b0bec5                                                                |
-| IconButton  | color: #F6F8F8 <br> hover: #00B39F                                                | color: #607d8b <br> hover: #00B39F                                                 |
-| Checkbox    | checked : <br> color: #00B39F<br><br>Unchecked: <br> SvgIcon bordercolor: #00B39F | color : <br> checked: #294957 <br><br>Unchecked: <br> SvgIcon bordercolor: #3C494F |
+| Component   | Dark                                                                          | Light                                                                         |
+| ----------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Paper       | Background: #E8EFF3                                                           | Background: #15272F                                                           |
+| Button      |                                                                               |                                                                               |
+| - Contained | Background: #00B39F                                                           | Background: #00B39F                                                           |
+| - Outlined  | Border: #00B39F                                                               | Border: #00B39F                                                               |
+| - Disabled  | Background: #b0bec5                                                           | Background: #b0bec5                                                           |
+| IconButton  | color: #F6F8F8<br>hover: #00B39F                                              | color: #607d8b<br>hover: #00B39F                                              |
+| Checkbox    | Checked:<br>color: #00B39F<br><br>Unchecked:<br>SvgIcon border color: #00B39F | Color:<br>Checked: #294957<br><br>Unchecked:<br>SvgIcon border color: #3C494F |

--- a/src/theme/colors/colors.ts
+++ b/src/theme/colors/colors.ts
@@ -203,6 +203,11 @@ export const cultured = {
   main: CULTURED
 };
 
+export const lightGray = {
+  main: LIGHT_TEAL,
+  dark: CULTURED
+};
+
 export const darkTeal = {
   main: DARK_TEAL,
   dark: LIGHT_TEAL

--- a/src/theme/components/checkbox.modifier.ts
+++ b/src/theme/components/checkbox.modifier.ts
@@ -1,18 +1,19 @@
 import { Components, Theme } from '@mui/material';
-import { connected, darkSlateGray } from '../colors';
+import { connected } from '../colors';
 
 export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
   styleOverrides: {
     root: ({ theme }) => {
       const {
         palette: {
-          primary: { main }
+          primary: { main },
+          checkbox: { main: checkboxMain }
         }
       } = theme;
       return {
         color: 'transparent',
         '&.Mui-checked': {
-          color: darkSlateGray.main,
+          color: checkboxMain,
           '& .MuiSvgIcon-root': {
             width: '1.25rem',
             height: '1.25rem',

--- a/src/theme/components/checkbox.modifier.ts
+++ b/src/theme/components/checkbox.modifier.ts
@@ -1,30 +1,37 @@
 import { Components, Theme } from '@mui/material';
-import { CHARCOAL, connected, darkSlateGray } from '../colors';
+import { connected, darkSlateGray } from '../colors';
 
 export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
   styleOverrides: {
-    root: {
-      color: 'transparent',
-      '&.Mui-checked': {
-        color: darkSlateGray.main,
+    root: ({ theme }) => {
+      const {
+        palette: {
+          primary: { main }
+        }
+      } = theme;
+      return {
+        color: 'transparent',
+        '&.Mui-checked': {
+          color: darkSlateGray.main,
+          '& .MuiSvgIcon-root': {
+            width: '1.25rem',
+            height: '1.25rem',
+            borderColor: connected.main,
+            marginLeft: '0px',
+            padding: '0px'
+          }
+        },
         '& .MuiSvgIcon-root': {
           width: '1.25rem',
           height: '1.25rem',
-          borderColor: connected.main,
-          marginLeft: '0px',
+          border: `.75px solid ${main}`,
+          borderRadius: '2px',
           padding: '0px'
+        },
+        '&:hover': {
+          backgroundColor: 'transparent'
         }
-      },
-      '& .MuiSvgIcon-root': {
-        width: '1.25rem',
-        height: '1.25rem',
-        border: `.75px solid ${CHARCOAL}`,
-        borderRadius: '2px',
-        padding: '0px'
-      },
-      '&:hover': {
-        backgroundColor: 'transparent'
-      }
+      };
     }
   }
 };

--- a/src/theme/components/iconbutton.modifier.ts
+++ b/src/theme/components/iconbutton.modifier.ts
@@ -1,11 +1,24 @@
 import { Components, Theme } from '@mui/material';
+import { KEPPEL } from '../colors';
 
 export const MuiIconButton: Components<Theme>['MuiIconButton'] = {
   styleOverrides: {
-    root: {
-      '@media (max-width: 400px)': {
-        padding: '2px'
-      }
+    root: ({ theme }) => {
+      const {
+        palette: {
+          iconButton: { main }
+        }
+      } = theme;
+      return {
+        color: main,
+        '&:hover': {
+          color: KEPPEL,
+          backgroundColor: 'none'
+        },
+        '@media (max-width: 400px)': {
+          padding: '2px'
+        }
+      };
     }
   }
 };

--- a/src/theme/components/paper.modifier.ts
+++ b/src/theme/components/paper.modifier.ts
@@ -1,0 +1,16 @@
+import { Components, Theme } from '@mui/material';
+
+export const MuiPaper: Components<Theme>['MuiPaper'] = {
+  styleOverrides: {
+    root: ({ theme }) => {
+      const {
+        palette: {
+          background: { paper }
+        }
+      } = theme;
+      return {
+        backgroundColor: paper
+      };
+    }
+  }
+};

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -9,6 +9,7 @@ import {
   cultured,
   notificationColors
 } from './colors';
+import { lightGray } from './colors/colors';
 
 declare module '@mui/material/styles' {
   interface PaletteColor {
@@ -30,6 +31,9 @@ declare module '@mui/material/styles' {
       main: string;
       hover: string;
     };
+    iconButton: {
+      main: string;
+    };
   }
   interface PaletteOptions {
     neutral?: PaletteOptions['primary'];
@@ -43,6 +47,9 @@ declare module '@mui/material/styles' {
     buttonDelete?: {
       main?: string;
       hover?: string;
+    };
+    iconButton?: {
+      main?: string;
     };
   }
 }
@@ -81,6 +88,9 @@ export const lightModePalette: PaletteOptions = {
   },
   cultured: {
     main: cultured.main
+  },
+  iconButton: {
+    main: lightGray.main
   },
   actionIcon: {
     main: actionIcon.main,
@@ -128,6 +138,9 @@ export const darkModePalette: PaletteOptions = {
   common: {
     black: common.black,
     white: common.white
+  },
+  iconButton: {
+    main: lightGray.dark
   },
   neutral: {}
 };

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -9,7 +9,7 @@ import {
   cultured,
   notificationColors
 } from './colors';
-import { lightGray } from './colors/colors';
+import { darkSlateGray, lightGray } from './colors/colors';
 
 declare module '@mui/material/styles' {
   interface PaletteColor {
@@ -34,6 +34,9 @@ declare module '@mui/material/styles' {
     iconButton: {
       main: string;
     };
+    checkbox: {
+      main: string;
+    };
   }
   interface PaletteOptions {
     neutral?: PaletteOptions['primary'];
@@ -49,6 +52,9 @@ declare module '@mui/material/styles' {
       hover?: string;
     };
     iconButton?: {
+      main?: string;
+    };
+    checkbox?: {
       main?: string;
     };
   }
@@ -100,6 +106,9 @@ export const lightModePalette: PaletteOptions = {
     main: buttonDelete.main,
     hover: buttonDelete.hover
   },
+  checkbox: {
+    main: darkSlateGray.main
+  },
   neutral: {},
   text: {}
 };
@@ -141,6 +150,9 @@ export const darkModePalette: PaletteOptions = {
   },
   iconButton: {
     main: lightGray.dark
+  },
+  checkbox: {
+    main: KEPPEL
   },
   neutral: {}
 };


### PR DESCRIPTION
**Notes for Reviewers**

## Description
This pr adds theme ref to component where we need but referencing direct colors and add components that were not previously added


> [!NOTE]
> I have provided a readme where i am listing the theme according to the mode which is available in figma and defined in sistent. @Rexford74 we need more to be published, all components are not available or documented what are there default dark and light colors

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
