### PR TITLE
Add Carousel Component to Top Performer Cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,14 +112,16 @@
   },
   "dependencies": {
     "@layer5/meshery-design-embed": "^0.4.0",
+    "@rollup/rollup-darwin-arm64": "^4.34.8",
+    "@types/mui-datatables": "*",
     "billboard.js": "^3.14.3",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
+    "mui-datatables": "*",
     "re-resizable": "^6.10.3",
     "react-draggable": "^4.4.6",
-    "react-share": "^5.1.0",
-    "mui-datatables": "*",
-    "@types/mui-datatables": "*"
+    "react-material-ui-carousel": "^3.4.2",
+    "react-share": "^5.1.0"
   }
 }

--- a/src/custom/PerformersSection/PerformersSection.tsx
+++ b/src/custom/PerformersSection/PerformersSection.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ArrowBack, ArrowForward } from '@mui/icons-material';
 import { memo, useMemo } from 'react';
+import Carousel from 'react-material-ui-carousel';
 import {
   CloneIcon,
   DeploymentsIcon,
@@ -299,17 +301,20 @@ const PerformersSection: React.FC<PerformersSectionProps> = ({
         </Title>
         <CardsContainer>
           {isLoading && <StateCardSekeleton />}
-          {!isLoading &&
-            stats.map((stat, index) => (
-              <StatCard
-                key={`${stat.id}-${index}`}
-                {...stat}
-                onCardClick={onCardClick}
-                onIconClick={onIconClick}
-                onAuthorClick={onAuthorClick}
-                onStatusClick={onStatusClick}
-              />
-            ))}
+          {!isLoading && (
+            <Carousel PrevIcon={<ArrowBack />} NextIcon={<ArrowForward />} swipe>
+              {stats.map((stat, index) => (
+                <StatCard
+                  key={`${stat.id}-${index}`}
+                  {...stat}
+                  onCardClick={onCardClick}
+                  onIconClick={onIconClick}
+                  onAuthorClick={onAuthorClick}
+                  onStatusClick={onStatusClick}
+                />
+              ))}
+            </Carousel>
+          )}
         </CardsContainer>
       </MainContainer>
     </ErrorBoundary>


### PR DESCRIPTION
**Notes for Reviewers**

This PR introduces a carousel component to the top performer cards, enhancing the user experience by allowing seamless navigation through multiple top-performing profiles. The carousel will improve content organization, making it easier for users to view and engage with featured performers.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
