### PR TITLE
Sharing Modal: Add link to docs

### DIFF
--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -315,7 +315,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
 
         <ModalFooter
           variant="filled"
-          helpText="You can share your designs or designs for which you have permission to share with other members of your organization and teams, and you can control access permissions."
+          helpText="You can share your designs or designs for which you have permission to share with other members of your organization and teams, and you can control access permissions. <a href='https://docs.layer5.io/kanvas/designer/share-resource/'>Learn more</a>"
         >
           <div
             style={{


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>

Problem: Missing docs link

<img width="1260" alt="Screenshot 2025-04-24 at 8 40 55 AM" src="https://github.com/user-attachments/assets/e41dea0e-5319-4cff-88cf-ada0c7cf8fd2" />
