### PR TITLE
fix: align catalog filter checkbox labels

### DIFF
--- a/src/__testing__/CatalogFilterSection.test.tsx
+++ b/src/__testing__/CatalogFilterSection.test.tsx
@@ -50,11 +50,19 @@ describe('CatalogFilterSection', () => {
     const label = screen.getByText('Learning Path');
     const labelGroup = label.parentElement;
     const optionRow = labelGroup?.parentElement;
+    const metadataGroup = optionRow?.lastElementChild as HTMLElement | null;
 
     expect(labelGroup?.getAttribute('alignitems')).toBeNull();
     expect(labelGroup?.getAttribute('gap')).toBeNull();
     expect(optionRow?.getAttribute('alignitems')).toBeNull();
     expect(optionRow?.getAttribute('justifycontent')).toBeNull();
     expect(optionRow?.getAttribute('px')).toBeNull();
+    expect(metadataGroup?.getAttribute('alignitems')).toBeNull();
+    expect(metadataGroup?.getAttribute('gap')).toBeNull();
+
+    expect(window.getComputedStyle(labelGroup as Element).alignItems).toBe('center');
+    expect(window.getComputedStyle(optionRow as Element).alignItems).toBe('center');
+    expect(window.getComputedStyle(optionRow as Element).justifyContent).toBe('space-between');
+    expect(window.getComputedStyle(metadataGroup as Element).alignItems).toBe('center');
   });
 });

--- a/src/__testing__/CatalogFilterSection.test.tsx
+++ b/src/__testing__/CatalogFilterSection.test.tsx
@@ -18,13 +18,15 @@ jest.mock('rehype-raw', () => ({
   default: () => {}
 }));
 
+const LEAKED_LAYOUT_ATTR_SELECTOR = '[alignitems],[justifycontent],[gap],[px]';
+
 const renderWithTheme = (ui: React.ReactElement) => {
   return render(<SistentThemeProvider>{ui}</SistentThemeProvider>);
 };
 
 describe('CatalogFilterSection', () => {
   it('applies option row layout via sx instead of leaking raw DOM attributes', () => {
-    renderWithTheme(
+    const { container } = renderWithTheme(
       <FilterSection
         filterKey="contentType"
         sectionDisplayName="Content Type"
@@ -52,13 +54,7 @@ describe('CatalogFilterSection', () => {
     const optionRow = labelGroup?.parentElement;
     const metadataGroup = optionRow?.lastElementChild as HTMLElement | null;
 
-    expect(labelGroup?.getAttribute('alignitems')).toBeNull();
-    expect(labelGroup?.getAttribute('gap')).toBeNull();
-    expect(optionRow?.getAttribute('alignitems')).toBeNull();
-    expect(optionRow?.getAttribute('justifycontent')).toBeNull();
-    expect(optionRow?.getAttribute('px')).toBeNull();
-    expect(metadataGroup?.getAttribute('alignitems')).toBeNull();
-    expect(metadataGroup?.getAttribute('gap')).toBeNull();
+    expect(container.querySelector(LEAKED_LAYOUT_ATTR_SELECTOR)).toBeNull();
 
     expect(window.getComputedStyle(labelGroup as Element).alignItems).toBe('center');
     expect(window.getComputedStyle(optionRow as Element).alignItems).toBe('center');

--- a/src/__testing__/CatalogFilterSection.test.tsx
+++ b/src/__testing__/CatalogFilterSection.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FilterSection from '../custom/CatalogFilterSection/FilterSection';
+import { SistentThemeProvider } from '../theme';
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}));
+
+jest.mock('remark-gfm', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+jest.mock('rehype-raw', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<SistentThemeProvider>{ui}</SistentThemeProvider>);
+};
+
+describe('CatalogFilterSection', () => {
+  it('applies option row layout via sx instead of leaking raw DOM attributes', () => {
+    renderWithTheme(
+      <FilterSection
+        filterKey="contentType"
+        sectionDisplayName="Content Type"
+        options={[
+          {
+            value: 'learning-path',
+            label: 'Learning Path',
+            totalCount: 7
+          }
+        ]}
+        filters={{ contentType: [] }}
+        openSections={{ contentType: true }}
+        onCheckboxChange={jest.fn()}
+        onSectionToggle={jest.fn()}
+        styleProps={{
+          backgroundColor: '#fff',
+          sectionTitleBackgroundColor: '#eee',
+          fontFamily: 'Arial'
+        }}
+      />
+    );
+
+    const label = screen.getByText('Learning Path');
+    const labelGroup = label.parentElement;
+    const optionRow = labelGroup?.parentElement;
+
+    expect(labelGroup?.getAttribute('alignitems')).toBeNull();
+    expect(labelGroup?.getAttribute('gap')).toBeNull();
+    expect(optionRow?.getAttribute('alignitems')).toBeNull();
+    expect(optionRow?.getAttribute('justifycontent')).toBeNull();
+    expect(optionRow?.getAttribute('px')).toBeNull();
+  });
+});

--- a/src/custom/CatalogFilterSection/FilterSection.tsx
+++ b/src/custom/CatalogFilterSection/FilterSection.tsx
@@ -109,11 +109,19 @@ const FilterSection: React.FC<FilterSectionProps> = ({
               <Stack
                 key={`${option.value}-${index}`}
                 direction="row"
-                alignItems="center"
-                px={'0.5rem'}
-                justifyContent="space-between"
+                sx={{
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  px: '0.5rem'
+                }}
               >
-                <Stack direction="row" alignItems="center" gap="0.35rem">
+                <Stack
+                  direction="row"
+                  sx={{
+                    alignItems: 'center',
+                    gap: '0.35rem'
+                  }}
+                >
                   <Checkbox
                     id={`checkbox-${option.label}`}
                     checked={
@@ -132,7 +140,13 @@ const FilterSection: React.FC<FilterSectionProps> = ({
 
                   <Typography fontFamily={styleProps.fontFamily}>{option.label}</Typography>
                 </Stack>
-                <Stack direction="row" alignItems="center" gap="0.35rem">
+                <Stack
+                  direction="row"
+                  sx={{
+                    alignItems: 'center',
+                    gap: '0.35rem'
+                  }}
+                >
                   {option.totalCount !== undefined && `(${option.totalCount || 0})`}
                   {option.description && (
                     <InfoTooltip variant="standard" helpText={option.description} />

--- a/src/custom/CatalogFilterSection/FilterSection.tsx
+++ b/src/custom/CatalogFilterSection/FilterSection.tsx
@@ -19,6 +19,17 @@ interface FilterSectionProps {
   customComponent?: React.ComponentType;
 }
 
+const optionRowSx = {
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  px: '0.5rem'
+} as const;
+
+const optionGroupSx = {
+  alignItems: 'center',
+  gap: '0.35rem'
+} as const;
+
 /**
  * @component FilterSection
  * @description A functional component that renders a filter section.
@@ -106,22 +117,8 @@ const FilterSection: React.FC<FilterSectionProps> = ({
               </Box>
             )}
             {searchedOptions.map((option, index) => (
-              <Stack
-                key={`${option.value}-${index}`}
-                direction="row"
-                sx={{
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  px: '0.5rem'
-                }}
-              >
-                <Stack
-                  direction="row"
-                  sx={{
-                    alignItems: 'center',
-                    gap: '0.35rem'
-                  }}
-                >
+              <Stack key={`${option.value}-${index}`} direction="row" sx={optionRowSx}>
+                <Stack direction="row" sx={optionGroupSx}>
                   <Checkbox
                     id={`checkbox-${option.label}`}
                     checked={
@@ -140,13 +137,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
 
                   <Typography fontFamily={styleProps.fontFamily}>{option.label}</Typography>
                 </Stack>
-                <Stack
-                  direction="row"
-                  sx={{
-                    alignItems: 'center',
-                    gap: '0.35rem'
-                  }}
-                >
+                <Stack direction="row" sx={optionGroupSx}>
                   {option.totalCount !== undefined && `(${option.totalCount || 0})`}
                   {option.description && (
                     <InfoTooltip variant="standard" helpText={option.description} />


### PR DESCRIPTION
## Summary
- move `Stack` layout props in `CatalogFilterSection` from raw props to `sx` so they render as CSS instead of leaking into the DOM
- restore vertical centering between filter checkboxes and labels across consumers of `CatalogFilterSidebar`
- add a regression test that fails if raw layout attributes like `alignitems`, `justifycontent`, `gap`, or `px` reappear on the rendered DOM

## Test plan
- [x] `npx eslint src/custom/CatalogFilterSection/FilterSection.tsx src/__testing__/CatalogFilterSection.test.tsx`
- [x] `npx jest src/__testing__/CatalogFilterSection.test.tsx --runInBand`
- [x] `npm test`
- [x] `npm run build`