### PR TITLE
fix: bundle rxjs in dist

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   format: ['cjs', 'esm'],
   external: ['react', 'xstate', '@xstate/react', 'react-dom', 'mui-datatables'],
-  noExternal: [/^@meshery\/schemas/],
+  noExternal: [/^@meshery\/schemas/, 'rxjs'],
   minify: env === 'production',
   watch: env === 'development',
   sourcemap: env === 'development',


### PR DESCRIPTION
**Notes for Reviewers**

Add rxjs to noExternal in tsup config so it's bundled into the package instead of requiring consumers to install it.
**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
