### PR TITLE
fix(types): use direct re-export for Prompt so tsup emits DTS declarations

### DIFF
--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -38,7 +38,6 @@ import { LearningCard } from './LearningCard';
 import { BasicMarkdown, RenderMarkdown } from './Markdown';
 import { ModalCard } from './ModalCard';
 import PopperListener, { IPopperListener } from './PopperListener';
-import { PROMPT_VARIANTS, PromptComponent, type PromptRef } from './Prompt';
 import ResponsiveDataTable, {
   DataTableEllipsisMenu,
   ResponsiveDataTableProps
@@ -75,6 +74,7 @@ export { Terminal } from './Terminal';
 export { TOC } from './TOCChapter';
 export { TOCLearning } from './TOCLearning';
 export { UserSearchField } from './UserSearchField';
+export { PROMPT_VARIANTS, PromptComponent, type PromptRef } from './Prompt';
 
 export {
   ActionButton,
@@ -102,10 +102,7 @@ export {
   InfoTooltip,
   LearningCard,
   ModalCard,
-  PROMPT_VARIANTS,
   PopperListener,
-  PromptComponent,
-  type PromptRef,
   ResponsiveDataTable,
   SearchBar,
   StyledDialogActions,


### PR DESCRIPTION
## Problem

`PromptComponent`, `PROMPT_VARIANTS`, and `PromptRef` were exported from `custom/index.tsx` using an **import-then-re-export** pattern:

```ts
import { PROMPT_VARIANTS, PromptComponent, type PromptRef } from './Prompt';
// ...
export { PROMPT_VARIANTS, PromptComponent, type PromptRef }; // in big export block
```

tsup's DTS generator does not trace this pattern, so these types were silently omitted from `dist/index.d.ts`. Consumers could import them at runtime (they appeared in the JS bundle) but had no TypeScript types available.

## Fix

Convert to a **direct re-export** matching the pattern used by other custom components (e.g. `CatalogCard`):

```ts
export { PROMPT_VARIANTS, PromptComponent, type PromptRef } from './Prompt';
```

This allows tsup's DTS generator to trace the re-export chain and emit proper declarations.

## Testing

All CI tests pass (note: local TS resolves `^6.0.2` to 5.9.3 which rejects `ignoreDeprecations: "6.0"` — CI with TS 6 is green).