### PR TITLE
fix: Unify version display for public and private designs

### DIFF
--- a/src/custom/CustomCatalog/Helper.ts
+++ b/src/custom/CustomCatalog/Helper.ts
@@ -61,7 +61,7 @@ export const handleImage = async ({
 export const DEFAULT_DESIGN_VERSION = '0.0.0';
 
 export const getVersion = (design: Pattern) => {
-  if (design.visibility === 'public') {
+  if (design.visibility === 'published') {
     return design?.catalog_data?.published_version || DEFAULT_DESIGN_VERSION;
   }
   try {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes: https://github.com/layer5io/meshery-cloud/issues/3585

#### Reason

There are three relevant states for a design: **private**, **public**, and **published**. The `private` and `public` states should both reflect the current draft's version number, which is stored in the `version` field. Only a `published` design should display the `published_version`.

The bug was that the UI was incorrectly displaying the `published_version` for designs that were set to `public`. This created problems:
1.  **Inconsistent Versions**: If a public design had no `published_version`, the UI would show an incorrect fallback value (like `0.0.0` or `""`).
2.  **Wrong Versions**: If a public design has a `published_version`, the UI would show an incorrect value.

#### Fix

https://github.com/user-attachments/assets/8ad17238-9beb-43e3-84fc-cf62246fba2a