### PR TITLE
chore: Remove unused field `tertiaryFill` from type definition.

### DIFF
--- a/src/icons/CatalogIcon/CatalogIcon.tsx
+++ b/src/icons/CatalogIcon/CatalogIcon.tsx
@@ -6,7 +6,6 @@ import { IconProps } from '../types';
 type CatalogIconProps = {
   primaryFill?: string;
   secondaryFill?: string;
-  tertiaryFill?: string;
 } & IconProps;
 
 export const CatalogIcon: FC<CatalogIconProps> = ({


### PR DESCRIPTION
This was discovered through a console error message in the Meshery UI.



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
