### PR TITLE
feat: add position and top property in stylePrpos for custom styling

### DIFF
--- a/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
+++ b/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
@@ -94,7 +94,7 @@ const CatalogFilterSidebar: React.FC<CatalogFilterSidebarProps> = ({
       theme.palette.mode === 'light' ? theme.palette.background.surfaces : darkTeal.main,
     fontFamily: theme.typography.fontFamily,
     position: styleProps?.position || 'relative',
-    top: styleProps?.top ? styleProps.top : styleProps?.position === 'sticky' ? '5rem' : ''
+    top: styleProps?.top ? styleProps.top : styleProps?.position === 'sticky' ? '6rem' : ''
   };
 
   const appliedStyleProps = {

--- a/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
+++ b/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
@@ -57,6 +57,8 @@ export interface StyleProps {
   backgroundColor?: string;
   sectionTitleBackgroundColor?: string;
   fontFamily?: string;
+  position?: 'relative' | 'sticky';
+  top?: string;
 }
 
 /**
@@ -90,7 +92,9 @@ const CatalogFilterSidebar: React.FC<CatalogFilterSidebarProps> = ({
         : theme.palette.background.secondary,
     sectionTitleBackgroundColor:
       theme.palette.mode === 'light' ? theme.palette.background.surfaces : darkTeal.main,
-    fontFamily: theme.typography.fontFamily
+    fontFamily: theme.typography.fontFamily,
+    position: styleProps?.position || 'relative',
+    top: styleProps?.top ? styleProps.top : styleProps?.position === 'sticky' ? '5rem' : ''
   };
 
   const appliedStyleProps = {

--- a/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
+++ b/src/custom/CatalogFilterSection/CatalogFilterSidebar.tsx
@@ -92,9 +92,7 @@ const CatalogFilterSidebar: React.FC<CatalogFilterSidebarProps> = ({
         : theme.palette.background.secondary,
     sectionTitleBackgroundColor:
       theme.palette.mode === 'light' ? theme.palette.background.surfaces : darkTeal.main,
-    fontFamily: theme.typography.fontFamily,
-    position: styleProps?.position || 'relative',
-    top: styleProps?.top ? styleProps.top : styleProps?.position === 'sticky' ? '6rem' : ''
+    fontFamily: theme.typography.fontFamily
   };
 
   const appliedStyleProps = {

--- a/src/custom/CatalogFilterSection/style.tsx
+++ b/src/custom/CatalogFilterSection/style.tsx
@@ -16,6 +16,8 @@ export const FiltersCardDiv = styled(Box)<{ styleProps: StyleProps }>(({ stylePr
   ['@media (max-width:900px)']: {
     display: 'none'
   },
+  position: styleProps.position ? styleProps.position : 'relative',
+  top: styleProps.top ? styleProps.top : styleProps.position === 'sticky' ? '5rem' : '',
   fontFamily: styleProps.fontFamily,
   '&::-webkit-scrollbar': {
     width: '6px'


### PR DESCRIPTION
**Notes for Reviewers**
Add conditional top styling for sticky position

- Introduced logic to apply `top: 5rem` only when the `position` is set to 'sticky'.
- Default behavior remains unaffected for other position values (e.g., 'relative').
- Ensured smooth handling of dynamic styling via props.


Screenshot: 
![image](https://github.com/user-attachments/assets/617eb9c4-906f-479f-acc3-0172c6380df4)

Applied the styleProps from the `CategoryFilterSidebar` at `/catalog` page in Layer5 Cloud

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
