### PR TITLE
fix: improve info messages for model and design import modals

### DIFF
--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -42,7 +42,7 @@ const importDesignSchema = {
             type: 'string',
             format: 'file',
             description:
-              'Browse the design file from your system. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs.',
+              'Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs.',
             'x-rjsf-grid-area': '12'
           }
         },

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -42,7 +42,7 @@ const importDesignSchema = {
             type: 'string',
             format: 'file',
             description:
-              'Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs.',
+              'Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Importing Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12'
           }
         },
@@ -64,7 +64,7 @@ const importDesignSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.',
+              'Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Importing Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12'
           }
         },

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -64,7 +64,7 @@ const importDesignSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'Provide the URL of the file you want to import. This should be a direct URL to the file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.',
+              'Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.',
             'x-rjsf-grid-area': '12'
           }
         },

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -42,7 +42,7 @@ const importDesignSchema = {
             type: 'string',
             format: 'file',
             description:
-              'Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Importing Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
+              'Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12'
           }
         },
@@ -64,7 +64,7 @@ const importDesignSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Importing Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
+              'Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12'
           }
         },

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -41,7 +41,8 @@ const importDesignSchema = {
           file: {
             type: 'string',
             format: 'file',
-            description: 'Browse the  file from your file system',
+            description:
+              'Browse the design file from your system. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs.',
             'x-rjsf-grid-area': '12'
           }
         },
@@ -63,7 +64,7 @@ const importDesignSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'Provide the URL of the  file you want to import. This should be a direct URL to the file, for example: https://raw.github.com/your-design-file.yaml',
+              'Provide the URL of the file you want to import. This should be a direct URL to the file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.',
             'x-rjsf-grid-area': '12'
           }
         },

--- a/src/schemas/importModel/schema.tsx
+++ b/src/schemas/importModel/schema.tsx
@@ -1,0 +1,61 @@
+const importModelSchema = {
+  type: 'object',
+  properties: {
+    uploadType: {
+      title: 'Upload method',
+      enum: ['File Import', 'URL Import'],
+      default: 'Select the Upload Method',
+      'x-rjsf-grid-area': '12',
+      description:
+        "Choose the method you prefer to upload your model file. Select 'File Upload' if you have the file on your local system or 'URL Import' if you have the file hosted online."
+    }
+  },
+  allOf: [
+    {
+      if: {
+        properties: {
+          uploadType: {
+            const: 'File Import'
+          }
+        }
+      },
+      then: {
+        properties: {
+          file: {
+            type: 'string',
+            format: 'file',
+            description:
+              'Browse the model file from your file system. Ensure file is an OCI artifact in .tar, .tar.gz or .tgz formats',
+            'x-rjsf-grid-area': '12'
+          }
+        },
+        required: ['file']
+      }
+    },
+    {
+      if: {
+        properties: {
+          uploadType: {
+            const: 'URL Import'
+          }
+        }
+      },
+      then: {
+        properties: {
+          url: {
+            type: 'string',
+            format: 'uri',
+            title: 'URL',
+            description:
+              'Provide the URL of the model you want to import. This should be a direct URL to the file, for example: https://raw.github.com/your-model-file.tar. Also, ensure file is an OCI artifact in .tar, .tar.gz or .tgz formats',
+            'x-rjsf-grid-area': '12',
+            disabled: true
+          }
+        }
+      }
+    }
+  ],
+  required: ['uploadType']
+};
+
+export default importModelSchema;

--- a/src/schemas/importModel/schema.tsx
+++ b/src/schemas/importModel/schema.tsx
@@ -25,7 +25,7 @@ const importModelSchema = {
             type: 'string',
             format: 'file',
             description:
-              'Browse the model file from your file system. Ensure file is an OCI artifact in .tar, .tar.gz or .tgz formats',
+              'Supported model file formats are: .tar, .tar.gz, and .tgz',
             'x-rjsf-grid-area': '12'
           }
         },
@@ -47,7 +47,9 @@ const importModelSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'Provide the URL of the model you want to import. This should be a direct URL to the file, for example: https://raw.github.com/your-model-file.tar. Also, ensure file is an OCI artifact in .tar, .tar.gz or .tgz formats',
+              'A direct URL to a single model file, for example: https://raw.github.com/your-model-file.tar. Supported model file formats are: .tar, .tar.gz, and .tgz. 
+              
+              For bulk import of your model use the GitHub connection or CSV files.',
             'x-rjsf-grid-area': '12',
             disabled: true
           }

--- a/src/schemas/importModel/schema.tsx
+++ b/src/schemas/importModel/schema.tsx
@@ -25,7 +25,7 @@ const importModelSchema = {
             type: 'string',
             format: 'file',
             description:
-              'Supported model file formats are: .tar, .tar.gz, and .tgz',
+              'Supported model file formats are: .tar, .tar.gz, and .tgz. See [Import Models Documentation](https://docs.meshery.io/guides/configuration-management/importing-models#import-models-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12'
           }
         },
@@ -47,9 +47,7 @@ const importModelSchema = {
             format: 'uri',
             title: 'URL',
             description:
-              'A direct URL to a single model file, for example: https://raw.github.com/your-model-file.tar. Supported model file formats are: .tar, .tar.gz, and .tgz. 
-              
-              For bulk import of your model use the GitHub connection or CSV files.',
+              'A direct URL to a single model file, for example: https://raw.github.com/your-model-file.tar. Supported model file formats are: .tar, .tar.gz, and .tgz. \n\nFor bulk import of your model use the GitHub connection or CSV files. See [Import Models Documentation](https://docs.meshery.io/guides/configuration-management/importing-models#import-models-using-meshery-ui) for details',
             'x-rjsf-grid-area': '12',
             disabled: true
           }

--- a/src/schemas/importModel/uiSchema.tsx
+++ b/src/schemas/importModel/uiSchema.tsx
@@ -1,0 +1,8 @@
+const importModelUiSchema = {
+  uploadType: {
+    'ui:widget': 'radio'
+  },
+  'ui:order': ['uploadType', 'file', 'url']
+};
+
+export default importModelUiSchema;

--- a/src/schemas/index.tsx
+++ b/src/schemas/index.tsx
@@ -16,6 +16,9 @@ import importDesignUiSchema from './importDesign/uiSchema';
 import importFilterSchema from './importFilter/schema';
 import importFilterUiSchema from './importFilter/uiSchema';
 
+import importModelSchema from './importModel/schema';
+import importModelUiSchema from './importModel/uiSchema';
+
 import publishCatalogItemSchema from './publishCatalogItem/schema';
 import publishCatalogItemUiSchema from './publishCatalogItem/uiSchema';
 
@@ -43,6 +46,8 @@ export {
   importDesignUiSchema,
   importFilterSchema,
   importFilterUiSchema,
+  importModelSchema,
+  importModelUiSchema,
   kubernetesCredentialSchema,
   kubernetesCredentialUiSchema,
   prometheusCredentialSchema,


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

1. More descriptive information messages for model and design import modals.
2. Added schema for model import modal here in sistent. 
**Prev behaviour:** This schema was present in meshkit schemas and fetched via server (api/schema/resource/{resourcename})
**Current behaviour:** Schema fetched from sistent. 
**Why?** To keep it consistent with Filter and Design. Meshkit Schemas are deprecated.

## Before

![Screenshot 2025-02-28 at 7 57 28 PM](https://github.com/user-attachments/assets/fa4d2914-c11f-469f-859f-9464c7760131)
![Screenshot 2025-02-28 at 7 57 34 PM](https://github.com/user-attachments/assets/b04fb9ed-8746-41a3-b3d7-3e29c84fc282)
![Screenshot 2025-02-28 at 7 58 10 PM](https://github.com/user-attachments/assets/0ddb0c3e-464c-4f07-a878-980e4fc6e111)
![Screenshot 2025-02-28 at 7 58 20 PM](https://github.com/user-attachments/assets/7f6491a1-c194-4ca1-8c33-e4290c4b8298)



## After

![Screenshot 2025-02-28 at 7 53 49 PM](https://github.com/user-attachments/assets/6157f2fe-e6dd-45db-8ec0-14c5f460d560)
![Screenshot 2025-02-28 at 7 53 58 PM](https://github.com/user-attachments/assets/f97979eb-0134-48b7-9a6c-4e2f76e86de7)
![Screenshot 2025-02-28 at 7 54 38 PM](https://github.com/user-attachments/assets/cc087e65-302c-407f-befc-03e053d8547e)
![Screenshot 2025-02-28 at 7 55 02 PM](https://github.com/user-attachments/assets/d43539ce-a8d8-4abb-ace6-d696cf1e0079)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [*] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
