### PR TITLE
fix(CatalogDetail): skip user profile lookup when card has no owner id

### DIFF
--- a/src/custom/CatalogDetail/RightPanel.tsx
+++ b/src/custom/CatalogDetail/RightPanel.tsx
@@ -61,9 +61,13 @@ const RightPanel: React.FC<RightPanelProps> = ({
   handleVisibilityChange
 }) => {
   const cleanedType = type.replace('my-', '').replace(/s$/, '');
-  const { data: userProfile } = useGetUserProfileByIdQuery({
-    id: details.userId
-  });
+  // Skip the lookup when the card has no owner id — firing with an empty or
+  // undefined id reaches the server and surfaces a 400/404 that, upstream,
+  // leaks a plain-text body which RTK Query cannot parse as JSON.
+  const { data: userProfile } = useGetUserProfileByIdQuery(
+    { id: details.userId },
+    { skip: !details.userId }
+  );
 
   return (
     <div>


### PR DESCRIPTION
## Summary

- `RightPanel` fired `useGetUserProfileByIdQuery` unconditionally, so cards rendered without a `userId` hit the server with an empty/invalid UUID.
- Upstream returned a plain-text 400/404, which the UI's RTK Query JSON parser then crashed on (`SyntaxError: Unexpected token … is not valid JSON`).
- Add a `skip: !details.userId` guard — matches the pattern every other `custom/` call site uses when the id comes from props.

## Root cause

Discovered while tracing the Meshery "Open Recents" console-error loop. Companion PRs:
- [meshery/meshery#18916](https://github.com/meshery/meshery/pull/18916) — eliminates the N+1 lookups and returns JSON errors.
- [layer5io/meshery-cloud#5098](https://github.com/layer5io/meshery-cloud/pull/5098) — 404 + JSON on `/api/identity/users/profile/:id`.

## Test plan

- [x] `tsc --noEmit` shows no new errors on `RightPanel.tsx` (pre-existing unrelated errors elsewhere in the repo).
- [x] `jest` pre-commit suite (21 tests) passes.
- [ ] Manual: visit a catalog card with no owner id — confirm no network call to `/api/identity/users/profile/` and no `SyntaxError` in the console.