### PR TITLE
fix(types): export PromptRef type from Prompt barrel

### DIFF
--- a/src/custom/Prompt/index.tsx
+++ b/src/custom/Prompt/index.tsx
@@ -1,3 +1,3 @@
-import PromptComponent, { PROMPT_VARIANTS } from './promt-component';
-export { PROMPT_VARIANTS, PromptComponent };
+import PromptComponent, { PROMPT_VARIANTS, type PromptRef } from './promt-component';
+export { PROMPT_VARIANTS, PromptComponent, type PromptRef };
 export default PromptComponent;

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -38,7 +38,7 @@ import { LearningCard } from './LearningCard';
 import { BasicMarkdown, RenderMarkdown } from './Markdown';
 import { ModalCard } from './ModalCard';
 import PopperListener, { IPopperListener } from './PopperListener';
-import { PROMPT_VARIANTS, PromptComponent } from './Prompt';
+import { PROMPT_VARIANTS, PromptComponent, type PromptRef } from './Prompt';
 import ResponsiveDataTable, {
   DataTableEllipsisMenu,
   ResponsiveDataTableProps
@@ -105,6 +105,7 @@ export {
   PROMPT_VARIANTS,
   PopperListener,
   PromptComponent,
+  type PromptRef,
   ResponsiveDataTable,
   SearchBar,
   StyledDialogActions,


### PR DESCRIPTION
## Description

`PromptRef` (the imperative handle interface for `PromptComponent`) was defined in `src/custom/Prompt/promt-component.tsx` but never re-exported from the barrel files, making it inaccessible to consumers of `@sistent/sistent`.

## Changes

- `src/custom/Prompt/index.tsx` — re-exports `PromptRef` alongside `PromptComponent` and `PROMPT_VARIANTS`
- `src/custom/index.tsx` — adds `PromptRef` to the main custom barrel export

## Why

Consumers that create a `React.RefObject` for `PromptComponent` need the `PromptRef` type to correctly type that ref:

```ts
import { PromptComponent, type PromptRef } from '@sistent/sistent';

const promptRef = React.useRef<PromptRef>(null);
```

Without this export, consumers were forced to either duplicate the interface locally or use a module augmentation workaround.

## Testing

All existing tests pass (`npm test` — 21 tests, 7 suites).