### PR TITLE
Migration of own-learning card from sistent to cloud-ui

### DIFF
--- a/src/custom/LearningCard/LearningCard.tsx
+++ b/src/custom/LearningCard/LearningCard.tsx
@@ -1,8 +1,5 @@
-import React, { useState } from 'react';
-import { Grid2, Typography } from '../../base';
-import { ExternalLinkIcon } from '../../icons';
-import { Modal, ModalBody, ModalButtonPrimary, ModalButtonSecondary, ModalFooter } from '../Modal';
-import { CopyToClipboard } from '../ResourceDetailFormatters/Component';
+import React from 'react';
+import { Typography } from '../../base';
 import {
   Card2,
   CardActive,
@@ -12,8 +9,7 @@ import {
   CardLink,
   CardParent,
   CardSubdata,
-  CardWrapper,
-  OwnLearningCard
+  CardWrapper
 } from './style';
 
 interface Tutorial {
@@ -35,43 +31,17 @@ interface Props {
   path?: string;
   courseCount: number;
   courseType: string;
-  orgId?: string;
-  modalContent?: string;
 }
 
-const OptionalLink: React.FC<React.PropsWithChildren<{ path?: string; isExternal?: boolean }>> = ({
-  path,
-  children,
-  isExternal
-}) => {
+const OptionalLink: React.FC<React.PropsWithChildren<{ path?: string }>> = ({ path, children }) => {
   if (!path) {
     return <>{children}</>;
   }
 
-  return (
-    <CardLink
-      href={path}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
-    >
-      {children}
-    </CardLink>
-  );
+  return <CardLink href={path}>{children}</CardLink>;
 };
 
-const LearningCard: React.FC<Props> = ({
-  tutorial,
-  path,
-  courseCount,
-  courseType,
-  orgId,
-  modalContent
-}) => {
-  const isCreateLearningPath = courseType === 'learning-card';
-  const [modalOpen, setModalOpen] = useState(false);
-
-  const handleModalOpen = () => setModalOpen(true);
-  const handleModalClose = () => setModalOpen(false);
+const LearningCard: React.FC<Props> = ({ tutorial, path, courseCount, courseType }) => {
   return (
     <CardWrapper>
       {tutorial.frontmatter.disabled === 'yes' ? (
@@ -98,120 +68,50 @@ const LearningCard: React.FC<Props> = ({
           </CardParent>
         </Card2>
       ) : (
-        <>
-          {isCreateLearningPath ? (
-            <OwnLearningCard onClick={handleModalOpen} style={{ cursor: 'pointer' }}>
-              <CardParent style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}>
-                <div>
-                  <CardHead>
-                    <h3>
-                      {tutorial.frontmatter.title
-                        ? tutorial.frontmatter.title
-                        : tutorial.frontmatter.courseTitle}
-                    </h3>
-                    {isCreateLearningPath && path && (
-                      <ExternalLinkIcon width="24px" height="24px" />
-                    )}
-                    {tutorial.frontmatter.status ? (
-                      <p>
-                        <span>New</span>
-                      </p>
-                    ) : null}
-                  </CardHead>
-                  <CardDesc>
-                    <p className="summary">{tutorial.frontmatter.description}</p>
-                  </CardDesc>
-                  <CardImage>
-                    <img src={tutorial.frontmatter.cardImage} />
-                  </CardImage>
-                </div>
-              </CardParent>
-            </OwnLearningCard>
-          ) : (
-            <OptionalLink path={path} isExternal={isCreateLearningPath}>
-              <CardActive>
-                <CardParent style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}>
-                  <div>
-                    <CardHead style={{ flexDirection: 'column' }}>
-                      <Typography variant="body1" color="textSecondary">
-                        {tutorial.frontmatter.type}
-                      </Typography>
-                      <h3 style={{ margin: '0.2rem 0.1rem' }}>
-                        {tutorial.frontmatter.title
-                          ? tutorial.frontmatter.title
-                          : tutorial.frontmatter.courseTitle}
-                      </h3>
+        <OptionalLink path={path}>
+          <CardActive>
+            <CardParent style={{ borderTop: `5px solid ${tutorial.frontmatter.themeColor}` }}>
+              <div>
+                <CardHead style={{ flexDirection: 'column' }}>
+                  <Typography variant="body1" color="textSecondary">
+                    {tutorial.frontmatter.type}
+                  </Typography>
+                  <h3 style={{ margin: '0.2rem 0.1rem' }}>
+                    {tutorial.frontmatter.title
+                      ? tutorial.frontmatter.title
+                      : tutorial.frontmatter.courseTitle}
+                  </h3>
 
-                      {tutorial.frontmatter.status ? (
-                        <p>
-                          <span>New</span>
-                        </p>
-                      ) : null}
-                    </CardHead>
-                    <CardDesc>
-                      <p className="summary">{tutorial.frontmatter.description}</p>
-                    </CardDesc>
-                    {!isCreateLearningPath && (
-                      <CardSubdata className="card-subdata">
-                        <p>
-                          {courseCount} {courseType}
-                          {courseCount > 1 ? 's' : ''}
-                        </p>
-                        <p>
-                          Level:{' '}
-                          {tutorial?.frontmatter?.level
-                            ? tutorial.frontmatter.level.charAt(0).toUpperCase() +
-                              tutorial.frontmatter.level.slice(1)
-                            : ''}
-                        </p>
-                      </CardSubdata>
-                    )}
-                    <CardImage>
-                      <img src={tutorial.frontmatter.cardImage} />
-                    </CardImage>
-                  </div>
-                </CardParent>
-              </CardActive>
-            </OptionalLink>
-          )}
-        </>
+                  {tutorial.frontmatter.status ? (
+                    <p>
+                      <span>New</span>
+                    </p>
+                  ) : null}
+                </CardHead>
+                <CardDesc>
+                  <p className="summary">{tutorial.frontmatter.description}</p>
+                </CardDesc>
+                <CardSubdata className="card-subdata">
+                  <p>
+                    {courseCount} {courseType}
+                    {courseCount > 1 ? 's' : ''}
+                  </p>
+                  <p>
+                    Level:{' '}
+                    {tutorial?.frontmatter?.level
+                      ? tutorial.frontmatter.level.charAt(0).toUpperCase() +
+                        tutorial.frontmatter.level.slice(1)
+                      : ''}
+                  </p>
+                </CardSubdata>
+                <CardImage>
+                  <img src={tutorial.frontmatter.cardImage} />
+                </CardImage>
+              </div>
+            </CardParent>
+          </CardActive>
+        </OptionalLink>
       )}
-
-      <Modal
-        open={modalOpen}
-        closeModal={handleModalClose}
-        title={tutorial.frontmatter.title || tutorial.frontmatter.courseTitle}
-        maxWidth="sm"
-      >
-        <ModalBody>
-          <Typography variant="body1">{modalContent}</Typography>
-          {orgId && (
-            <Grid2 container direction="row" alignItems="center" spacing={1}>
-              <Grid2>
-                <Typography variant="body1" color="textSecondary">
-                  Your Organization ID: {orgId}
-                </Typography>
-              </Grid2>
-              <Grid2>
-                <CopyToClipboard data={orgId} />
-              </Grid2>
-            </Grid2>
-          )}
-        </ModalBody>
-        <ModalFooter variant="filled">
-          <ModalButtonSecondary onClick={handleModalClose}>Close</ModalButtonSecondary>
-          {path && (
-            <ModalButtonPrimary
-              onClick={() => {
-                window.open(path, '_blank');
-                handleModalClose();
-              }}
-            >
-              Visit Docs
-            </ModalButtonPrimary>
-          )}
-        </ModalFooter>
-      </Modal>
     </CardWrapper>
   );
 };

--- a/src/custom/LearningCard/style.tsx
+++ b/src/custom/LearningCard/style.tsx
@@ -19,36 +19,6 @@ const CardActive = styled('div')(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'light' ? WHITE : BLACK
 }));
 
-const OwnLearningCard = styled('div')(({ theme }) => ({
-  cursor: 'pointer',
-  transition: 'all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s',
-  position: 'relative',
-  overflow: 'hidden',
-  '&:hover': {
-    boxShadow: `${theme.palette.background.brand?.default} 0px 0px 19px 6px`
-  },
-  background: `linear-gradient(135deg, 
-        rgba(255, 255, 255, 0.85) 0%, 
-        rgba(248, 250, 252, 0.9) 50%, 
-        rgba(241, 245, 249, 0.85) 100%)`,
-  '&::before': {
-    content: '""',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background: `repeating-linear-gradient(
-          45deg,
-          transparent,
-          transparent 15px,
-          rgba(148, 163, 184, 0.1) 15px,
-          rgba(148, 163, 184, 0.1) 30px
-        )`,
-    pointerEvents: 'none'
-  }
-}));
-
 const CardLink = styled('a')({
   color: 'black',
   textDecoration: 'none'
@@ -135,6 +105,5 @@ export {
   CardLink,
   CardParent,
   CardSubdata,
-  CardWrapper,
-  OwnLearningCard
+  CardWrapper
 };


### PR DESCRIPTION
**Notes for Reviewers**

Initially the ownLearningcard was placed in sistent as it was not much different from other learning cards but now it includes a modal and follows a stepper component which does not makes it suitable to place in sistent.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
