### PR TITLE
Add useGetUserByEmailQuery to GetStartedModal and InviteUserModal components

### DIFF
--- a/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
@@ -75,6 +75,7 @@ interface GetStartedModalProps {
   useLazyGetTeamsQuery: any;
   embedDesignPath: string;
   isFromMeshery: boolean;
+  useGetUserByEmailQuery: any;
 }
 
 const Loading: React.FC<LoadingProps> = ({ showModal, handleClose, style }) => {
@@ -164,7 +165,8 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({
   isAssignUserRolesAllowed,
   useLazyGetTeamsQuery,
   embedDesignPath,
-  isFromMeshery
+  isFromMeshery,
+  useGetUserByEmailQuery
 }) => {
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [clicked, setClicked] = useState<number | undefined>(undefined);
@@ -309,6 +311,7 @@ const GetStartedModal: React.FC<GetStartedModalProps> = ({
           useNotificationHandlers={useNotificationHandlers}
           isAssignUserRolesAllowed={isAssignUserRolesAllowed}
           useLazyGetTeamsQuery={useLazyGetTeamsQuery}
+          useGetUserByEmailQuery={useGetUserByEmailQuery}
         />
       )}
     </>


### PR DESCRIPTION
Signed-off-by: Lee Calcote <lee.calcote@layer5.io>


Prevent the user invite modal's form from being submitted if the email address supplied is already associated with an existing account.