### PR TITLE
feat(icons): add AccessTime icon to Sistent

### DIFF
--- a/src/icons/AccessTime/AccessTimeIcon.tsx
+++ b/src/icons/AccessTime/AccessTimeIcon.tsx
@@ -1,0 +1,26 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, KEPPEL_GREEN_FILL } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const AccessTimeIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  fill = KEPPEL_GREEN_FILL,
+  ...props
+}: IconProps): JSX.Element => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path
+        d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+        fill={fill}
+      />
+    </svg>
+  );
+};
+
+export default AccessTimeIcon;

--- a/src/icons/AccessTime/index.ts
+++ b/src/icons/AccessTime/index.ts
@@ -1,0 +1,1 @@
+export { default as AccessTime } from './AccessTimeIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,4 +1,5 @@
 export * from './Academy';
+export * from './AccessTime';
 export * from './Add';
 export * from './AddCircle';
 export * from './Application';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1258

**Summary**

This PR adds a new AccessTime icon to the Sistent icon collection, replacing the dependency on ``@mui/icons-material`` for this icon.

The icon follows the existing Sistent icon structure and styling conventions, making it reusable and consistent with the rest of the icon set.

**Changes Included**

Added AccessTime icon component under src/icons/AccessTime

Implemented the icon using:

``KEPPEL_GREEN_FILL`` as the default fill color

Exported the icon via:

1) ``src/icons/AccessTime/index.ts``
2) ``src/icons/index.ts``

**Design Reference:**

Material UI AccessTime icon:
[https://mui.com/material-ui/material-icons/?query=Access&selected=AccessTime]()

The SVG path was adapted to match Sistent’s icon conventions.

**Screenshot/Image:**

<img width="138" height="92" alt="Screenshot (518)" src="https://github.com/user-attachments/assets/d43088bd-cd83-4914-9610-efb73d342553" />


<!-- Add a screenshot of the icon rendered in Storybook / local UI if available -->

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
