### PR TITLE
fix: Owner section Search input adds %2520 instead of space (double encoding issue)

### DIFF
--- a/src/custom/InputSearchField/InputSearchField.tsx
+++ b/src/custom/InputSearchField/InputSearchField.tsx
@@ -84,8 +84,7 @@ const InputSearchField: React.FC<InputSearchFieldProps> = ({
       if (value === '') {
         setOpen(false);
       } else {
-        const encodedValue = encodeURIComponent(value);
-        fetchSuggestions(encodedValue);
+        fetchSuggestions(value);
         setError('');
         setOpen(true);
       }


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes https://github.com/layer5io/meshery-cloud/issues/3765


https://github.com/user-attachments/assets/e106aa5e-1e25-40b9-b959-3e201ed36a8c



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
