### PR TITLE
feat: add default Theme for MuiButtonGroup component

### DIFF
--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -1,6 +1,7 @@
 import { Components, Theme } from '@mui/material';
 import { MuiAppBar } from './components/appbar.modifiter';
 import { MuiButton } from './components/button.modifier';
+import { MuiButtonGroup } from './components/buttongroup.modifier';
 import { MuiCard } from './components/card.modifier';
 import { MuiCheckbox } from './components/checkbox.modifier';
 import { MuiCollapse } from './components/collapse.modifier';
@@ -35,6 +36,7 @@ export const components: Components<Theme> = {
   MuiSvgIcon,
   MuiTab,
   MuiSwitch,
+  MuiButtonGroup,
   MuiButton,
   MuiListItem
 };

--- a/src/theme/components/buttongroup.modifier.ts
+++ b/src/theme/components/buttongroup.modifier.ts
@@ -1,0 +1,9 @@
+import { Components, Theme } from '@mui/material';
+
+export const MuiButtonGroup: Components<Theme>['MuiButtonGroup'] = {
+  styleOverrides: {
+    grouped: ({ theme }) => ({
+      borderColor: theme.palette.common.white
+    })
+  }
+};


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes ButtonGroup component

- 
![image](https://github.com/layer5io/sistent/assets/80959679/3187ecfe-78ef-48ba-8153-9838a1b6188f)


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
