### PR TITLE
refactor: make the link tag optional on learning card

### DIFF
--- a/src/custom/LearningCard/LearningCard.tsx
+++ b/src/custom/LearningCard/LearningCard.tsx
@@ -30,7 +30,7 @@ interface Props {
   courseType: string;
 }
 
-const OptionalLink: React.PropsWithChildren<{ path?: string }> = ({ path, children }) => {
+const OptionalLink: React.FC<React.PropsWithChildren<{ path?: string }>> = ({ path, children }) => {
   if (!path) {
     return <>{children}</>;
   }
@@ -65,7 +65,7 @@ const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType
           </CardParent>
         </Card2>
       ) : (
-        <OptionalLink href={path}>
+        <OptionalLink path={path}>
           <CardActive>
             <CardParent style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}>
               <div>

--- a/src/custom/LearningCard/LearningCard.tsx
+++ b/src/custom/LearningCard/LearningCard.tsx
@@ -25,9 +25,17 @@ interface Tutorial {
 
 interface Props {
   tutorial: Tutorial;
-  path: string;
+  path?: string;
   courseCount: number;
   courseType: string;
+}
+
+const OptionalLink: React.PropsWithChildren<{path?: string}> = ({ path, children }) => {
+  if (!path) {
+    return <>{children}</>
+  }
+  
+  return <CardLink href={path}>{children}</CardLink>
 }
 
 const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType }) => {
@@ -57,7 +65,7 @@ const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType
           </CardParent>
         </Card2>
       ) : (
-        <CardLink href={path}>
+        <OptionalLink href={path}>
           <CardActive>
             <CardParent style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}>
               <div>
@@ -88,7 +96,7 @@ const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType
               </div>
             </CardParent>
           </CardActive>
-        </CardLink>
+        </OptionalLink>
       )}
     </CardWrapper>
   );

--- a/src/custom/LearningCard/LearningCard.tsx
+++ b/src/custom/LearningCard/LearningCard.tsx
@@ -30,13 +30,13 @@ interface Props {
   courseType: string;
 }
 
-const OptionalLink: React.PropsWithChildren<{path?: string}> = ({ path, children }) => {
+const OptionalLink: React.PropsWithChildren<{ path?: string }> = ({ path, children }) => {
   if (!path) {
-    return <>{children}</>
+    return <>{children}</>;
   }
-  
-  return <CardLink href={path}>{children}</CardLink>
-}
+
+  return <CardLink href={path}>{children}</CardLink>;
+};
 
 const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType }) => {
   return (


### PR DESCRIPTION
**Notes for Reviewers**

In NextJS 14 have no longer supporting passing `<a>` tag element directly, but need to encapsulate by using `next/link` like [this](https://nextjs.org/docs/pages/api-reference/components/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag), because the a tag is to deep inside the element, we need to make it optional and pass from the outside of sistent


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
