### PR TITLE
[Feature] Add ArrowDownward icon

### DIFF
--- a/src/icons/ArrowDownward/ArrowDownwardIcon.tsx
+++ b/src/icons/ArrowDownward/ArrowDownwardIcon.tsx
@@ -1,0 +1,23 @@
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const ArrowDownwardIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  fill = DEFAULT_FILL_NONE,
+  ...props
+}: IconProps): JSX.Element => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z" fill={fill} />
+    </svg>
+  );
+};
+
+export default ArrowDownwardIcon;

--- a/src/icons/ArrowDownward/index.ts
+++ b/src/icons/ArrowDownward/index.ts
@@ -1,0 +1,1 @@
+export {default as ArrowDownwardIcon} from "./ArrowDownwardIcon";

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -7,6 +7,7 @@ export * from './Alert';
 export * from './Application';
 export * from './ArrowBack';
 export * from './ArrowCompress';
+export * from "./ArrowDownward";
 export * from './ArrowDropDown';
 export * from './ArrowExpand';
 export * from './Article';


### PR DESCRIPTION
## Description
Add `ArrowDownwardIcon` to Sistent to reduce dependency on 
`@mui/icons-material` and ensure design consistency across 
Layer5 products.

## Changes
- Added `ArrowDownwardIcon` component in `src/icons/ArrowDownward/`
- Exported icon via `src/icons/ArrowDownward/index.ts`

## Related Issue
Closes #1414

## Screenshots
N/A (SVG Icon)