### PR TITLE
Add new component to fix the dynamic allocation for label space

### DIFF
--- a/src/custom/StyledTextField/index.tsx
+++ b/src/custom/StyledTextField/index.tsx
@@ -1,0 +1,57 @@
+import { TextField } from '../../base/TextField';
+import { styled } from '@mui/material/styles';
+import type { TextFieldProps } from '../../base/TextField';
+
+export const StyledTextField = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    backgroundColor: theme.palette.background.paper,
+    '& fieldset': {
+      borderColor: 'theme.palette.background.brand.default',
+      borderWidth: 1,
+    },
+    '&:hover fieldset': {
+      borderColor: 'theme.palette.background.brand.default',
+      borderWidth: 2,
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: 'theme.palette.background.brand.default',
+      borderWidth: 2,
+      borderLeftWidth: 4,
+      padding: '4px',
+    },
+  },
+  '& .MuiInputLabel-root': {
+    color: theme.palette.text.secondary,
+    '&.Mui-focused': {
+      color: 'theme.palette.background.brand.default',
+    },
+  },
+  '& .MuiInputLabel-asterisk': {
+    display: 'none',
+  },
+  '& .MuiInputBase-input': {
+    color: theme.palette.common.black,
+  },
+}));
+
+interface CustomTextFieldProps extends Omit<TextFieldProps, 'variant' | 'size'> {
+  minWidth?: number;
+  variant?: 'outlined' | 'filled' | 'standard';
+  size?: 'small' | 'medium';
+}
+
+export const CustomTextField = ({
+  minWidth = 150,
+  variant = 'outlined',
+  size = 'small',
+  ...props
+}: CustomTextFieldProps): JSX.Element => {
+  return (
+    <StyledTextField
+      variant={variant}
+      size={size}
+      sx={{ minWidth }}
+      {...props}
+    />
+  );
+};

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -68,6 +68,7 @@ export {
 export { SetupPreReq } from './SetupPrerequisite';
 export { StyledChapter } from './StyledChapter';
 export { StyledSearchBar } from './StyledSearchBar';
+export { CustomTextField } from './StyledTextField';
 export { Terminal } from './Terminal';
 export { TOC } from './TOCChapter';
 export { TOCLearning } from './TOCLearning';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1175

Currently we use FormControl, InputLabel and Select for input fields or select dropdowns, but we face the issue for the label not getting the space allocated dynamically. I did test the components in Staclblitz from the official MUI website, and did not find any solution to it.

This new component: Replaces FormControl + TextField combinations with a single, properly styled component that fixes label/border intersection issues.

Features:

1. Dynamic Label Positioning
2. Consistent Brand Styling
3. Improved Developer Experience - The component can be changed as per needs by passing props to it
4. All other TextField props supported

Working: 

https://github.com/user-attachments/assets/46251d5d-65f2-4bfb-b19a-d83f3080e776



https://github.com/user-attachments/assets/f2fb9232-5672-423c-86e1-1afaedd1cbe3


We need to replace all the current FormControl and TextField with this component, then the issue for the dynamic label space will be solved. 


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
