### PR TITLE
Fix: Prevent unexpected card flip when non-owner users click workspace action buttons

### DIFF
--- a/src/custom/Workspaces/WorkspaceCard.tsx
+++ b/src/custom/Workspaces/WorkspaceCard.tsx
@@ -354,11 +354,12 @@ const CardBack = ({
     <CardBackWrapper elevation={2} onClick={onFlipBack}>
       <CardBackTopGrid size={12}>
         <CardBackTitleGrid size={6}>
-          <BulkSelectCheckbox
-            onClick={(e) => e.stopPropagation()}
-            onChange={onSelect}
-            disabled={deleted ? true : !isDeleteWorkspaceAllowed}
-          />
+          <div onClick={(e) => e.stopPropagation()}>
+            <BulkSelectCheckbox
+              onChange={onSelect}
+              disabled={deleted ? true : !isDeleteWorkspaceAllowed}
+            />
+          </div>
           <CardTitle
             sx={{ color: theme.palette.background.constant?.white }}
             variant="body2"
@@ -368,18 +369,22 @@ const CardBack = ({
           </CardTitle>
         </CardBackTitleGrid>
         <CardBackActionsGrid size={6}>
-          <L5EditIcon
-            onClick={onEdit}
-            disabled={isEditButtonDisabled}
-            style={{ fill: theme.palette.background.constant?.white }}
-            bulk={true}
-          />
-          <L5DeleteIcon
-            onClick={onDelete}
-            style={{ fill: theme.palette.background.constant?.white }}
-            disabled={isDeleteButtonDisabled}
-            bulk={true}
-          />
+          <div onClick={(e) => e.stopPropagation()}>
+            <L5EditIcon
+              onClick={onEdit}
+              disabled={isEditButtonDisabled}
+              style={!isEditButtonDisabled ? { fill: theme.palette.background.constant?.white } : undefined}
+              bulk={true}
+            />
+          </div>
+          <div onClick={(e) => e.stopPropagation()}>
+            <L5DeleteIcon
+              onClick={onDelete}
+              style={!isDeleteButtonDisabled ? { fill: theme.palette.background.constant?.white } : undefined}
+              disabled={isDeleteButtonDisabled}
+              bulk={true}
+            />
+          </div>
         </CardBackActionsGrid>
       </CardBackTopGrid>
       <Grid2 sx={{ display: 'flex', alignItems: 'center', flexDirection: 'row' }}>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the  unexpected card flip when non-owner users click workspace action buttons.

[Screencast from 2026-01-05 14-15-29.webm](https://github.com/user-attachments/assets/fa396b16-0e76-42e3-8af3-f20762616969)


- Added stopPropagation() to prevent parent flip event
- Removed default white icon styling for disabled state

**Output**

[Screencast from 2026-01-05 14-24-29.webm](https://github.com/user-attachments/assets/16cd8260-aa63-4b2e-9922-0dcb2309b764)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
