### PR TITLE
Fix `pre` tag of html and its theme

### DIFF
--- a/src/custom/Markdown/index.tsx
+++ b/src/custom/Markdown/index.tsx
@@ -12,6 +12,7 @@ import {
   StyledMarkdownH6,
   StyledMarkdownLi,
   StyledMarkdownP,
+  StyledMarkdownPre,
   StyledMarkdownTd,
   StyledMarkdownTh,
   StyledMarkdownTooltipP,
@@ -51,7 +52,8 @@ export const RenderMarkdown: React.FC<RenderMarkdownProps> = ({ content }) => {
         ul: ({ ...props }) => <StyledMarkdownUl>{props.children}</StyledMarkdownUl>,
         li: ({ ...props }) => <StyledMarkdownLi>{props.children}</StyledMarkdownLi>,
         th: ({ ...props }) => <StyledMarkdownTh>{props.children}</StyledMarkdownTh>,
-        td: ({ ...props }) => <StyledMarkdownTd>{props.children}</StyledMarkdownTd>
+        td: ({ ...props }) => <StyledMarkdownTd>{props.children}</StyledMarkdownTd>,
+        pre: ({ ...props }) => <StyledMarkdownPre>{props.children}</StyledMarkdownPre>
       }}
     >
       {content}

--- a/src/custom/Markdown/style.tsx
+++ b/src/custom/Markdown/style.tsx
@@ -71,3 +71,8 @@ export const StyledMarkdownTd = styled('td')(({ theme }) => ({
   marginBlock: '0px',
   ...theme.typography.textB1Regular
 }));
+
+export const StyledMarkdownPre = styled('pre')(({ theme }) => ({
+  background: theme.palette.background.code,
+  whiteSpace: 'pre-line'
+}));


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #
1. Pre tag of html under markdown component to fix its overflowing
2. add background theme 
example:
![image](https://github.com/user-attachments/assets/155a3d83-5786-4942-a378-d514c45d2c77)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
3. Build and test your changes before submitting a PR.
4. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
