### PR TITLE
fix(schemas): align importDesign with oneOf[File|URL] shape (0.19.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sistent/sistent",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Reusable React Components and SVG Icons library",
   "repository": {
     "type": "git",

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -3,15 +3,32 @@ import { DesignDefinitionV1Beta1OpenApiSchema } from '@meshery/schemas';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const DesignSchema = (DesignDefinitionV1Beta1OpenApiSchema as any).components.schemas;
 
+// In @meshery/schemas >= 1.1.0, MesheryPatternImportRequestBody is a
+// `oneOf` union of a File-import variant and a URL-import variant rather than
+// a flat properties object. Resolve the individual field shapes from the
+// dedicated payload components so the form schema remains driven by the
+// upstream API contract.
+// See meshery/schemas commit b08a4f62 "fix(design): tighten
+// MesheryPatternImportRequestBody to oneOf[File|URL]".
+const ImportBody = DesignSchema.MesheryPatternImportRequestBody;
+const FilePayload = DesignSchema.MesheryPatternImportFilePayload;
+const URLPayload = DesignSchema.MesheryPatternImportURLPayload;
+
+// `name` is a common field present on both variants; File is used as the
+// canonical source.
+const nameField = FilePayload.properties.name;
+const fileField = FilePayload.properties.file;
+const urlField = URLPayload.properties.url;
+
 const importDesignSchema = {
   type: 'object',
   properties: {
     name: {
-      type: DesignSchema.MesheryPatternImportRequestBody.properties.name.type,
+      type: nameField.type,
       title: 'Design file name',
-      default: DesignSchema.MesheryPatternImportRequestBody.properties.name.default,
+      default: nameField.default,
       'x-rjsf-grid-area': '12',
-      description: DesignSchema.MesheryPatternImportRequestBody.properties.name.description
+      description: nameField.description
     },
 
     uploadType: {
@@ -19,7 +36,7 @@ const importDesignSchema = {
       enum: ['File Upload', 'URL Import'],
       default: 'URL Import',
       'x-rjsf-grid-area': '12',
-      description: DesignSchema.MesheryPatternImportRequestBody.description
+      description: ImportBody.description
     }
   },
 
@@ -35,9 +52,9 @@ const importDesignSchema = {
       then: {
         properties: {
           file: {
-            type: DesignSchema.MesheryPatternImportRequestBody.properties.file.type,
-            format: DesignSchema.MesheryPatternImportRequestBody.properties.file.format,
-            description: DesignSchema.MesheryPatternImportRequestBody.properties.file.description,
+            type: fileField.type,
+            format: fileField.format,
+            description: fileField.description,
             'x-rjsf-grid-area': '12'
           }
         },
@@ -55,10 +72,10 @@ const importDesignSchema = {
       then: {
         properties: {
           url: {
-            type: DesignSchema.MesheryPatternImportRequestBody.properties.url.type,
-            format: DesignSchema.MesheryPatternImportRequestBody.properties.url.format,
+            type: urlField.type,
+            format: urlField.format,
             title: 'URL',
-            description: DesignSchema.MesheryPatternImportRequestBody.properties.url.description,
+            description: urlField.description,
             'x-rjsf-grid-area': '12'
           }
         },


### PR DESCRIPTION
## Summary

Fixes the Next.js SSR crash `TypeError: Cannot read properties of undefined (reading 'name')` that surfaced downstream in meshery-cloud staging after pinning `@sistent/sistent@0.19.0` (meshery-cloud PR [#5094](https://github.com/layer5io/meshery-cloud/pull/5094)) and that was also flagged on PRs #1431 / #1433 but deferred as "out of scope."

### Root cause

[meshery/schemas commit b08a4f62](https://github.com/meshery/schemas/commit/b08a4f62) tightened `MesheryPatternImportRequestBody` from a flat `properties` object to a `oneOf: [MesheryPatternImportFilePayload, MesheryPatternImportURLPayload]` union, matching the server handler's "exactly one of File Import or URL Import" contract. That contract shipped in `@meshery/schemas@1.1.0` and is re-exposed here through the bundled `DesignDefinitionV1Beta1OpenApiSchema`.

`src/schemas/importDesign/schema.tsx` still walked `.properties.name`, `.properties.file`, `.properties.url` at the root of the request body. With the `oneOf` shape those paths resolve to `undefined`, and module evaluation throws at the first `.properties.name.type` read — before any React component even mounts. Because Sistent bundles `@meshery/schemas` inline (`noExternal: [/^@meshery\\/schemas/]` in `tsup.config.ts`), every downstream Next.js SSR build ships the same crash at `Collecting page data`.

### Fix

Resolve the individual field shapes from the dedicated payload components so the UI schema continues to be driven by the API contract rather than duplicating it:

- `name` and `file` come from `MesheryPatternImportFilePayload.properties`
- `url` comes from `MesheryPatternImportURLPayload.properties`
- The top-level prompt description still sources from the wrapper `MesheryPatternImportRequestBody.description`

No behavior change for the rendered form — same fields, same descriptions, same validation.

### Version bump

Bumps to `0.19.1`. Downstream consumers pinned `^0.19.0` (meshery-cloud, meshery-ui, meshery-extensions) will pick this up on their next install without any consumer-side change.

## Test plan

- [x] `npm run build` succeeds (`tsup` produces `dist/index.js` and `dist/index.mjs`).
- [x] `npm test` passes (7 suites / 21 tests).
- [x] `require('@sistent/sistent')` no longer throws at module load.
- [x] `meshery-cloud/ui` `npm run build-staging` completes successfully with the patched sistent overlaid into `node_modules/` (previously crashed at `Collecting page data using 7 workers`).
- [x] `importDesignSchema` resolves to a well-formed JSON schema with `properties.name.title === 'Design file name'`.