### PR TITLE
Removed fillOpacity from CrossCircleIcon

### DIFF
--- a/src/icons/CrossCircle/index.tsx
+++ b/src/icons/CrossCircle/index.tsx
@@ -1,10 +1,10 @@
-import { DEFAULT_FILL, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
 
 function CrossCircleIcon({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
-  fill = DEFAULT_FILL,
+  fill = DEFAULT_FILL_NONE,
   ...props
 }: IconProps): JSX.Element {
   return (
@@ -20,6 +20,7 @@ function CrossCircleIcon({
       <g clipPath="url(#a)">
         <path
           d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2Zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59Z"
+          fill={fill}
         />
       </g>
       <defs>


### PR DESCRIPTION
**Notes for Reviewers**

This PR removes the Default -> fillOpacity property from the CrossCircleIcon.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
