### PR TITLE
fix: custom - tooltip on hover should stay there for atleast some seconds 

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -29,8 +29,8 @@ function CustomTooltip({
 }: CustomTooltipProps): JSX.Element {
   return (
     <Tooltip
-      enterTouchDelay={0}
-      leaveTouchDelay={2000}
+      enterDelay={0}
+      leaveDelay={1200}
       componentsProps={_.merge(
         {
           tooltip: {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1130 
The users are not able to interact with tooltip because it disappears as soon as the user removes the hover over the parent element . This pr introduces a delay of 1.2sec after hover is removed from the parent element .

https://github.com/user-attachments/assets/7c199018-3aea-40c8-adcf-362f7c9cf216



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
