### PR TITLE
Fix click event for tooltip

### DIFF
--- a/src/custom/Markdown/index.tsx
+++ b/src/custom/Markdown/index.tsx
@@ -66,10 +66,10 @@ export const RenderMarkdownTooltip: React.FC<RenderMarkdownProps> = ({ content }
         a: ({ ...props }) => (
           <StyledMarkdown
             onClick={(e) => {
-              e.preventDefault();
               window.open(props.href, '_blank');
+              e.stopPropagation();
             }}
-            href={props.href}
+            as="a"
           >
             {props.children}
           </StyledMarkdown>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the click event on links inside tooltips which was mainly occurring inside modal . Moving `event propogation` below now ensures that the link is opened first, and then the event propagation is stopped.

Adding `as="a"` ensures that the StyledMarkdown component is rendered as an <a> tag, making it behave correctly as a hyperlink.

https://github.com/layer5io/sistent/assets/90546692/f0de8ad2-2fae-4315-8ba6-273757f74913



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
