### PR TITLE
fix(wire-format): flip sistent consumer reads of meshery wire to canonical camelCase (Phase 7c)

### DIFF
--- a/src/custom/CatalogCard/CatalogCard.tsx
+++ b/src/custom/CatalogCard/CatalogCard.tsx
@@ -73,7 +73,7 @@ const CatalogCard: React.FC<CatalogCardProps> = ({
   return (
     <DesignCard outerStyles={outerStyles} onClick={onCardClick}>
       <DesignInnerCard className="innerCard">
-        <ClassWrap catalogClassName={pattern?.catalog_data?.content_class} />
+        <ClassWrap catalogClassName={pattern?.catalogData?.contentClass} />
         <DesignType>{patternType}</DesignType>
         <DesignDetailsDiv>
           <DesignName

--- a/src/custom/CatalogDetail/ActionButton.tsx
+++ b/src/custom/CatalogDetail/ActionButton.tsx
@@ -108,7 +108,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
             }}
             onClick={() =>
               cleanedType === VIEWS
-                ? downloadYaml(details.pattern_file, details.name)
+                ? downloadYaml(details.patternFile, details.name)
                 : downloadPattern(details.id, details.name, getDownloadUrl)
             }
           >

--- a/src/custom/CatalogDetail/CaveatsSection.tsx
+++ b/src/custom/CatalogDetail/CaveatsSection.tsx
@@ -14,10 +14,10 @@ const CaveatsSection: React.FC<CaveatsSectionProps> = ({ details }) => {
       <ContentHeading>
         <h2 style={{ margin: '0' }}>CAVEATS AND CONSIDERATIONS</h2>
       </ContentHeading>
-      {details?.catalog_data?.patternCaveats ? (
+      {details?.catalogData?.patternCaveats ? (
         <ContentDetailsText style={{ whiteSpace: 'normal', fontFamily: 'inherit' }}>
           <RenderMarkdown
-            content={decodeURIComponent(details.catalog_data.patternCaveats || '')}
+            content={decodeURIComponent(details.catalogData.patternCaveats || '')}
           />
         </ContentDetailsText>
       ) : (

--- a/src/custom/CatalogDetail/LeftPanel.tsx
+++ b/src/custom/CatalogDetail/LeftPanel.tsx
@@ -75,7 +75,7 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
         cardWidth="100%"
       >
         <CatalogCardDesignLogo
-          imgURL={details?.catalog_data?.imageURL}
+          imgURL={details?.catalogData?.imageURL}
           height={'100%'}
           width={'100%'}
           zoomEffect={true}
@@ -103,7 +103,7 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
         <TechnologySection
           technologySVGPath={technologySVGPath}
           technologySVGSubpath={technologySVGSubpath}
-          technologies={details.catalog_data?.compatibility || []}
+          technologies={details.catalogData?.compatibility || []}
         />
       )}
       <LearningSection filteredAcademyData={filteredAcademyData} />

--- a/src/custom/CatalogDetail/OverviewSection.tsx
+++ b/src/custom/CatalogDetail/OverviewSection.tsx
@@ -82,10 +82,10 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
                 xs: 6
               }}
             >
-              {details?.catalog_data?.content_class && (
+              {details?.catalogData?.contentClass && (
                 <ContentRow>
                   <ContentClassInfo
-                    contentClass={details.catalog_data.content_class}
+                    contentClass={details.catalogData.contentClass}
                     classes={classes}
                   />
                 </ContentRow>
@@ -111,8 +111,8 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
           {showContentDetails ? (
             <ContentRow>
               <h2 style={{ margin: '0' }}>WHAT DOES THIS DESIGN DO?</h2>
-              {details?.catalog_data?.patternInfo ? (
-                <PatternInfo text={decodeURIComponent(details.catalog_data.patternInfo)} />
+              {details?.catalogData?.patternInfo ? (
+                <PatternInfo text={decodeURIComponent(details.catalogData.patternInfo)} />
               ) : (
                 <div>No description available</div>
               )}

--- a/src/custom/CatalogDetail/RelatedDesigns.tsx
+++ b/src/custom/CatalogDetail/RelatedDesigns.tsx
@@ -60,7 +60,7 @@ const RelatedDesigns: React.FC<RelatedDesignsProps> = ({
       cardTechnologies={true}
     >
       <CatalogCardDesignLogo
-        imgURL={pattern?.catalog_data?.imageURL}
+        imgURL={pattern?.catalogData?.imageURL}
         height={'5.5rem'}
         width={'100%'}
         zoomEffect={false}

--- a/src/custom/CustomCatalog/CustomCard.tsx
+++ b/src/custom/CustomCatalog/CustomCard.tsx
@@ -40,7 +40,7 @@ export const DesignCardUrl = styled('a')(() => ({
 export interface Pattern {
   id: string;
   userId: string;
-  pattern_file: string;
+  patternFile: string;
   user: {
     firstName: string;
     lastName: string;
@@ -61,11 +61,11 @@ export interface Pattern {
     technologies?: string[];
     updatedAt?: string;
   };
-  catalog_data?: {
-    content_class?: string;
+  catalogData?: {
+    contentClass?: string;
     imageURL?: string[];
     compatibility?: string[];
-    published_version?: string;
+    publishedVersion?: string;
     type?: string;
     patternInfo?: string;
     patternCaveats?: string;
@@ -135,7 +135,7 @@ const CustomCatalogCard: React.FC<CatalogCardProps> = ({
   };
   const theme = useTheme();
 
-  const technologies = pattern.catalog_data?.compatibility || [];
+  const technologies = pattern.catalogData?.compatibility || [];
   const techlimit = 5;
   const [availableTechnologies, setAvailableTechnologies] = useState<string[]>([]);
   const version = getVersion(pattern);
@@ -172,9 +172,9 @@ const CustomCatalogCard: React.FC<CatalogCardProps> = ({
         <CardFront shouldFlip={shouldFlip} isDetailed={isDetailed}>
           {isDetailed && (
             <>
-              <ClassWrap catalogClassName={pattern?.catalog_data?.content_class ?? ''} />
+              <ClassWrap catalogClassName={pattern?.catalogData?.contentClass ?? ''} />
               <DesignType>{patternType}</DesignType>
-              <DesignName hasRibbon={!!pattern?.catalog_data?.content_class}>
+              <DesignName hasRibbon={!!pattern?.catalogData?.contentClass}>
                 {pattern.name}
               </DesignName>
             </>

--- a/src/custom/CustomCatalog/Helper.ts
+++ b/src/custom/CustomCatalog/Helper.ts
@@ -79,11 +79,11 @@ export const DEFAULT_DESIGN_VERSION = '0.0.0';
 export const getVersion = (design: Pattern) => {
   switch (design.visibility) {
     case 'published':
-      return design?.catalog_data?.published_version || DEFAULT_DESIGN_VERSION;
+      return design?.catalogData?.publishedVersion || DEFAULT_DESIGN_VERSION;
     case 'public':
     case 'private':
-      return getWorkingVersionFromPatternFile(design.pattern_file);
+      return getWorkingVersionFromPatternFile(design.patternFile);
     default:
-      return getWorkingVersionFromPatternFile(design.pattern_file);
+      return getWorkingVersionFromPatternFile(design.patternFile);
   }
 };

--- a/src/custom/DashboardWidgets/GettingStartedWidget/InviteUserModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/InviteUserModal.tsx
@@ -131,15 +131,15 @@ export default function UserInviteModal({
       const organizationRoles: string[] = [];
 
       if (providerRolesData) {
-        providerRolesData?.roles?.forEach((role: { role_name: string }) =>
-          providerRoles.push(role?.role_name)
+        providerRolesData?.roles?.forEach((role: { roleName: string }) =>
+          providerRoles.push(role?.roleName)
         );
         setAvailableProviderRoles(providerRoles);
       }
 
       if (organizationRolesData) {
-        organizationRolesData?.roles?.forEach((role: { role_name: string }) =>
-          organizationRoles.push(role?.role_name)
+        organizationRolesData?.roles?.forEach((role: { roleName: string }) =>
+          organizationRoles.push(role?.roleName)
         );
         setAvailableOrgRoles(organizationRoles);
       }

--- a/src/custom/PerformersSection/PerformersSection.tsx
+++ b/src/custom/PerformersSection/PerformersSection.tsx
@@ -216,7 +216,7 @@ const processQueryData = (
     pattern: pattern,
     userName: pattern.user?.firstName || 'Unknown',
     id: config.id,
-    status: pattern?.catalog_data?.content_class
+    status: pattern?.catalogData?.contentClass
   };
 };
 

--- a/src/custom/UsersTable/UsersTable.tsx
+++ b/src/custom/UsersTable/UsersTable.tsx
@@ -141,7 +141,7 @@ const UsersTable: React.FC<UsersTableProps> = ({
       roleNames: [...teamRoles, ...organizationRoles]
     };
   });
-  const count = userData?.total_count || 0;
+  const count = userData?.totalCount || 0;
 
   const handleRemoveFromTeam = (data: any[]) => async () => {
     const userId = data[0];

--- a/src/custom/Workspaces/DesignTable.tsx
+++ b/src/custom/Workspaces/DesignTable.tsx
@@ -183,7 +183,7 @@ const DesignTable: React.FC<DesignTableProps> = ({
   useEffect(() => {
     const fetchSchema = async () => {
       const modelNames = _.uniq(
-        meshModelModelsData?.models?.map((model: any) => model.display_name)
+        meshModelModelsData?.models?.map((model: any) => model.displayName)
       );
       const modifiedSchema = _.set(
         _.cloneDeep(publishCatalogItemSchema),
@@ -250,7 +250,7 @@ const DesignTable: React.FC<DesignTableProps> = ({
       {tableHeaderContent}
       <CatalogDesignsTable
         patterns={designsOfWorkspace?.designs || []}
-        totalCount={designsOfWorkspace?.total_count}
+        totalCount={designsOfWorkspace?.totalCount}
         sortOrder={sortOrder}
         setSortOrder={setSortOrder}
         pageSize={pageSize}

--- a/src/custom/Workspaces/EnvironmentTable.tsx
+++ b/src/custom/Workspaces/EnvironmentTable.tsx
@@ -201,7 +201,7 @@ const EnvironmentTable: React.FC<EnvironmentTableProps> = ({
     filter: false,
     responsive: 'standard',
     selectableRows: 'none',
-    count: environmentsOfWorkspace?.total_count,
+    count: environmentsOfWorkspace?.totalCount,
     rowsPerPage: pageSize,
     page,
     elevation: 0,
@@ -311,7 +311,7 @@ const EnvironmentTable: React.FC<EnvironmentTableProps> = ({
         handleAssignablePage={environmentAssignment.handleAssignablePage}
         handleAssignedPage={environmentAssignment.handleAssignedPage}
         originalLeftCount={environmentAssignment.data?.length || 0}
-        originalRightCount={environmentsOfWorkspace?.total_count || 0}
+        originalRightCount={environmentsOfWorkspace?.totalCount || 0}
         onAssign={environmentAssignment.handleAssign}
         disableTransfer={environmentAssignment.disableTransferButton}
         helpText={`Assign Environments to ${workspaceName}`}

--- a/src/custom/Workspaces/WorkspaceRecentActivityModal.tsx
+++ b/src/custom/Workspaces/WorkspaceRecentActivityModal.tsx
@@ -29,7 +29,7 @@ interface EventData {
 interface EventsResponse {
   data: EventData[];
   page: number;
-  total_count: number;
+  totalCount: number;
 }
 
 interface RecentActivityModalProps {
@@ -88,7 +88,7 @@ const WorkspaceRecentActivityModal: React.FC<RecentActivityModalProps> = ({
       }
 
       // Check if we've loaded all events
-      setHasMore((eventsData.page + 1) * _pageSize < eventsData.total_count);
+      setHasMore((eventsData.page + 1) * _pageSize < eventsData.totalCount);
     }
   }, [eventsData, page, _pageSize]);
 

--- a/src/custom/Workspaces/WorkspaceTeamsTable.tsx
+++ b/src/custom/Workspaces/WorkspaceTeamsTable.tsx
@@ -79,7 +79,7 @@ const TeamsTable: React.FC<TeamsTableProps> = ({
 
   const tableProps = TeamTableConfiguration({
     teams: teamsOfWorkspace?.teams,
-    count: teamsOfWorkspace?.total_count,
+    count: teamsOfWorkspace?.totalCount,
     page,
     pageSize,
     setPage,
@@ -177,7 +177,7 @@ const TeamsTable: React.FC<TeamsTableProps> = ({
         handleAssignablePage={teamAssignment.handleAssignablePage}
         handleAssignedPage={teamAssignment.handleAssignedPage}
         originalLeftCount={teamAssignment.data?.length || 0}
-        originalRightCount={teamsOfWorkspace?.total_count || 0}
+        originalRightCount={teamsOfWorkspace?.totalCount || 0}
         onAssign={teamAssignment.handleAssign}
         disableTransfer={teamAssignment.disableTransferButton}
         helpText={`Assign Teams to ${workspaceName}`}

--- a/src/custom/Workspaces/WorkspaceViewsTable.tsx
+++ b/src/custom/Workspaces/WorkspaceViewsTable.tsx
@@ -292,7 +292,7 @@ const WorkspaceViewsTable: React.FC<ViewsTableProps> = ({
     filter: false,
     responsive: 'standard',
     selectableRows: 'none',
-    count: viewsOfWorkspace?.total_count,
+    count: viewsOfWorkspace?.totalCount,
     rowsPerPage: pageSize,
     serverSide: true,
     page,
@@ -393,7 +393,7 @@ const WorkspaceViewsTable: React.FC<ViewsTableProps> = ({
         handleAssignablePage={viewAssignment.handleAssignablePage}
         handleAssignedPage={viewAssignment.handleAssignedPage}
         originalLeftCount={viewAssignment.data?.length || 0}
-        originalRightCount={viewsOfWorkspace?.total_count || 0}
+        originalRightCount={viewsOfWorkspace?.totalCount || 0}
         onAssign={viewAssignment.handleAssign}
         disableTransfer={viewAssignment.disableTransferButton}
         helpText={`Assign Views to ${workspaceName}`}

--- a/src/custom/Workspaces/hooks/useDesignAssignment.tsx
+++ b/src/custom/Workspaces/hooks/useDesignAssignment.tsx
@@ -83,14 +83,14 @@ const useDesignAssignment = ({
   };
 
   const handleAssignablePageDesign = (): void => {
-    const pagesCount = Math.ceil(Number(designs?.total_count) / designsPageSize);
+    const pagesCount = Math.ceil(Number(designs?.totalCount) / designsPageSize);
     if (designsPage < pagesCount - 1) {
       setDesignsPage((prevDesignsPage) => prevDesignsPage + 1);
     }
   };
 
   const handleAssignedPageDesign = (): void => {
-    const pagesCount = Math.ceil(Number(designsOfWorkspace?.total_count) / designsPageSize);
+    const pagesCount = Math.ceil(Number(designsOfWorkspace?.totalCount) / designsPageSize);
     if (designsOfWorkspacePage < pagesCount - 1) {
       setDesignsOfWorkspacePage((prevPage) => prevPage + 1);
     }

--- a/src/custom/Workspaces/hooks/useEnvironmentAssignment.tsx
+++ b/src/custom/Workspaces/hooks/useEnvironmentAssignment.tsx
@@ -79,7 +79,7 @@ const useEnvironmentAssignment = ({
   };
 
   const handleAssignablePageEnvironment = () => {
-    const pagesCount = Math.ceil(Number(environments?.total_count) / environmentsPageSize);
+    const pagesCount = Math.ceil(Number(environments?.totalCount) / environmentsPageSize);
     if (environmentsPage < pagesCount - 1) {
       setEnvironmentsPage((prevEnvironmentsPage) => prevEnvironmentsPage + 1);
     }
@@ -87,7 +87,7 @@ const useEnvironmentAssignment = ({
 
   const handleAssignedPageEnvironment = () => {
     const pagesCount = Math.ceil(
-      Number(environmentsOfWorkspace?.total_count) / environmentsPageSize
+      Number(environmentsOfWorkspace?.totalCount) / environmentsPageSize
     );
     if (environmentsOfWorkspacePage < pagesCount - 1) {
       setEnvironmentsOfWorkspacePage((prevPage) => prevPage + 1);

--- a/src/custom/Workspaces/hooks/useTeamAssignment.tsx
+++ b/src/custom/Workspaces/hooks/useTeamAssignment.tsx
@@ -76,14 +76,14 @@ const useTeamAssignment = ({
   };
 
   const handleAssignablePageTeam = () => {
-    const pagesCount = Math.ceil(Number(teams?.total_count) / teamsPageSize);
+    const pagesCount = Math.ceil(Number(teams?.totalCount) / teamsPageSize);
     if (teamsPage < pagesCount - 1) {
       setTeamsPage((prevTeamsPage) => prevTeamsPage + 1);
     }
   };
 
   const handleAssignedPageTeam = () => {
-    const pagesCount = Math.ceil(Number(teamsOfWorkspace?.total_count) / teamsPageSize);
+    const pagesCount = Math.ceil(Number(teamsOfWorkspace?.totalCount) / teamsPageSize);
 
     if (teamsOfWorkspacePage < pagesCount - 1) {
       setTeamsOfWorkspacePage((prevPage) => prevPage + 1);

--- a/src/custom/Workspaces/hooks/useViewsAssignment.tsx
+++ b/src/custom/Workspaces/hooks/useViewsAssignment.tsx
@@ -87,14 +87,14 @@ const useViewAssignment = ({
   };
 
   const handleAssignablePageview = (): void => {
-    const pagesCount = Math.ceil(Number(views?.total_count) / viewsPageSize);
+    const pagesCount = Math.ceil(Number(views?.totalCount) / viewsPageSize);
     if (viewsPage < pagesCount - 1) {
       setviewsPage((prevviewsPage) => prevviewsPage + 1);
     }
   };
 
   const handleAssignedPageview = (): void => {
-    const pagesCount = Math.ceil(Number(viewsOfWorkspace?.total_count) / viewsPageSize);
+    const pagesCount = Math.ceil(Number(viewsOfWorkspace?.totalCount) / viewsPageSize);
     if (viewsOfWorkspacePage < pagesCount - 1) {
       setviewsOfWorkspacePage((prevPage) => prevPage + 1);
     }


### PR DESCRIPTION
## Summary

Sistent components consume meshery / meshery-cloud wire payloads. Per the ecosystem identifier-naming contract (`TypeScript property: camelCase` everywhere, see [`meshery/schemas` `docs/identifier-naming-contributor-guide.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md)), consumer reads must match the canonical camelCase wire keys that meshery-cloud emits post Phase 4. This change is a surgical field-rename sweep — no behavioural or structural changes.

This is the sistent half of Phase 7c.

## Flipped (45 sites across 20 files)

**Catalog / design wire** (`Pattern`, `MesheryPattern`, `CatalogContent`):
- `catalog_data` → `catalogData`
- `content_class` → `contentClass`
- `published_version` → `publishedVersion`
- `pattern_file` → `patternFile`

**Pagination wire** (`MesheryViewPage` / `TeamsPage` / `EnvironmentsPage` / `DesignsPage` / `UsersPage` / `EventsPage`):
- `total_count` → `totalCount`

**Role wire** (`Role`):
- `role_name` → `roleName` — response read in `InviteUserModal` only. The `order: 'role_name asc'` request parameter is left as-is until the cloud server adds dual-accept on the sort key.

**Component / model wire** (`Component`):
- `display_name` → `displayName`

### Files changed

- `src/custom/CustomCatalog/CustomCard.tsx` — `Pattern` interface and reads
- `src/custom/CustomCatalog/Helper.ts` — `getVersion()` reads
- `src/custom/CatalogDetail/OverviewSection.tsx`
- `src/custom/CatalogDetail/RelatedDesigns.tsx`
- `src/custom/CatalogDetail/LeftPanel.tsx`
- `src/custom/CatalogDetail/CaveatsSection.tsx`
- `src/custom/CatalogDetail/ActionButton.tsx`
- `src/custom/CatalogCard/CatalogCard.tsx`
- `src/custom/PerformersSection/PerformersSection.tsx`
- `src/custom/Workspaces/WorkspaceTeamsTable.tsx`
- `src/custom/Workspaces/WorkspaceViewsTable.tsx`
- `src/custom/Workspaces/EnvironmentTable.tsx`
- `src/custom/Workspaces/WorkspaceRecentActivityModal.tsx` — also flipped local `EventsResponse` type
- `src/custom/Workspaces/DesignTable.tsx`
- `src/custom/Workspaces/hooks/useDesignAssignment.tsx`
- `src/custom/Workspaces/hooks/useEnvironmentAssignment.tsx`
- `src/custom/Workspaces/hooks/useTeamAssignment.tsx`
- `src/custom/Workspaces/hooks/useViewsAssignment.tsx`
- `src/custom/UsersTable/UsersTable.tsx` — `totalCount` only
- `src/custom/DashboardWidgets/GettingStartedWidget/InviteUserModal.tsx`

## Intentionally retained as sistent-internal contract (not meshery wire)

- `src/hooks/useRoomActivity.ts` — `provider_url`, `data.user_map` are sistent's collaboration WebSocket signaling protocol identifiers, not meshery wire fields. The signaling server (meshery-cloud collaboration endpoint) speaks this protocol with sistent and is independent of the REST API wire-format contract.
- `src/custom/CollaboratorAvatarGroup/CollaboratorAvatarGroup.tsx` — `User.border_color` is part of sistent's exported `Users` prop shape (the sistent API surface that consumers pass in). Flipping this would be a public API break, not a wire-format alignment.

## Already retained-as-deferred per prior phases (no change in this PR)

- `src/custom/UsersTable/UsersTable.tsx` — `fullUser.organization_with_user_roles?.role_names` deferred until the containing response type is migrated upstream (existing inline TODO).
- `src/custom/TeamTable/TeamTableConfiguration.tsx` — `team_names` / `team_name` deferred until meshery-cloud bulk-delete handler lands dual-accept on the request body (existing decision from PR #1431 / cascade-10).

## Test plan

- [x] `npx tsc --noEmit` — no new errors vs baseline of 105 pre-existing errors (all unrelated: missing `@types/jest`, `@types/node`, `@types/js-yaml`, `@sistent/mui-datatables` declaration, etc.).
- [x] `npm run lint` — clean.
- [x] `npm test` — 21/21 tests passing across 7 suites.
- [x] `npm run build` — `tsup` build succeeds (CJS + ESM + DTS).
- [x] Final grep sweep confirms no remaining snake_case wire-format reads in scope. The four retained reads (`useRoomActivity` user_map, `CollaboratorAvatarGroup` border_color, `UsersTable` organization_with_user_roles.role_names, `TeamTableConfiguration` team_names/team_name) are documented above with rationale.

## Refs

- [`meshery/schemas` `docs/identifier-naming-contributor-guide.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) — the 26-row canonical naming directory
- Phase 2.K cascade (#1435) — prior wire-format alignment in sistent