### PR TITLE
Fix re render bug when using `ResponsiveDataTable`

### DIFF
--- a/src/custom/ResponsiveDataTable.tsx
+++ b/src/custom/ResponsiveDataTable.tsx
@@ -1,5 +1,5 @@
 import MUIDataTable from 'mui-datatables';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 export interface Column {
   name: string;
@@ -76,7 +76,7 @@ const ResponsiveDataTable = ({
     }
   };
 
-  React.useEffect(() => {
+  const updateColumnsEffect = useCallback(() => {
     columns?.forEach((col) => {
       if (typeof col === 'object' && col !== null) {
         if (!col.options) {
@@ -117,7 +117,13 @@ const ResponsiveDataTable = ({
       }
     });
     updateCols && updateCols([...columns]);
-  }, [columnVisibility, columns, updateCols]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columnVisibility, updateCols]);
+
+  React.useEffect(() => {
+    updateColumnsEffect();
+  }, [updateColumnsEffect]);
 
   const components = {
     ExpandButton: () => ''


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #521 

### What are the changes
- Applied useCallback: We applied the useCallback hook to the updateColumnsEffect function. This memoizes the function and prevents unnecessary re-renders when its dependencies (columnVisibility and updateCols) change.

- Removed Dependencies: We removed columns and updateCols from the dependency array of updateColumnsEffect. This prevents re-renders caused by changes in these dependencies, as they are not directly used within the function.

- Optimized useEffect: We updated the useEffect hook to only depend on updateColumnsEffect. This ensures that the effect runs whenever updateColumnsEffect changes, effectively triggering the updates related to column visibility.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
