### PR TITLE
Remove unnecessary div wrapper in Modal component

### DIFF
--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -168,7 +168,7 @@ export const ModalFooter: React.FC<ModalFooterProps> = ({ helpText, children, va
           </IconButton>
         </CustomTooltip>
       )}
-      <div>{children}</div>
+      {children}
     </StyledFooter>
   );
 };


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #
This div prevents the footer from utilizing its full width. If we set `width: 100%`, it still not resolves the issue. I checked all the modal footers, and there are no side effects from this change.


Before: 
![image](https://github.com/user-attachments/assets/007c7ccb-920f-40ae-a49c-fcdd301ace84)

After
![image](https://github.com/user-attachments/assets/675c1c04-05a3-436c-911b-eacbcf0be6fa)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
