### PR TITLE
fix: custom - tooltip on hover should stay there for atleast some seconds

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -29,8 +29,9 @@ function CustomTooltip({
 }: CustomTooltipProps): JSX.Element {
   return (
     <Tooltip
-      enterTouchDelay={0}
-      leaveTouchDelay={2000}
+      enterDelay={150}
+      enterNextDelay={400} //->delay when moving between siblings
+      leaveDelay={700}
       componentsProps={_.merge(
         {
           tooltip: {


### PR DESCRIPTION
**Notes for Reviewers**


https://github.com/user-attachments/assets/44ff71d1-a003-4044-9b67-9e4127ab5070

**Changes:**
1. Tooltip leave duration: Initially would disappear immediately -> now will be there for 0.7sec
2. milliseconds to wait before showing the tooltip when one was already recently opened -> 0.4sec
3. Tooltip appear on hover : Initial 0.1sec -> now 0.15sec


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
4. Build and test your changes before submitting a PR.
5. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
