### PR TITLE
Added Meshery Icon in Icon collections 

### DIFF
--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -81,6 +81,7 @@ export * from './Lock';
 export * from './Logout';
 export * from './Mendeley';
 export * from './Menu';
+export * from './Meshery';
 export * from './MesheryFilter';
 export * from './MesheryOperator';
 export * from './MoveFile';


### PR DESCRIPTION
**Notes for Reviewers**

**Hacktoberfest Contribution 🎉**

This PR fixes #1170 
This PR adds MesheryIcon to the Sistent icon collection. The current library does not include Meshery’s official icon, and adding it ensures consistency with Meshery branding and provides developers with easy access when using Sistent.
- Added MesheryIcon to the Sistent icon set.
<img width="500" height="250" alt="darkmode" src="https://github.com/user-attachments/assets/a4f43b75-78a2-45e7-861b-93fd5fb9dff0" />
<img width="500" height="250" alt="whitemod" src="https://github.com/user-attachments/assets/bae403f9-093e-4a42-9d52-5e9abc3d25ac" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
