### PR TITLE
Fix ResponsiveDataTable bug

### DIFF
--- a/src/custom/CatalogDetail/ActionButton.tsx
+++ b/src/custom/CatalogDetail/ActionButton.tsx
@@ -4,7 +4,7 @@ import { CopyIcon, EditIcon, KanvasIcon, PublishIcon } from '../../icons';
 import Download from '../../icons/Download/Download';
 import { charcoal, useTheme } from '../../theme';
 import { Pattern } from '../CustomCatalog/CustomCard';
-import { downloadFilter, downloadYaml } from './helper';
+import { downloadPattern, downloadYaml } from './helper';
 import { ActionButton, StyledActionWrapper, UnpublishAction } from './style';
 import { RESOURCE_TYPES } from './types';
 
@@ -79,9 +79,9 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
               color: theme.palette.text.default
             }}
             onClick={() =>
-              cleanedType === RESOURCE_TYPES.FILTERS
-                ? downloadFilter(details.id, details.name)
-                : downloadYaml(details.pattern_file, details.name)
+              cleanedType === RESOURCE_TYPES.VIEWS
+                ? downloadYaml(details.pattern_file, details.name)
+                : downloadPattern(details.id, details.name, cleanedType)
             }
           >
             <Download width={24} height={24} fill={theme.palette.icon.default} />

--- a/src/custom/CatalogDetail/helper.ts
+++ b/src/custom/CatalogDetail/helper.ts
@@ -34,8 +34,9 @@ export function slugify(str: string): string {
   return str;
 }
 
-export const downloadFilter = (id: string, name: string): void => {
-  const dataUri = `${process.env.API_ENDPOINT_PREFIX}/api/content/filters/download/${id}`;
+export const downloadPattern = (id: string, name: string, type: string): void => {
+  const pattern = type == 'design' ? 'patterns' : 'filters';
+  const dataUri = `${process.env.API_ENDPOINT_PREFIX}/api/content/${pattern}/download/${id}`;
 
   // Add the .wasm extension to the filename
   const fileNameWithExtension = name + '.wasm';

--- a/src/custom/CatalogDetail/helper.ts
+++ b/src/custom/CatalogDetail/helper.ts
@@ -34,6 +34,19 @@ export function slugify(str: string): string {
   return str;
 }
 
+export const downloadFilter = (id: string, name: string): void => {
+  const dataUri = `${process.env.API_ENDPOINT_PREFIX}/api/content/filters/download/${id}`;
+
+  // Add the .wasm extension to the filename
+  const fileNameWithExtension = name + '.wasm';
+
+  const linkElement = document.createElement('a');
+  linkElement.setAttribute('href', dataUri);
+  linkElement.setAttribute('download', fileNameWithExtension);
+  linkElement.click();
+  linkElement.remove();
+};
+
 export const downloadPattern = (id: string, name: string, type: string): void => {
   const pattern = type == 'design' ? 'patterns' : 'filters';
   const dataUri = `${process.env.API_ENDPOINT_PREFIX}/api/content/${pattern}/download/${id}`;

--- a/src/custom/ResponsiveDataTable.tsx
+++ b/src/custom/ResponsiveDataTable.tsx
@@ -409,7 +409,7 @@ const ResponsiveDataTable = ({
   return (
     <ThemeProvider theme={finalTheme}>
       <MUIDataTable
-        columns={tableCols ?? []}
+        columns={(tableCols || columns) ?? []}
         data={data || []}
         title={undefined}
         components={components}


### PR DESCRIPTION
**Notes for Reviewers**
This PR fixes the bug if `ResponsiveDataTable` it has a required prop as `columns` and option props as `tableCols`( both the prop type is same) which is displayed in MUI datatable, if someone doesn't pass `tableCols` the table breaks.

So I fixed this by passing the both `columns` or `tableCols`, if the optional prop is not passed it wont break anymore. Altough the any big props changes may lead to make the chages all over where it is been used.


This PR fixes #635

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
