### PR TITLE
feat: Migrate infoTooltip from cloud

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -56,3 +56,4 @@ function CustomTooltip({
 }
 
 export default CustomTooltip;
+export type { CustomTooltipProps };

--- a/src/custom/CustomTooltip/index.tsx
+++ b/src/custom/CustomTooltip/index.tsx
@@ -1,3 +1,4 @@
 import CustomTooltip from './customTooltip';
+import InfoTooltip from './infoTooltip';
 
-export { CustomTooltip };
+export { CustomTooltip, InfoTooltip };

--- a/src/custom/CustomTooltip/infoTooltip.tsx
+++ b/src/custom/CustomTooltip/infoTooltip.tsx
@@ -1,0 +1,28 @@
+import { iconSmall } from '../../constants/iconsSizes';
+import InfoOutlinedIcon from '../../icons/InfoOutlined/InfoOutlined';
+import CustomTooltip, { CustomTooltipProps } from './customTooltip';
+
+type InfoTooltipProps = {
+  helpText: string | React.ReactNode | JSX.Element;
+  style?: React.CSSProperties;
+} & Omit<CustomTooltipProps, 'title' | 'children'>;
+
+const InfoTooltip = ({ helpText, style = {}, ...props }: InfoTooltipProps) => {
+  return (
+    <CustomTooltip title={helpText} {...props}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          ...style
+        }}
+      >
+        <InfoOutlinedIcon {...iconSmall} />
+      </div>
+    </CustomTooltip>
+  );
+};
+
+export default InfoTooltip;

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -8,7 +8,7 @@ import {
   CustomColumnVisibilityControl,
   CustomColumnVisibilityControlProps
 } from './CustomColumnVisibilityControl/CustomColumnVisibilityControl';
-import { CustomTooltip } from './CustomTooltip';
+import { CustomTooltip, InfoTooltip } from './CustomTooltip';
 import {
   CustomDialog,
   StyledDialogActions,
@@ -60,6 +60,7 @@ export {
   Fallback,
   FeedbackButton,
   FlipCard,
+  InfoTooltip,
   LearningCard,
   ModalCard,
   PopperListener,


### PR DESCRIPTION
**Notes for Reviewers**

This PR adds InfoTooltip, which was previously in cloud

- I have added the component under the CustomTooltip folder.
    - This might need to be changed to tooltip, but the folder name is hardcoded in many other custom-components in Sistent.

### Demo tested in Cloud:
![image](https://github.com/layer5io/sistent/assets/80959679/347fb6a8-5614-4a7b-b759-0b2b856c6ce6)


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
