### PR TITLE
Fix: release workflow uses inputs.tag_name for workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "Set Package Version"
         uses: reedyuk/npm-version@1.1.1
         with:
-          version: ${{ github.event.release.tag_name }}
+          version: ${{ github.event.release.tag_name || inputs.tag_name }}
 
       - name: Install, Build, and Publish Package
         run: |


### PR DESCRIPTION
## Summary

- The release workflow was using `github.event.release.tag_name` in the `Set Package Version` step, which is only populated for `release` events
- When triggered via `workflow_dispatch`, this evaluates to an empty string, causing the version to not be updated and the publish to fail with "cannot publish over previously published version"
- Fix: use `${{ github.event.release.tag_name || inputs.tag_name }}` to fall back to the workflow dispatch input

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` with a valid version tag (e.g. `v0.18.1`) and verify the publish succeeds