### PR TITLE
Fix onClick func for `a` tag for tooltips 

### DIFF
--- a/src/custom/Markdown/index.tsx
+++ b/src/custom/Markdown/index.tsx
@@ -26,7 +26,17 @@ export const RenderMarkdown: React.FC<RenderMarkdownProps> = ({ content }) => {
       remarkPlugins={[remarkGfm]}
       components={{
         p: ({ ...props }) => <StyledMarkdownP>{props.children}</StyledMarkdownP>,
-        a: ({ ...props }) => <StyledMarkdown>{props.children}</StyledMarkdown>,
+        a: ({ ...props }) => (
+          <StyledMarkdown
+            onClick={(e) => {
+              e.preventDefault();
+              window.open(props.href, '_blank');
+            }}
+            href={props.href}
+          >
+            {props.children}
+          </StyledMarkdown>
+        ),
         h1: ({ ...props }) => <StyledMarkdownH1>{props.children}</StyledMarkdownH1>,
         h2: ({ ...props }) => <StyledMarkdownH2>{props.children}</StyledMarkdownH2>,
         h3: ({ ...props }) => <StyledMarkdownH3>{props.children}</StyledMarkdownH3>,
@@ -53,7 +63,17 @@ export const RenderMarkdownTooltip: React.FC<RenderMarkdownProps> = ({ content }
       remarkPlugins={[remarkGfm]}
       components={{
         p: ({ ...props }) => <StyledMarkdownTooltipP>{props.children}</StyledMarkdownTooltipP>,
-        a: ({ ...props }) => <StyledMarkdown>{props.children}</StyledMarkdown>,
+        a: ({ ...props }) => (
+          <StyledMarkdown
+            onClick={(e) => {
+              e.preventDefault();
+              window.open(props.href, '_blank');
+            }}
+            href={props.href}
+          >
+            {props.children}
+          </StyledMarkdown>
+        ),
         h1: ({ ...props }) => <StyledMarkdownH1>{props.children}</StyledMarkdownH1>,
         h2: ({ ...props }) => <StyledMarkdownH2>{props.children}</StyledMarkdownH2>,
         h3: ({ ...props }) => <StyledMarkdownH3>{props.children}</StyledMarkdownH3>,

--- a/src/custom/Markdown/style.tsx
+++ b/src/custom/Markdown/style.tsx
@@ -6,7 +6,8 @@ export const StyledMarkdown = styled('a')(({ theme }) => ({
   textDecoration: 'none',
   '&:hover': {
     textDecoration: 'underline'
-  }
+  },
+  cursor: 'pointer'
 }));
 
 export const StyledMarkdownP = styled('p')(({ theme }) => ({


### PR DESCRIPTION
Signed-off-by: Sudhanshu Dasgupta <dasguptashivam23@gmail.com>

**Notes for Reviewers**

This PR fixes the onclick functionality with anchor tags inside tooltips which was not clickable

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
