### PR TITLE
fix(icons): set Sistent icons to be filled by default using currentColor

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_WIDTH = '24';
 export const DEFAULT_HEIGHT = '24';
 export const DEFAULT_FILL = '#000';
-export const DEFAULT_FILL_NONE = 'none';
+export const DEFAULT_FILL_NONE = 'currentColor';
 export const KEPPEL_GREEN_FILL = '#00B39F';
 export const CARIBBEAN_GREEN_FILL = '#00D3A9';
 export const DEFAULT_STROKE = '#000';


### PR DESCRIPTION
**Notes for Reviewers**
this was the only best way i found out by changing the DEFAULT_FILL_NONE = "none" to DEFAULT_FILL_NONE="currentcolor"
This PR fixes #663

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
