### PR TITLE
Feat: Separate Markdown Renderer for Tooltips

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, type TooltipProps } from '@mui/material';
 import React from 'react';
 import { CHARCOAL, WHITE } from '../../theme';
-import RenderMarkdown from '../Markdown';
+import { RenderMarkdownTooltip } from '../Markdown';
 
 type CustomTooltipProps = {
   title: string | React.ReactNode | JSX.Element;
@@ -9,6 +9,7 @@ type CustomTooltipProps = {
   children: React.ReactNode;
   fontSize?: string;
   fontWeight?: number;
+  variant?: 'standard' | 'small';
 } & Omit<TooltipProps, 'title' | 'onClick'>;
 
 function CustomTooltip({
@@ -16,8 +17,9 @@ function CustomTooltip({
   onClick,
   placement,
   children,
-  fontSize = '1rem',
+  fontSize,
   fontWeight = 400,
+  variant = 'small',
   ...props
 }: CustomTooltipProps): JSX.Element {
   return (
@@ -27,10 +29,10 @@ function CustomTooltip({
           sx: {
             background: CHARCOAL,
             color: WHITE,
-            fontSize: { fontSize },
+            fontSize: fontSize || (variant === 'standard' ? '1rem' : '0.75rem'),
             fontWeight: { fontWeight },
             borderRadius: '0.5rem',
-            padding: '0.9rem'
+            padding: variant === 'standard' ? '0.9rem' : '0.5rem 0.75rem'
           }
         },
         popper: {
@@ -39,7 +41,7 @@ function CustomTooltip({
           }
         }
       }}
-      title={<RenderMarkdown content={typeof title === 'string' ? title : ''} />}
+      title={<RenderMarkdownTooltip content={typeof title === 'string' ? title : ''} />}
       placement={placement}
       arrow
       onClick={onClick}

--- a/src/custom/Markdown/index.tsx
+++ b/src/custom/Markdown/index.tsx
@@ -10,19 +10,22 @@ import {
   StyledMarkdownH5,
   StyledMarkdownH6,
   StyledMarkdownLi,
+  StyledMarkdownP,
   StyledMarkdownTd,
   StyledMarkdownTh,
+  StyledMarkdownTooltipP,
   StyledMarkdownUl
 } from './style';
 export interface RenderMarkdownProps {
   content: string;
 }
 
-const RenderMarkdown: React.FC<RenderMarkdownProps> = ({ content }) => {
+export const RenderMarkdown: React.FC<RenderMarkdownProps> = ({ content }) => {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
+        p: ({ ...props }) => <StyledMarkdownP>{props.children}</StyledMarkdownP>,
         a: ({ ...props }) => <StyledMarkdown>{props.children}</StyledMarkdown>,
         h1: ({ ...props }) => <StyledMarkdownH1>{props.children}</StyledMarkdownH1>,
         h2: ({ ...props }) => <StyledMarkdownH2>{props.children}</StyledMarkdownH2>,
@@ -44,4 +47,29 @@ const RenderMarkdown: React.FC<RenderMarkdownProps> = ({ content }) => {
   );
 };
 
-export default RenderMarkdown;
+export const RenderMarkdownTooltip: React.FC<RenderMarkdownProps> = ({ content }) => {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        p: ({ ...props }) => <StyledMarkdownTooltipP>{props.children}</StyledMarkdownTooltipP>,
+        a: ({ ...props }) => <StyledMarkdown>{props.children}</StyledMarkdown>,
+        h1: ({ ...props }) => <StyledMarkdownH1>{props.children}</StyledMarkdownH1>,
+        h2: ({ ...props }) => <StyledMarkdownH2>{props.children}</StyledMarkdownH2>,
+        h3: ({ ...props }) => <StyledMarkdownH3>{props.children}</StyledMarkdownH3>,
+        h4: ({ ...props }) => <StyledMarkdownH4>{props.children}</StyledMarkdownH4>,
+        h5: ({ ...props }) => <StyledMarkdownH5>{props.children}</StyledMarkdownH5>,
+        h6: ({ ...props }) => <StyledMarkdownH6>{props.children}</StyledMarkdownH6>,
+        blockquote: ({ ...props }) => (
+          <StyledMarkdownBlockquote>{props.children}</StyledMarkdownBlockquote>
+        ),
+        ul: ({ ...props }) => <StyledMarkdownUl>{props.children}</StyledMarkdownUl>,
+        li: ({ ...props }) => <StyledMarkdownLi>{props.children}</StyledMarkdownLi>,
+        th: ({ ...props }) => <StyledMarkdownTh>{props.children}</StyledMarkdownTh>,
+        td: ({ ...props }) => <StyledMarkdownTd>{props.children}</StyledMarkdownTd>
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+};

--- a/src/custom/Markdown/style.tsx
+++ b/src/custom/Markdown/style.tsx
@@ -13,6 +13,11 @@ export const StyledMarkdownP = styled('p')(({ theme }) => ({
   ...theme.typography.textB1Regular
 }));
 
+export const StyledMarkdownTooltipP = styled('p')(({ theme }) => ({
+  color: theme.palette.text.default,
+  marginBlock: '0px'
+}));
+
 export const StyledMarkdownH1 = styled('h1')(({ theme }) => ({
   color: theme.palette.text.default
 }));

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -28,7 +28,7 @@ import { FlipCard, FlipCardProps } from './FlipCard';
 import { useWindowDimensions } from './Helpers/Dimension';
 import { useNotificationHandler } from './Helpers/Notification';
 import { LearningCard } from './LearningCard';
-import RenderMarkdown from './Markdown';
+import { RenderMarkdown } from './Markdown';
 import { ModalCard } from './ModalCard';
 import PopperListener, { IPopperListener } from './PopperListener';
 import ResponsiveDataTable, { ResponsiveDataTableProps } from './ResponsiveDataTable';


### PR DESCRIPTION
**Notes for Reviewers**

This PR adds a new mardown renderer, as the old one was causing issues with keeping the custom tooltips consistent with Figma designs. 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
