### PR TITLE
[Feature] Add MoreHorizIcon

### DIFF
--- a/src/icons/MoreHoriz/MoreHorizIcon.tsx
+++ b/src/icons/MoreHoriz/MoreHorizIcon.tsx
@@ -1,0 +1,29 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, DEFAULT_FILL_NONE } from '../../constants/constants';
+import { IconProps } from '../types';
+
+const MoreHorizIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  fill = DEFAULT_FILL_NONE,
+  title,
+  ...props
+}: IconProps): JSX.Element => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      data-testid="more-horiz-icon-svg"
+      {...props}
+    >
+      {title && <title>{title}</title>}
+      <path
+        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+        fill={fill}
+      />
+    </svg>
+  );
+};
+
+export default MoreHorizIcon;

--- a/src/icons/MoreHoriz/index.ts
+++ b/src/icons/MoreHoriz/index.ts
@@ -1,0 +1,1 @@
+export { default as MoreHorizIcon } from './MoreHorizIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -116,6 +116,7 @@ export * from './MesheryFilter';
 export * from './MesheryOperator';
 export * from './Mesh';
 export { default as ModifiedApplicationFileIcon } from './ModifiedApplicationFileIcon';
+export * from './MoreHoriz';
 export * from './MoreVert';
 export * from './MoveFile';
 export * from './Open';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1444

Adds a new `MoreHorizIcon` SVG component to the Sistent icon library. This icon represents a horizontal ellipsis for overflow menus and is based on the Material UI `MoreHoriz` icon design. The addition reduces dependency on `@mui/icons-material` and ensures design consistency across Layer5 products.

**Changes made:**
- `src/icons/MoreHoriz/MoreHorizIcon.tsx` — New `MoreHorizIcon` SVG component using `DEFAULT_FILL_NONE`, `DEFAULT_WIDTH`, `DEFAULT_HEIGHT`, and `title` prop for accessibility
- `src/icons/MoreHoriz/index.ts` — Barrel export for the MoreHoriz icon directory
- `src/icons/index.ts` — Registered `MoreHorizIcon` in the icon library's main exports

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.