### PR TITLE
[Tooltip] Update zindex and title display condition

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -39,11 +39,12 @@ function CustomTooltip({
         },
         popper: {
           sx: {
+            zIndex: 99999,
             opacity: '1'
           }
         }
       }}
-      title={<RenderMarkdownTooltip content={typeof title === 'string' ? title : ''} />}
+      title={typeof title === 'string' ? <RenderMarkdownTooltip content={title} /> : title}
       placement={placement}
       arrow
       onClick={onClick}

--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -39,7 +39,7 @@ function CustomTooltip({
         },
         popper: {
           sx: {
-            zIndex: 99999,
+            zIndex: 9999999999,
             opacity: '1'
           }
         }


### PR DESCRIPTION
**Notes for Reviewers**

- In meshery UI, ziCalc is used to give tooltips a zindex of ziCalc(5), so I instead migrated it here, thus eliminating the need for ziCalc in meshery and meshery cloud.
Moreover, in meshmap  many components are given a high zindex which results in the tooltip not displaying properly.
In meshmap, no ziCalc value exceeds ziCalc(9) and thus I have set this value to remedy the problem there too.

- The tooltip was also not rendering content which was not in string format making it hard to catch bugs and refactor.
So I updated the condition for title usage.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
