### PR TITLE
Add `customtooltip` as default for tables and fix around it

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -50,7 +50,7 @@ function CustomTooltip({
       onClick={onClick}
       {...props}
     >
-      {children}
+      <div>{children}</div>
     </Tooltip>
   );
 }

--- a/src/custom/ResponsiveDataTable.tsx
+++ b/src/custom/ResponsiveDataTable.tsx
@@ -1,10 +1,13 @@
 import { Theme, ThemeProvider, createTheme } from '@mui/material';
 import MUIDataTable from 'mui-datatables';
 import React, { useCallback } from 'react';
+import { CustomTooltip } from './CustomTooltip';
 
 const dataTableTheme = (theme: Theme) =>
   createTheme({
+    ...theme,
     components: {
+      ...theme.components,
       MuiTable: {
         styleOverrides: {
           root: {
@@ -253,7 +256,10 @@ const ResponsiveDataTable = ({
         columns={tableCols ?? []}
         data={data || []}
         title={undefined}
-        components={components}
+        components={{
+          Tooltip: CustomTooltip as unknown as React.ReactNode,
+          ...components
+        }}
         options={updatedOptions}
         {...props}
       />


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

- Add Customtooltip as default for data tables
- remove the click effect for tooltip to show content 
- inject sistent theme into tables to support it.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
