### PR TITLE
feat(icons): add Academy icon

### DIFF
--- a/src/icons/Academy/AcademyIcon.tsx
+++ b/src/icons/Academy/AcademyIcon.tsx
@@ -3,13 +3,17 @@ import { DEFAULT_HEIGHT, DEFAULT_WIDTH, KEPPEL_GREEN_FILL,} from '../../constant
 import { IconProps } from '../types';
 
 type AcademyIconProps = {
-  primaryFill: string;
+topFill: string;
+centerFill: string;
+bottomFill: string;
 } & IconProps;
 
 const AcademyIcon: FC<AcademyIconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
-  primaryFill = KEPPEL_GREEN_FILL,
+  topFill = KEPPEL_GREEN_FILL,
+  centerFill = KEPPEL_GREEN_FILL,
+  bottomFill = KEPPEL_GREEN_FILL,
   ...props
 }) => {
   return (
@@ -17,12 +21,23 @@ const AcademyIcon: FC<AcademyIconProps> = ({
       width={width}
       height={height}
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 512 512"
+      viewBox="0 0 22 22"
       data-testid="academy-icon-svg"
       {...props}
     >
-      <path  d="M496 128v16a8 8 0 0 1-8 8h-24v12c0 6.627-5.373 12-12 12H60c-6.627 0-12-5.373-12-12v-12H24a8 8 0 0 1-8-8v-16a8 8 0 0 1 4.941-7.392l232-88a7.996 7.996 0 0 1 6.118 0l232 88A8 8 0 0 1 496 128zm-24 304H40c-13.255 0-24 10.745-24 24v16a8 8 0 0 0 8 8h464a8 8 0 0 0 8-8v-16c0-13.255-10.745-24-24-24zM96 192v192H60c-6.627 0-12 5.373-12 12v20h416v-20c0-6.627-5.373-12-12-12h-36V192h-64v192h-64V192h-64v192h-64V192H96z" fill={primaryFill} />
-    </svg>
+        <path
+          fill={topFill}
+          d="M22.5,4.5v.8c0,.2-.2.4-.4.4h-1.1v.6c0,.3-.3.6-.6.6H2.1c-.3,0-.6-.3-.6-.6v-.6H.4c-.2,0-.4-.2-.4-.4v-.8c0-.2,0-.3.2-.3L11.1,0c0,0,.2,0,.3,0l10.9,4.1c.1,0,.2.2.2.3Z"
+        />
+        <path
+          fill={centerFill}
+          d="M3.8,7.5v9h-1.7c-.3,0-.6.3-.6.6v.9h19.5v-.9c0-.3-.3-.6-.6-.6h-1.7V7.5h-3v9h-3V7.5h-3v9h-3V7.5h-3Z"
+        />
+        <path
+          fill={bottomFill}
+          d="M21.4,18.8H1.1c-.6,0-1.1.5-1.1,1.1v.8c0,.2.2.4.4.4h21.8c.2,0,.4-.2.4-.4v-.8c0-.6-.5-1.1-1.1-1.1Z"
+        />
+       </svg>
   );
 };
 

--- a/src/icons/Academy/AcademyIcon.tsx
+++ b/src/icons/Academy/AcademyIcon.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, KEPPEL_GREEN_FILL,} from '../../constants/constants';
+import { IconProps } from '../types';
+
+type AcademyIconProps = {
+  primaryFill: string;
+} & IconProps;
+
+const AcademyIcon: FC<AcademyIconProps> = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  primaryFill = KEPPEL_GREEN_FILL,
+  ...props
+}) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      data-testid="academy-icon-svg"
+      {...props}
+    >
+      <path  d="M496 128v16a8 8 0 0 1-8 8h-24v12c0 6.627-5.373 12-12 12H60c-6.627 0-12-5.373-12-12v-12H24a8 8 0 0 1-8-8v-16a8 8 0 0 1 4.941-7.392l232-88a7.996 7.996 0 0 1 6.118 0l232 88A8 8 0 0 1 496 128zm-24 304H40c-13.255 0-24 10.745-24 24v16a8 8 0 0 0 8 8h464a8 8 0 0 0 8-8v-16c0-13.255-10.745-24-24-24zM96 192v192H60c-6.627 0-12 5.373-12 12v20h416v-20c0-6.627-5.373-12-12-12h-36V192h-64v192h-64V192h-64v192h-64V192H96z" fill={primaryFill} />
+    </svg>
+  );
+};
+
+export default AcademyIcon;

--- a/src/icons/Academy/index.ts
+++ b/src/icons/Academy/index.ts
@@ -1,0 +1,1 @@
+export { default as AcademyIcon } from './AcademyIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,3 +1,4 @@
+export * from './Academy';
 export * from './Add';
 export * from './AddCircle';
 export * from './Application';


### PR DESCRIPTION
This PR adds the Academy icon to the Sistent project’s icon collection.

**Notes for Reviewers**
  - Please review the Academy icon’s design
  - The icon can be customized by changing the colors of the top, center, and bottom sections.
    -  topFill
    -  centerFill
    -  bottomFill
  - Example : <AcademyIcon **topFill**={theme?.palette?.background?.inverse || "#eee"}/>;
         
  
  **Default Icon :**
<img width="736" height="102" alt="image" src="https://github.com/user-attachments/assets/3a482ac2-8d8b-473a-9075-ec3715731955" />
<img width="736" height="102" alt="image" src="https://github.com/user-attachments/assets/5ec9e976-f57d-4e45-8292-4945d904449c" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
