### PR TITLE
Fix: add GithubIcon to TransferList

### DIFF
--- a/src/custom/TransferModal/TransferList/TransferList.tsx
+++ b/src/custom/TransferModal/TransferList/TransferList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Checkbox, Grid, List, ListItem, Typography } from '../../../base';
 import { KubernetesIcon, LeftArrowIcon, RightArrowIcon, SMPIcon } from '../../../icons';
+import { GithubIcon } from '../../../icons/Github';
 import { MesheryIcon } from '../../../icons/Meshery';
 import Tooltip from '../../../patches/Tooltip';
 import {
@@ -22,7 +23,8 @@ export function getFallbackImageBasedOnKind(kind: string | undefined): JSX.Eleme
   }
   const fallbackComponents: { [key: string]: JSX.Element } = {
     meshery: <MesheryIcon />,
-    kubernetes: <KubernetesIcon />
+    kubernetes: <KubernetesIcon />,
+    github: <GithubIcon />
   };
 
   return fallbackComponents[kind] || null;


### PR DESCRIPTION
**Notes for Reviewers**
Add `GithubIcon` to TransferList

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

# Screenshots

## Before
<img width="900" alt="Before" src="https://github.com/user-attachments/assets/cde2bc5d-0303-40bf-ba6a-c6c571ec734a" />


## After
<img width="900" alt="After" src="https://github.com/user-attachments/assets/aa14d464-397f-4fc4-9b6d-d9e5eb48258e" />



