### PR TITLE
fix doublescrollbar occuring when datatables are placed inside modal

### DIFF
--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -120,7 +120,12 @@ export const ModalBody = styled(Paper)(({ theme }) => ({
   padding: '1rem',
   backgroundColor: theme.palette.background.surfaces,
   overflowY: 'auto',
-  height: '100%'
+  height: '100%',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': {
+    display: 'none'
+  },
+  '-ms-overflow-style': 'none'
 }));
 
 const StyledFooter = styled('div', {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes https://github.com/layer5io/meshery-cloud/issues/3602

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
