### PR TITLE
use qanelas soft for buttons

### DIFF
--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -97,7 +97,7 @@ export const typography = (mode: PaletteMode): TypographyOptions => {
       }
     },
     textB2SemiBold: {
-      fontFamily: ['"Open Sans"', 'sans-serif'].join(','),
+      fontFamily: ['Qanelas Soft Regular'].join(','),
       color: mode === 'light' ? common.black : common.white,
       fontSize: '1rem',
       fontWeight: 600,


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the buttons variant to follow qanelas soft font family. To achieve this we can directly fix the typography variant that is passed to button component,

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
