### PR TITLE
feat: add ScienceIcon

### DIFF
--- a/src/icons/Science/ScienceIcon.tsx
+++ b/src/icons/Science/ScienceIcon.tsx
@@ -1,0 +1,29 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+const KEPPEL_GREEN_FILL = '#00B39F';
+
+export const ScienceIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  fill = KEPPEL_GREEN_FILL,
+  ...props
+}: IconProps): JSX.Element => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      data-testid="science-icon-svg"
+      {...props}
+    >
+      <path
+        d="M19.8 18.4L14 10.67V6.5l1.35-1.69c.26-.33.03-.81-.39-.81H9.04c-.42 0-.65.48-.39.81L10 6.5v4.17L4.2 18.4c-.49.66-.02 1.6.8 1.6h14c.82 0 1.29-.94.8-1.6z"
+        fill={fill}
+      />
+    </svg>
+  );
+};
+
+export default ScienceIcon;

--- a/src/icons/Science/index.ts
+++ b/src/icons/Science/index.ts
@@ -1,0 +1,1 @@
+export { default as ScienceIcon } from './ScienceIcon';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1259 
This PR adds the ScienceIcon component to the Sistent design system, ported from Material UI.

Default Fill: Configured to use Keppel Green (#00B39F) by default from constants/constants.ts, as requested.

Style: Aligned with standard Sistent icon props (width, height, fill).

Implementation Details
Added ScienceIcon.tsx in components/icons.

Exported component via components/icons/index.ts.
Screenshot:
<img width="152" height="97" alt="Screenshot 2026-02-03 104106" src="https://github.com/user-attachments/assets/4a9aa74f-8a3a-46a5-8576-c70fd57508c1" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
