### PR TITLE
docs: Revise "Building Docker image" section in CONTRIBUTING.md (#252)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,13 +109,35 @@ To test code changes on your local machine, run the following command:
 make tests
 ```
 
-#### Building Docker image
+#### 🐳 Building the Docker Image
 
-To build a Docker image of the project, please ensure you have `Docker` installed to be able to build the image. Now, run the following command to build the Docker image:
+To build a Docker image of the `sistent` project, make sure you have [Docker](https://docs.docker.com/get-docker/) installed and running.
+
+---
+
+**Option 1: Build with Make**  
+This will build the `sistent` image as defined in the `Makefile`:
 
 ```sh
 make docker
 ```
+
+#### Option 2: Build Manually with Docker
+
+If you prefer, you can build the image directly:
+
+```sh
+docker build -t sistent:latest .
+```
+
+#### 🚀 Run and Test the Image
+
+Once built, run the image:
+
+```sh
+docker run -p 8080:8080 sistent:latest
+```
+Open [http://localhost:8080](http://localhost:8080) to verify that the application is running.
 
 You can also refer to this "<a href="https://www.youtube.com/live/lsw9KA__iu4?si=o8gpZdSHcqO2OKxE">Training: contributing to Sistent</a>" and this <a href="https://www.youtube.com/live/yiXkxbibLUU?si=Dybj5qr0VLhLWEpl">Websites call</a> where experienced contributors have taught how to use sistent in your project or Meshery
 


### PR DESCRIPTION
Updated the "Building Docker image" section of CONTRIBUTING.md to:

Clarify how to build the image using both the Make command and the manual `docker build` method. Add instructions for running and testing the built image

Fixes #252

**Notes for Reviewers**

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
