### PR TITLE
docs: cross-reference the identifier-naming contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Sistent Design System provides the open source building blocks to design and implement consistent, accessible, and delightful product experiences. Visit the <a href="https://layer5.io/projects/sistent">project website</a> for more information.
 
+## Naming conventions
+
+Sistent components that surface API data (tables, form fields, charts) must use the camelCase-on-the-wire identifiers defined by the Meshery / Layer5 ecosystem contract. See the [identifier-naming contributor guide](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) in `meshery/schemas` — the reader-friendly 26-row naming directory with before/after and do/don't examples — before adding props, column keys, or query-arg types that map to a Meshery or Layer5 Cloud response shape.
+
 ## Contributing to Sistent
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

Adds a "Naming conventions" section to `README.md` pointing at the ecosystem-wide canonical reference at <https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>.

Sistent components that surface API data (tables, form fields, charts) must use the camelCase-on-the-wire identifiers defined by the Meshery / Layer5 ecosystem contract. The new pointer sits above "Contributing to Sistent" so it is visible to anyone adding or reviewing component props that map to a Meshery or Layer5 Cloud response shape. No inline rules are duplicated here — the guide is the single authoritative directory.

Paired cross-reference PRs are being opened in `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`, and `meshery/meshkit`.

## Test plan

- [x] `git diff --stat` shows 1 doc-only file, +4 lines / -0 lines, no code modified.
- [x] Branch opened off `origin/master`, signed off per DCO.