### PR TITLE
[Chore] Skip lint checking of workflows and markdown files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - '*'
+    paths-ignore:
+      - 'system/**/*'
+      - '.github/**/*'
+      - '*.md'
   pull_request:
     branches:
       - '*'
-
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Notes for Reviewers**

This PR shaves a few seconds off of PRs that don't need javascript lint checks to be run.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
