### PR TITLE
[Feature] Add ReplyIcon

### DIFF
--- a/src/__testing__/ReplyIcon.test.tsx
+++ b/src/__testing__/ReplyIcon.test.tsx
@@ -6,10 +6,17 @@ describe('ReplyIcon', () => {
     render(<ReplyIcon width={24} height={24} />);
   });
 
-  it('applies width and height', () => {
-    const { getByTestId } = render(<ReplyIcon width={24} height={24} />);
+  it('uses default width and height', () => {
+    const { getByTestId } = render(<ReplyIcon />);
     const svgElement = getByTestId('reply-icon-svg');
     expect(svgElement.getAttribute('width')).toBe('24');
     expect(svgElement.getAttribute('height')).toBe('24');
+  });
+
+  it('applies custom width and height', () => {
+    const { getByTestId } = render(<ReplyIcon width={32} height={32} />);
+    const svgElement = getByTestId('reply-icon-svg');
+    expect(svgElement.getAttribute('width')).toBe('32');
+    expect(svgElement.getAttribute('height')).toBe('32');
   });
 });

--- a/src/__testing__/ReplyIcon.test.tsx
+++ b/src/__testing__/ReplyIcon.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { ReplyIcon } from '../icons';
+
+describe('ReplyIcon', () => {
+  it('renders without errors', () => {
+    render(<ReplyIcon width={24} height={24} />);
+  });
+
+  it('applies width and height', () => {
+    const { getByTestId } = render(<ReplyIcon width={24} height={24} />);
+    const svgElement = getByTestId('reply-icon-svg');
+    expect(svgElement.getAttribute('width')).toBe('24');
+    expect(svgElement.getAttribute('height')).toBe('24');
+  });
+});

--- a/src/icons/Reply/ReplyIcon.tsx
+++ b/src/icons/Reply/ReplyIcon.tsx
@@ -5,6 +5,7 @@ export const ReplyIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   fill = DEFAULT_FILL_NONE,
+  title,
   ...props
 }: IconProps): JSX.Element => {
   return (
@@ -16,6 +17,7 @@ export const ReplyIcon = ({
       data-testid="reply-icon-svg"
       {...props}
     >
+      {title && <title>{title}</title>}
       <path
         d="M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-10z"
         fill={fill}

--- a/src/icons/Reply/ReplyIcon.tsx
+++ b/src/icons/Reply/ReplyIcon.tsx
@@ -1,0 +1,27 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, DEFAULT_FILL_NONE } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const ReplyIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  fill = DEFAULT_FILL_NONE,
+  ...props
+}: IconProps): JSX.Element => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      data-testid="reply-icon-svg"
+      {...props}
+    >
+      <path
+        d="M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-10z"
+        fill={fill}
+      />
+    </svg>
+  );
+};
+
+export default ReplyIcon;

--- a/src/icons/Reply/index.ts
+++ b/src/icons/Reply/index.ts
@@ -1,0 +1,1 @@
+export { default as ReplyIcon } from './ReplyIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -136,6 +136,7 @@ export * from './Rectangle';
 export * from './Redo';
 export * from './Refresh';
 export * from './Remove';
+export * from './Reply';
 export * from './Reset';
 export * from './Resize';
 export * from './Response';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1447

Adds a new `ReplyIcon` SVG component to the Sistent icon library. This icon represents a reply action and is based on the Material UI `Reply` icon design. The addition reduces dependency on `@mui/icons-material` and ensures design consistency across Layer5 products.

**Changes made:**
- `src/icons/Reply/ReplyIcon.tsx` — New `ReplyIcon` SVG component using `DEFAULT_FILL_NONE`, `DEFAULT_WIDTH`, and `DEFAULT_HEIGHT` constants
- `src/icons/Reply/index.ts` — Barrel export for the Reply icon directory
- `src/icons/index.ts` — Registered `ReplyIcon` in the icon library's main exports
- `src/__testing__/ReplyIcon.test.tsx` — Unit tests verifying render and dimension props

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.