### PR TITLE
ISSUE #1193. Now show correct warning icon 

### DIFF
--- a/src/icons/Warning/WarningIcon.tsx
+++ b/src/icons/Warning/WarningIcon.tsx
@@ -7,17 +7,17 @@ export const WarningIcon = ({
   ...props
 }: IconProps): JSX.Element => {
   return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      data-testid="WarningIcon"
-      width={width}
-      height={height}
-      xmlns="http://www.w3.org/2000/svg"
-      {...props}
-    >
-      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8z"></path>
-    </svg>
+  <svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    data-testid="WarningIcon"
+    width={width}
+    height={height}
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+  </svg>
   );
 };
 


### PR DESCRIPTION
BEFORE: in layer5 page, when warning icon was searched, a wrong icon was showed (img1)
AFTER: changed the path of the warning icon to match a correct svg (img 2)
<img width="1225" height="351" alt="grafik" src="https://github.com/user-attachments/assets/ed373101-cd37-4855-9c35-699e6d892eed" />
<img width="944" height="660" alt="grafik" src="https://github.com/user-attachments/assets/8044719e-09ef-4057-9579-fa3337fbbccd" />

