### PR TITLE
fix(ci): use --legacy-peer-deps when bumping meshery-extensions

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -120,7 +120,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       - name: Make changes to pull request
         working-directory: meshmap
-        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }}
+        run: npm install @sistent/sistent@^${{ env.RELEASE_VERSION }} --legacy-peer-deps
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` to `npm install` in the `bump-meshery-extensions` job of `notify-dependents.yml`, matching the existing `bump-layer5` job and meshmap's own `install:legacy-peer-deps` script.

## Why
The previous run failed with ERESOLVE because `meshmap/` has legitimate peer-dep relaxations (e.g. `jquery@^4` × `cytoscape-clipboard`): [failing run](https://github.com/layer5io/sistent/actions/runs/24587487656/job/71900653724). Paired with [layer5labs/meshery-extensions#4193](https://github.com/layer5labs/meshery-extensions/pull/4193) which removes stale ESLint-9-pinning deps that were the primary blocker.

## Test plan
- [ ] Merge [layer5labs/meshery-extensions#4193](https://github.com/layer5labs/meshery-extensions/pull/4193) first
- [ ] Trigger `Bump Meshery, Meshery Extensions and Meshery Cloud` manually with latest release version and confirm `bump-meshery-extensions` succeeds