### PR TITLE
fix: academy learning cards overflow on smaller screens.

### DIFF
--- a/src/custom/LearningCard/style.tsx
+++ b/src/custom/LearningCard/style.tsx
@@ -2,7 +2,8 @@ import { styled } from '@mui/material/styles';
 import { BLACK, ONYX_BLACK, SILVER_GRAY, WHITE } from '../../theme';
 
 const CardWrapper = styled('div')({
-  width: '28rem',
+  maxWidth: '28rem',
+  minWidth: '10rem',
   height: '16rem',
   margin: 'auto',
   borderRadius: '1rem'


### PR DESCRIPTION
**Notes for Reviewers**

<img width="439" height="604" alt="image" src="https://github.com/user-attachments/assets/fff8f36d-8ca4-49db-bcbd-0bc80a849ecb" />

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
