### PR TITLE
Fix feedback component to use standard style

### DIFF
--- a/src/custom/Feedback/FeedbackButton.tsx
+++ b/src/custom/Feedback/FeedbackButton.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../icons';
 import { CULTURED } from '../../theme';
 import { CustomTooltip } from '../CustomTooltip';
+import { ModalButtonPrimary } from '../Modal';
 import { ModalCard } from '../ModalCard';
 import {
   ActionWrapper,
@@ -21,7 +22,6 @@ import {
   FeedbackMiniIcon,
   FeedbackOptionButton,
   FeedbackOptions,
-  FeedbackSubmitButton,
   FeedbackTextArea,
   HelperWrapper,
   InnerComponentWrapper,
@@ -166,14 +166,14 @@ const FeedbackComponent: React.FC<FeedbackComponentProps> = ({
                       We may email you for more information or updates
                     </Typography>
                   </ActionWrapper>
-                  <FeedbackSubmitButton
+                  <ModalButtonPrimary
                     type="submit"
                     disabled={!(messageValue && isChecked)}
                     isOpen={!(messageValue && isChecked)}
                     onClick={handleSubmit}
                   >
                     Send
-                  </FeedbackSubmitButton>
+                  </ModalButtonPrimary>
                 </div>
               }
               leftHeaderIcon={<FeedbackIcon />}

--- a/src/custom/Feedback/style.tsx
+++ b/src/custom/Feedback/style.tsx
@@ -218,7 +218,7 @@ export const FeedbackMessage = styled(Box)<FeedbackMessageProps>(({ isOpen, them
   position: 'relative',
   bottom: isOpen ? '0px' : '-240px',
   right: '0',
-  color: BLACK,
+  color: theme.palette.text.default,
   backgroundColor: theme.palette.mode === 'dark' ? DARK_JUNGLE_GREEN : WHITE,
   border: `1px solid ${MEDIUM_GREY}`,
   padding: '20px',

--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { DialogProps, styled } from '@mui/material';
+import { ButtonProps, DialogProps, styled } from '@mui/material';
 import React, { useRef, useState } from 'react';
 import { Dialog, IconButton, Paper, Typography } from '../../base';
 import { ContainedButton, OutlinedButton, TextButton } from '../../base/Button/Button';
@@ -171,18 +171,24 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({ helpText, children, va
   );
 };
 
+interface ModalButtonPrimaryProps extends ButtonProps {
+  isOpen: boolean;
+}
+
 // ModalButtonPrimary
-export const ModalButtonPrimary: React.FC = styled(ContainedButton)(({ theme }) => ({
-  backgroundColor: theme.palette.background.brand?.default,
-  color: theme.palette.text.constant?.white,
-  '&:hover': {
-    background: theme.palette.background.brand?.hover
-  },
-  '&.MuiButton-contained.Mui-disabled': {
-    color: theme.palette.text.constant?.disabled,
-    backgroundColor: theme.palette.background.constant?.disabled
-  }
-}));
+export const ModalButtonPrimary: React.FC<ModalButtonPrimaryProps> = styled(ContainedButton)(
+  ({ theme }) => ({
+    backgroundColor: theme.palette.background.brand?.default,
+    color: theme.palette.text.constant?.white,
+    '&:hover': {
+      background: theme.palette.background.brand?.hover
+    },
+    '&.MuiButton-contained.Mui-disabled': {
+      color: theme.palette.text.constant?.disabled,
+      backgroundColor: theme.palette.background.constant?.disabled
+    }
+  })
+);
 
 // ModalButtonSecondary
 export const ModalButtonSecondary = styled(OutlinedButton)(({ theme }) => ({

--- a/src/custom/ModalCard/style.tsx
+++ b/src/custom/ModalCard/style.tsx
@@ -1,16 +1,9 @@
 import { styled } from '@mui/material';
 import { Typography } from '../../base';
-import {
-  BLACK,
-  BUTTON_MODAL,
-  BUTTON_MODAL_DARK,
-  SLIGHT_BLACK_2,
-  SLIGHT_BLUE,
-  WHITE
-} from '../../theme/colors/colors';
+import { WHITE } from '../../theme/colors/colors';
 
 export const ContentContainer = styled('div')(({ theme }) => ({
-  backgroundColor: theme.palette.background.default
+  backgroundColor: theme.palette.background.surfaces
 }));
 
 export const ModalWrapper = styled('div')(() => ({
@@ -18,39 +11,27 @@ export const ModalWrapper = styled('div')(() => ({
   borderRadius: '5px'
 }));
 
-export const ButtonContainer = styled('div')(({ theme }) => {
-  const startColor = theme.palette.mode === 'light' ? BUTTON_MODAL : BLACK;
-  const endColor = theme.palette.mode === 'light' ? SLIGHT_BLUE : SLIGHT_BLACK_2;
+export const ButtonContainer = styled('div')(() => ({
+  padding: '1.25rem 1rem',
+  display: 'flex',
+  justifyContent: 'flex-end',
 
-  return {
-    padding: '1.25rem 1rem',
-    display: 'flex',
-    justifyContent: 'flex-end',
+  background: 'linear-gradient(90deg, #3B687B 0%, #507D90 100%)',
+  boxShadow: 'inset 0px 3px 5px 0px rgba(0,0,0,0.25)',
+  position: 'relative',
+  zIndex: '100'
+}));
 
-    background: `linear-gradient(90deg, ${startColor}, ${endColor})`,
-    boxShadow: 'inset 0px 3px 5px 0px rgba(0,0,0,0.25)',
-    position: 'relative',
-    zIndex: '100'
-  };
-});
 export const HeaderTypography = styled(Typography)({
   fontSize: '18px'
 });
-export const HeaderModal = styled('div')(({ theme }) => {
-  const startColor = theme.palette.mode === 'light' ? BUTTON_MODAL : BLACK;
-  const endColor = theme.palette.mode === 'light' ? SLIGHT_BLUE : SLIGHT_BLACK_2;
-  return {
-    display: 'flex',
-    borderRadius: '5px  5px 0px 0px',
-    justifyContent: 'space-between',
-    padding: '11px 16px',
-    height: '52px',
-    fill: WHITE,
-    boxShadow: 'inset 0px -1px 3px 0px rgba(0,0,0,0.2)',
-    background: `linear-gradient(90deg, ${startColor}, ${endColor})`,
-    filter:
-      theme.palette.mode === 'light'
-        ? `progid:DXImageTransform.Microsoft.gradient(startColorstr='${BUTTON_MODAL}',endColorstr='${SLIGHT_BLUE}',GradientType=1)`
-        : `progid:DXImageTransform.Microsoft.gradient(startColorstr='${BUTTON_MODAL_DARK}',GradientType=1)`
-  };
-});
+export const HeaderModal = styled('div')(() => ({
+  display: 'flex',
+  borderRadius: '5px  5px 0px 0px',
+  justifyContent: 'space-between',
+  padding: '11px 16px',
+  height: '52px',
+  fill: WHITE,
+  boxShadow: 'inset 0px -1px 3px 0px rgba(0,0,0,0.2)',
+  background: 'linear-gradient(90deg, #3B687B 0%, #507D90 100%)'
+}));


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the standard style for feedback component which is standard style for modal
![image](https://github.com/layer5io/sistent/assets/90546692/1f4e1fc7-5ee3-4a21-a8e7-9ec16160c317)


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
