### PR TITLE
add: Dynamic Organization color support across all modals in cloud-ui || remove hardcoded modal colors

### DIFF
--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -5,7 +5,6 @@ import { ContainedButton, OutlinedButton, TextButton } from '../../base/Button/B
 import { iconLarge } from '../../constants/iconsSizes';
 import { CloseIcon, FullScreenIcon } from '../../icons';
 import FullScreenExitIcon from '../../icons/Fullscreen/FullScreenExitIcon';
-import { darkModalGradient, lightModalGradient } from '../../theme/colors/colors';
 import { CustomTooltip } from '../CustomTooltip';
 import { HelperTextPopover } from '../HelperTextPopover';
 
@@ -74,7 +73,7 @@ const FullscreenExitButton = styled(FullScreenExitIcon)(({ theme }) => ({
 }));
 
 export const ModalStyledHeader = styled('div')(({ theme }) => ({
-  background: theme.palette.mode === 'light' ? lightModalGradient.header : darkModalGradient.header,
+  background: `linear-gradient(90deg, ${theme.palette?.primary?.main} 0%, ${theme.palette?.primary?.dark || theme.palette?.primary?.main} 100%)`,
   color: '#eee',
   display: 'flex',
   justifyContent: 'space-between',
@@ -134,9 +133,7 @@ const StyledFooter = styled('div', {
 })<ModalFooterProps>(({ theme, variant, hasHelpText }) => ({
   background:
     variant === 'filled'
-      ? theme.palette.mode === 'light'
-        ? lightModalGradient.fotter
-        : darkModalGradient.fotter
+      ? `linear-gradient(90deg, ${theme.palette?.primary?.dark || theme.palette?.primary?.main} 0%, ${theme.palette?.primary?.main} 100%)`
       : 'transparent',
   display: 'flex',
   alignItems: 'center',


### PR DESCRIPTION
**Notes for Reviewers**

This pr removes the hardcoded colors used in modal and replaces them with primary.main as they will automatically adapt to brand-colors sistent based.

<img width="834" height="535" alt="SCR-20250812-ngkl" src="https://github.com/user-attachments/assets/47f6404b-82b7-4a6c-9fdb-1486e3771afb" />

This PR fixes https://github.com/layer5io/meshery-cloud/issues/3917

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
