### PR TITLE
Ensure caret (^) is included in automated Sistent dependency bumps

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -77,7 +77,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
         working-directory: ui
-        run: npm install @sistent/sistent@${{ env.RELEASE_VERSION }}
+        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -120,7 +120,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
         working-directory: meshmap
-        run: npm install @sistent/sistent@${{ env.RELEASE_VERSION }}
+        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -163,7 +163,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
-        run: npm install @sistent/sistent@${{ env.RELEASE_VERSION }} --legacy-peer-deps
+        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }} --legacy-peer-deps
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8
@@ -206,7 +206,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
         working-directory: ui
-        run: npm install @sistent/sistent@${{ env.RELEASE_VERSION }}
+        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }}
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
This PR ensures that the automated dependency update workflow
always includes the caret (^) when bumping @sistent/sistent.

This resolve issue : #1250
