### PR TITLE
fix(importModel): force file widget on conditional file field

### DIFF
--- a/src/schemas/importModel/uiSchema.tsx
+++ b/src/schemas/importModel/uiSchema.tsx
@@ -2,6 +2,17 @@ const importModelUiSchema = {
   uploadType: {
     'ui:widget': 'radio'
   },
+  // The conditional `file` property in importModelSchema sources its `format`
+  // from @meshery/schemas' ImportBody.oneOf[0].properties.modelFile, which
+  // declares `type: string` with no format. Without an explicit widget,
+  // RJSF falls back to TextWidget — leaving the form without a real
+  // <input type="file"> element, which breaks the File Import flow and the
+  // Playwright test that drives it. Forcing 'ui:widget': 'file' here routes
+  // the field through whichever FileWidget the consumer registers (e.g.,
+  // Meshery's CustomFileWidget) and emits the expected file input.
+  file: {
+    'ui:widget': 'file'
+  },
   'ui:order': ['uploadType', 'file', 'url', 'csv']
 };
 


### PR DESCRIPTION
## Summary

The conditional `File Import` branch in [`importModelSchema`](src/schemas/importModel/schema.tsx) reads its `format` from the upstream `@meshery/schemas` `ImportBody.oneOf[0].properties.modelFile` definition, which declares `type: string` with no `format`. RJSF's default widget resolution therefore falls back to `TextWidget`, so the rendered form never contains a real `<input type="file">` element.

Consumers (notably Meshery, where this surfaced as the broken "Import a Model via File Import" Playwright test — see [meshery#19072](https://github.com/meshery/meshery/pull/19072)) had to override the uiSchema downstream to force the widget. This PR moves that override upstream so the schema/uiSchema pair ships in a usable state.

## Changes

- `src/schemas/importModel/uiSchema.tsx` — declare `file: { 'ui:widget': 'file' }`. Consumers register their own FileWidget implementation against the `file` name (e.g. Meshery's `CustomFileWidget`); this commit just guarantees the widget is selected when the form is rendered.

## Test plan

- [x] `npm test` — all 9 suites pass locally.
- [ ] Once merged + released, drop the downstream `uiSchema.file` override in [meshery#19072](https://github.com/meshery/meshery/pull/19072) and confirm the Playwright e2e suite passes against the upstream uiSchema alone.

## Notes for reviewers

- No change to `importModelSchema` (the JSON schema). The OpenAPI `format: "binary"` convention isn't what RJSF resolves on; using `ui:widget` is the cleaner separation between data shape and UI widget.
- `'ui:order': ['uploadType', 'file', 'url', 'csv']` already lists `file` so this is purely additive — no consumer who currently sets their own `file` widget needs to migrate.