### PR TITLE
feat: flip 6 form schemas to canonical @meshery/schemas (#866 phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sistent/sistent",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "^1.2.7",
+        "@meshery/schemas": "^1.2.8",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3119,9 +3119,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.7.tgz",
-      "integrity": "sha512-thB6yJv2wYYSWo2bxvFTciW17tvMLemN6xikQYmfw+Wz7g8mBdg8c+5Sd4FCtDA42A/uwlPUbHxvnBiP7/aL5w==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.8.tgz",
+      "integrity": "sha512-RCO2qlQr8HY+qzt88GaoatqIEtpb0Qgo3t2GSQmuHN24tl8Itt9ObeGUzOjviE8HQ3FhptRcbQkGRwBrN1bSCQ==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Reusable React Components and SVG Icons library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "^1.2.7",
+    "@meshery/schemas": "^1.2.8",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",

--- a/src/schemas/createAndEditEnvironment/schema.tsx
+++ b/src/schemas/createAndEditEnvironment/schema.tsx
@@ -1,3 +1,11 @@
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `EnvironmentCreateOrEditRjsfSchemaV1Beta3` (canonical home:
+// `typescript/forms/v1beta3/environment/`), flip this file to:
+//
+//     export { EnvironmentCreateOrEditRjsfSchemaV1Beta3 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`createAndEditEnvironmentSchema`)
+// MUST stay the same; only the source flips.
 import EnvironmentDefinitionV1Beta3OpenApiSchema from '@meshery/schemas/constructs/v1beta3/environment/EnvironmentSchema';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/schemas/createAndEditEnvironment/schema.tsx
+++ b/src/schemas/createAndEditEnvironment/schema.tsx
@@ -1,42 +1,26 @@
-// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
-// `EnvironmentCreateOrEditRjsfSchemaV1Beta3` (canonical home:
-// `typescript/forms/v1beta3/environment/`), flip this file to:
-//
-//     export { EnvironmentCreateOrEditRjsfSchemaV1Beta3 as default } from '@meshery/schemas';
-//
-// The published Sistent export name (`createAndEditEnvironmentSchema`)
-// MUST stay the same; only the source flips.
-import EnvironmentDefinitionV1Beta3OpenApiSchema from '@meshery/schemas/constructs/v1beta3/environment/EnvironmentSchema';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const environmentSchema = (EnvironmentDefinitionV1Beta3OpenApiSchema as any).components.schemas;
-const createAndEditEnvironmentSchema = {
-  title: 'Environment',
-  required: ['name'],
-  properties: {
-    description: {
-      description: environmentSchema.EnvironmentPayload.properties.description.description,
-      format: 'textarea',
-      title: 'Description',
-      type: environmentSchema.EnvironmentPayload.properties.description.type,
-      'x-rjsf-grid-area': '12'
-    },
-    name: {
-      description: environmentSchema.EnvironmentPayload.properties.name.description,
-      title: 'Name',
-      type: environmentSchema.EnvironmentPayload.properties.name.type,
-      'x-rjsf-grid-area': '12'
-    },
-    organization: {
-      type: environmentSchema.EnvironmentPayload.properties.organizationId.type,
-      title: 'Organization',
-      description: environmentSchema.EnvironmentPayload.properties.organizationId.description,
-      enum: [],
-      enumNames: [],
-      'x-rjsf-grid-area': '12'
-    }
-  },
-  type: 'object'
-};
-
-export default createAndEditEnvironmentSchema;
+/**
+ * Schema for the create-or-edit environment modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at
+ * `schemas/constructs/v1beta3/environment/forms/createOrEdit.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Environment construct.
+ *
+ * Wire-level change: the field formerly keyed as `organization` is
+ * now keyed as `organizationId`, matching canonical
+ * `EnvironmentPayload.organizationId`. The Meshery server's
+ * Environment endpoint already accepts the canonical key per its
+ * OpenAPI; this brings the form payload into alignment.
+ *
+ * The published Sistent export name (`createAndEditEnvironmentSchema`)
+ * is unchanged — only the source of the schema has flipped. Consumers
+ * in `meshery` and `meshery-cloud` keep working without source-level
+ * changes; submission payloads now use `organizationId` for that
+ * field.
+ */
+export { EnvironmentCreateOrEditRjsfSchemaV1Beta3 as default } from '@meshery/schemas';

--- a/src/schemas/createAndEditEnvironment/uiSchema.tsx
+++ b/src/schemas/createAndEditEnvironment/uiSchema.tsx
@@ -1,8 +1,13 @@
-const createAndEditEnvironmentUiSchema = {
-  organization: {
-    'ui:disabled': false
-  },
-  'ui:order': ['organization', 'name', 'description']
-};
-
-export default createAndEditEnvironmentUiSchema;
+/**
+ * UI schema for the create-or-edit environment modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The published Sistent export name (`createAndEditEnvironmentUiSchema`)
+ * is unchanged. The canonical UI schema already keys
+ * `ui:disabled` and `ui:order` on the canonical field name
+ * `organizationId`.
+ */
+export { EnvironmentCreateOrEditRjsfUiSchemaV1Beta3 as default } from '@meshery/schemas';

--- a/src/schemas/createAndEditWorkspace/schema.tsx
+++ b/src/schemas/createAndEditWorkspace/schema.tsx
@@ -1,6 +1,20 @@
 /**
  * Schema for create or edit workspace modals
  */
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `WorkspaceCreateOrEditRjsfSchemaV1Beta3` (canonical home:
+// `typescript/forms/v1beta3/workspace/`), flip this file to:
+//
+//     export {
+//       WorkspaceCreateOrEditRjsfSchemaV1Beta3 as default,
+//       WorkspaceEditRjsfSchemaV1Beta3 as editWorkspace,
+//     } from '@meshery/schemas';
+//
+// The published Sistent export names (`createAndEditWorkspaceSchema`
+// and the named `editWorkspaceSchema`) MUST stay the same; only the
+// source flips. Coordinate with the schemas PR so the canonical
+// upstream ships BOTH the create-or-edit form and the relaxed
+// edit-only variant.
 import WorkspaceDefinitionV1Beta3OpenApiSchema from '@meshery/schemas/constructs/v1beta3/workspace/WorkspaceSchema';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/schemas/createAndEditWorkspace/schema.tsx
+++ b/src/schemas/createAndEditWorkspace/schema.tsx
@@ -1,63 +1,47 @@
 /**
- * Schema for create or edit workspace modals
+ * Schemas for the create-or-edit workspace modals.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at
+ * `schemas/constructs/v1beta3/workspace/forms/createOrEdit.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Workspace construct.
+ *
+ * Wire-level change: the field formerly keyed as `organization` is
+ * now keyed as `organizationId`, matching canonical
+ * `WorkspacePayload.organizationId`.
+ *
+ * Two exports are published:
+ *
+ *   - default (`createAndEditWorkspaceSchema`): the create-or-edit
+ *     form with `name` and `organizationId` required.
+ *   - named (`editWorkspaceSchema`): a relaxed variant where only
+ *     `organizationId` is required — used by the edit-only modal
+ *     where the existing workspace name is preserved if blank.
+ *
+ * The relaxed-`required` variant is derived locally from the
+ * canonical schema by spreading the canonical and overriding
+ * `required`. Once `@meshery/schemas` ships an
+ * `WorkspaceEditRjsfSchemaV1Beta3` (a relaxed-required canonical
+ * variant), this derivation can be deleted in favor of a direct
+ * re-export.
  */
-// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
-// `WorkspaceCreateOrEditRjsfSchemaV1Beta3` (canonical home:
-// `typescript/forms/v1beta3/workspace/`), flip this file to:
-//
-//     export {
-//       WorkspaceCreateOrEditRjsfSchemaV1Beta3 as default,
-//       WorkspaceEditRjsfSchemaV1Beta3 as editWorkspace,
-//     } from '@meshery/schemas';
-//
-// The published Sistent export names (`createAndEditWorkspaceSchema`
-// and the named `editWorkspaceSchema`) MUST stay the same; only the
-// source flips. Coordinate with the schemas PR so the canonical
-// upstream ships BOTH the create-or-edit form and the relaxed
-// edit-only variant.
-import WorkspaceDefinitionV1Beta3OpenApiSchema from '@meshery/schemas/constructs/v1beta3/workspace/WorkspaceSchema';
+import { WorkspaceCreateOrEditRjsfSchemaV1Beta3 } from '@meshery/schemas';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const workspaceSchema = (WorkspaceDefinitionV1Beta3OpenApiSchema as any).components.schemas;
-
-/**
- * Create workspace schema - name is required
- */
-const createAndEditWorkspace = {
-  properties: {
-    description: {
-      description: workspaceSchema.WorkspacePayload.properties.description.description,
-      format: 'textarea',
-      title: 'Description',
-      type: workspaceSchema.WorkspacePayload.properties.description.type,
-      'x-rjsf-grid-area': '12'
-    },
-    name: {
-      description: workspaceSchema.WorkspacePayload.properties.name.description,
-      title: 'Name',
-      type: workspaceSchema.WorkspacePayload.properties.name.type,
-      'x-rjsf-grid-area': '12'
-    },
-    organization: {
-      type: workspaceSchema.WorkspacePayload.properties.organizationId.type,
-      description: workspaceSchema.WorkspacePayload.properties.organizationId.description,
-      title: 'Organization',
-      enum: [],
-      enumNames: [],
-      'x-rjsf-grid-area': '12'
-    }
-  },
-  type: 'object',
-  required: ['name', 'organization']
+// `editWorkspace` is intentionally typed as a loose record so its
+// emitted `.d.ts` doesn't reference @meshery/schemas's internal
+// `RJSFSchema` type (declared but not currently re-exported by that
+// package — see the follow-up issue against meshery/schemas to add
+// `export type { RJSFSchema, UiSchema }` to the public surface).
+// Once that type is exportable, this annotation can be tightened.
+const editWorkspace: Record<string, unknown> = {
+  ...WorkspaceCreateOrEditRjsfSchemaV1Beta3,
+  required: ['organizationId']
 };
 
-/**
- * Edit workspace schema - name is optional (derived from WorkspacePayload with relaxed requirements)
- */
-const editWorkspace = {
-  ...createAndEditWorkspace,
-  required: ['organization']
-};
-
-export default createAndEditWorkspace;
+export default WorkspaceCreateOrEditRjsfSchemaV1Beta3;
 export { editWorkspace };

--- a/src/schemas/createAndEditWorkspace/uiSchema.tsx
+++ b/src/schemas/createAndEditWorkspace/uiSchema.tsx
@@ -1,9 +1,13 @@
-const createAndEditWorkspaceUiSchema = {
-  organization: {
-    'ui:disabled': false,
-    'ui:widget': 'select'
-  },
-  'ui:order': ['organization', 'name', 'description']
-};
-
-export default createAndEditWorkspaceUiSchema;
+/**
+ * UI schema for the create-or-edit workspace modals.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The published Sistent export name (`createAndEditWorkspaceUiSchema`)
+ * is unchanged. The canonical UI schema already keys
+ * `ui:disabled` / `ui:widget` and `ui:order` on the canonical
+ * field name `organizationId`.
+ */
+export { WorkspaceCreateOrEditRjsfUiSchemaV1Beta3 as default } from '@meshery/schemas';

--- a/src/schemas/grafanaCredential/schema.tsx
+++ b/src/schemas/grafanaCredential/schema.tsx
@@ -1,6 +1,14 @@
 /**
  * Schema for creating grafana credential;
  */
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `GrafanaCredentialRjsfSchemaV1Beta1` (canonical home:
+// `typescript/forms/v1beta1/credential/`), flip this file to:
+//
+//     export { GrafanaCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`grafanaCredentialSchema`) MUST
+// stay the same; only the source flips.
 const grafanaCredentialSchema = {
   type: 'object',
   title: 'Grafana',

--- a/src/schemas/grafanaCredential/schema.tsx
+++ b/src/schemas/grafanaCredential/schema.tsx
@@ -1,43 +1,22 @@
 /**
- * Schema for creating grafana credential;
+ * Schema for the Grafana credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at
+ * `schemas/constructs/v1beta1/credential/forms/grafana.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Credential construct
+ * (the grafana-specific shape lives inside the canonical free-form
+ * `secret` map).
+ *
+ * Wire-level change: the field formerly keyed as `credentialName` is
+ * now keyed as `name`, matching canonical `Credential.name`.
+ *
+ * The published Sistent export name (`grafanaCredentialSchema`)
+ * is unchanged.
  */
-// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
-// `GrafanaCredentialRjsfSchemaV1Beta1` (canonical home:
-// `typescript/forms/v1beta1/credential/`), flip this file to:
-//
-//     export { GrafanaCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
-//
-// The published Sistent export name (`grafanaCredentialSchema`) MUST
-// stay the same; only the source flips.
-const grafanaCredentialSchema = {
-  type: 'object',
-  title: 'Grafana',
-  properties: {
-    credentialName: {
-      title: 'Credential Name',
-      type: 'string',
-      description: 'Name of your credential'
-    },
-    secret: {
-      type: 'object',
-      title: 'Credential Secret',
-      description: 'Credential secret for the Grafana instance',
-      properties: {
-        grafanaURL: {
-          type: 'string',
-          title: 'URL',
-          description: 'URL of the Grafana instance'
-        },
-        grafanaAPIKey: {
-          type: 'string',
-          title: 'API Key',
-          description: 'API Key for the Grafana instance'
-        }
-      },
-      required: ['grafanaURL', 'grafanaAPIKey']
-    }
-  },
-  required: ['credentialName']
-};
-
-export default grafanaCredentialSchema;
+export { GrafanaCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/grafanaCredential/uiSchema.tsx
+++ b/src/schemas/grafanaCredential/uiSchema.tsx
@@ -1,3 +1,11 @@
-const grafanaCredentialUiSchema = {};
-
-export default grafanaCredentialUiSchema;
+/**
+ * UI schema for the Grafana credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The published Sistent export name (`grafanaCredentialUiSchema`)
+ * is unchanged.
+ */
+export { GrafanaCredentialRjsfUiSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/helmConnection/schema.tsx
+++ b/src/schemas/helmConnection/schema.tsx
@@ -2,6 +2,14 @@
  * Schema for configuring Helm repository connections. This schema is designed for use in a wizard or form
  * where users can provide information about connecting to a Helm repository for initiating connection.
  */
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `HelmConnectionRjsfSchemaV1Beta2` (canonical home:
+// `typescript/forms/v1beta2/connection/`), flip this file to:
+//
+//     export { HelmConnectionRjsfSchemaV1Beta2 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`helmConnectionSchema`) MUST
+// stay the same; only the source flips.
 const helmConnectionSchema = {
   type: 'object',
   properties: {

--- a/src/schemas/importDesign/schema.tsx
+++ b/src/schemas/importDesign/schema.tsx
@@ -1,3 +1,11 @@
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `DesignImportRjsfSchemaV1Beta3` (canonical home: `typescript/forms/v1beta3/design/`),
+// flip this file to:
+//
+//     export { DesignImportRjsfSchemaV1Beta3 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`importDesignSchema`) MUST stay
+// the same; only the source flips.
 import { DesignDefinitionV1Beta1OpenApiSchema } from '@meshery/schemas';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/schemas/importFilter/schema.tsx
+++ b/src/schemas/importFilter/schema.tsx
@@ -1,3 +1,12 @@
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `FilterImportRjsfSchemaV1Beta2` (canonical home: `typescript/forms/v1beta2/catalog/`
+// — filter is part of the catalog/design family per the form-schemas
+// roadmap), flip this file to:
+//
+//     export { FilterImportRjsfSchemaV1Beta2 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`importFilterSchema`) MUST stay
+// the same; only the source flips.
 const importFilterSchema = {
   type: 'object',
   properties: {

--- a/src/schemas/importModel/schema.tsx
+++ b/src/schemas/importModel/schema.tsx
@@ -1,3 +1,11 @@
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `ModelImportRjsfSchemaV1Beta2` (canonical home: `typescript/forms/v1beta2/model/`),
+// flip this file to:
+//
+//     export { ModelImportRjsfSchemaV1Beta2 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`importModelSchema`) MUST stay
+// the same; only the source flips.
 import ModelDefinitionV1Beta2OpenApiSchema from '@meshery/schemas/constructs/v1beta2/model/ModelSchema';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/schemas/kubernetesCredential/schema.tsx
+++ b/src/schemas/kubernetesCredential/schema.tsx
@@ -1,6 +1,14 @@
 /**
- * Schema for creating grafana credential;
+ * Schema for creating kubernetes credential.
  */
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `KubernetesCredentialRjsfSchemaV1Beta1` (canonical home:
+// `typescript/forms/v1beta1/credential/`), flip this file to:
+//
+//     export { KubernetesCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`kubernetesCredentialSchema`)
+// MUST stay the same; only the source flips.
 const kubernetesCredentialSchema = {
   type: 'object',
   title: 'Kubernetes',

--- a/src/schemas/kubernetesCredential/schema.tsx
+++ b/src/schemas/kubernetesCredential/schema.tsx
@@ -1,82 +1,24 @@
 /**
- * Schema for creating kubernetes credential.
+ * Schema for the Kubernetes credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at
+ * `schemas/constructs/v1beta1/credential/forms/kubernetes.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Credential construct
+ * (the kubernetes-specific shape lives inside the canonical free-form
+ * `secret` map).
+ *
+ * Wire-level change: the field formerly keyed as `credentialName` is
+ * now keyed as `name`, matching canonical `Credential.name`. The
+ * Meshery server's Credential endpoint already accepts the canonical
+ * key per its OpenAPI; this brings the form payload into alignment.
+ *
+ * The published Sistent export name (`kubernetesCredentialSchema`)
+ * is unchanged.
  */
-// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
-// `KubernetesCredentialRjsfSchemaV1Beta1` (canonical home:
-// `typescript/forms/v1beta1/credential/`), flip this file to:
-//
-//     export { KubernetesCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
-//
-// The published Sistent export name (`kubernetesCredentialSchema`)
-// MUST stay the same; only the source flips.
-const kubernetesCredentialSchema = {
-  type: 'object',
-  title: 'Kubernetes',
-  properties: {
-    credentialName: {
-      title: 'Credential Name',
-      type: 'string',
-      description: 'Name of your credential'
-    },
-    secret: {
-      type: 'object',
-      title: 'Credential Secret',
-      description: 'Credential secret for the Kubernetes cluster',
-      properties: {
-        clusterName: {
-          type: 'string',
-          title: 'Cluster Name',
-          description: 'Name of the Kubernetes cluster'
-        },
-        clusterServerURL: {
-          type: 'string',
-          title: 'Server URL',
-          description: 'URL of the Kubernetes cluster'
-        },
-        auth: {
-          type: 'object',
-          title: 'Auth',
-          description: 'Kubernetes cluster authentication',
-          properties: {
-            clusterUserName: {
-              type: 'string',
-              title: 'User Name',
-              description: 'Name of the Kubernetes cluster user'
-            },
-            clusterToken: {
-              type: 'string',
-              title: 'Token',
-              description: 'Token of the Kubernetes cluster user'
-            },
-            clusterClientCertificateData: {
-              type: 'string',
-              title: 'Client Certificate Data',
-              description: 'Certificate data of the Kubernetes cluster'
-            },
-            clusterClientKeyData: {
-              type: 'string',
-              title: 'Client Key Data',
-              description: 'Client Key data of the Kubernetes cluster'
-            },
-            clusterCertificateAuthorityData: {
-              type: 'string',
-              title: 'Certificate Authority Data',
-              description: 'Certificate Authority data of the Kubernetes cluster'
-            }
-          },
-          required: [
-            'clusterUserName',
-            'clusterToken',
-            'clusterClientCertificateData',
-            'clusterClientKeyData',
-            'clusterCertificateAuthorityData'
-          ]
-        }
-      },
-      required: ['clusterName', 'clusterServerURL']
-    }
-  },
-  required: ['credentialName']
-};
-
-export default kubernetesCredentialSchema;
+export { KubernetesCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/kubernetesCredential/uiSchema.tsx
+++ b/src/schemas/kubernetesCredential/uiSchema.tsx
@@ -1,3 +1,11 @@
-const kubernetesCredentialUiSchema = {};
-
-export default kubernetesCredentialUiSchema;
+/**
+ * UI schema for the Kubernetes credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The published Sistent export name (`kubernetesCredentialUiSchema`)
+ * is unchanged.
+ */
+export { KubernetesCredentialRjsfUiSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/prometheusCredential/schema.tsx
+++ b/src/schemas/prometheusCredential/schema.tsx
@@ -1,38 +1,22 @@
 /**
- * Schema for creating prometheus credential;
+ * Schema for the Prometheus credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at
+ * `schemas/constructs/v1beta1/credential/forms/prometheus.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Credential construct
+ * (the prometheus-specific shape lives inside the canonical free-form
+ * `secret` map).
+ *
+ * Wire-level change: the field formerly keyed as `credentialName` is
+ * now keyed as `name`, matching canonical `Credential.name`.
+ *
+ * The published Sistent export name (`prometheusCredentialSchema`)
+ * is unchanged.
  */
-// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
-// `PrometheusCredentialRjsfSchemaV1Beta1` (canonical home:
-// `typescript/forms/v1beta1/credential/`), flip this file to:
-//
-//     export { PrometheusCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
-//
-// The published Sistent export name (`prometheusCredentialSchema`)
-// MUST stay the same; only the source flips.
-const prometheusCredentialSchema = {
-  type: 'object',
-  title: 'Prometheus',
-  properties: {
-    credentialName: {
-      title: 'Credential Name',
-      type: 'string',
-      description: 'Name of your credential'
-    },
-    secret: {
-      type: 'object',
-      title: 'Credential Secret',
-      description: 'Credential secret for the Prometheus instance',
-      properties: {
-        prometheusURL: {
-          type: 'string',
-          title: 'URL',
-          description: 'URL of the Prometheus instance'
-        }
-      },
-      required: ['prometheusURL']
-    }
-  },
-  required: ['credentialName']
-};
-
-export default prometheusCredentialSchema;
+export { PrometheusCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/prometheusCredential/schema.tsx
+++ b/src/schemas/prometheusCredential/schema.tsx
@@ -1,6 +1,14 @@
 /**
  * Schema for creating prometheus credential;
  */
+// TODO(meshery/schemas#866 — Phase 3): once `@meshery/schemas` ships
+// `PrometheusCredentialRjsfSchemaV1Beta1` (canonical home:
+// `typescript/forms/v1beta1/credential/`), flip this file to:
+//
+//     export { PrometheusCredentialRjsfSchemaV1Beta1 as default } from '@meshery/schemas';
+//
+// The published Sistent export name (`prometheusCredentialSchema`)
+// MUST stay the same; only the source flips.
 const prometheusCredentialSchema = {
   type: 'object',
   title: 'Prometheus',

--- a/src/schemas/prometheusCredential/uiSchema.tsx
+++ b/src/schemas/prometheusCredential/uiSchema.tsx
@@ -1,3 +1,11 @@
-const prometheusCredentialUiSchema = {};
-
-export default prometheusCredentialUiSchema;
+/**
+ * UI schema for the Prometheus credential modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 3).
+ *
+ * The published Sistent export name (`prometheusCredentialUiSchema`)
+ * is unchanged.
+ */
+export { PrometheusCredentialRjsfUiSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/publishCatalogItem/schema.tsx
+++ b/src/schemas/publishCatalogItem/schema.tsx
@@ -1,60 +1,18 @@
 /**
  * Schema for publish catalog item modal;
- * Can be use for publishing filters and designs
+ * Can be used for publishing filters and designs.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the form-schema
+ * canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 1).
+ *
+ * The previously hand-authored object literal has moved to
+ * `meshery/schemas` at `typescript/forms/v1beta2/catalog/publish.json`,
+ * where a Go subset-validator (`validation/forms_test.go`) keeps it
+ * structurally aligned with the canonical OpenAPI Catalog construct.
+ *
+ * The published Sistent export name (`publishCatalogItemSchema`) is
+ * unchanged — only the source of the schema has flipped. Consumers in
+ * `meshery` and `meshery-cloud` keep working without source changes.
  */
-const publishCatalogItemSchema = {
-  type: 'object',
-  properties: {
-    compatibility: {
-      type: 'array',
-      title: 'Technology',
-      items: {
-        enum: ['kubernetes'],
-        type: 'string'
-      },
-      uniqueItems: true,
-      minItems: 1,
-      description:
-        'A list of technologies included in or implicated by this design; a list of relevant technology tags.',
-      'x-rjsf-grid-area': 6
-    },
-    patternCaveats: {
-      type: 'string',
-      title: 'Caveats and Considerations',
-      description:
-        'Specific stipulations to consider and known behaviors to be aware of when using this design.',
-      format: 'textarea',
-      'x-rjsf-grid-area': 12,
-      'x-encode-in-uri': true
-    },
-    patternInfo: {
-      type: 'string',
-      title: 'Description',
-      description: 'Purpose of the design along with its intended and unintended uses.',
-      format: 'textarea',
-      'x-rjsf-grid-area': 12,
-      'x-encode-in-uri': true
-    },
-    type: {
-      type: 'string',
-      title: 'Type',
-      enum: [
-        'Deployment',
-        'Observability',
-        'Resiliency',
-        'Scaling',
-        'Security',
-        'Traffic-management',
-        'Troubleshooting',
-        'Workloads'
-      ],
-      default: 'Deployment',
-      description:
-        'Categorization of the type of design or operational flow depicted in this design.',
-      'x-rjsf-grid-area': 6
-    }
-  },
-  required: ['compatibility', 'patternCaveats', 'patternInfo', 'type']
-};
-
-export default publishCatalogItemSchema;
+export { CatalogPublishRjsfSchemaV1Beta2 as default } from '@meshery/schemas';

--- a/src/schemas/publishCatalogItem/uiSchema.tsx
+++ b/src/schemas/publishCatalogItem/uiSchema.tsx
@@ -1,5 +1,11 @@
-const publishCatalogItemUiSchema = {
-  'ui:order': ['type', 'compatibility', 'patternInfo', 'patternCaveats']
-};
-
-export default publishCatalogItemUiSchema;
+/**
+ * UI schema for publish catalog item modal.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866 (Phase 1).
+ *
+ * The published Sistent export name (`publishCatalogItemUiSchema`) is
+ * unchanged.
+ */
+export { CatalogPublishRjsfUiSchemaV1Beta2 as default } from '@meshery/schemas';


### PR DESCRIPTION
## Summary

Phase 3 of [meshery/schemas#866](https://github.com/meshery/schemas/issues/866). Flips **6 Sistent form schemas** from hand-authored object literals to re-exports of canonical artifacts in [`@meshery/schemas` v1.2.8](https://www.npmjs.com/package/@meshery/schemas/v/1.2.8). The Sistent-published export names are unchanged so all downstream consumers (meshery, meshery-cloud) keep working without source-level changes.

## Forms flipped

| Sistent local | Canonical export |
|---|---|
| `publishCatalogItem` | `CatalogPublishRjsfSchemaV1Beta2` / `…UiSchema…` |
| `createAndEditEnvironment` | `EnvironmentCreateOrEditRjsfSchemaV1Beta3` / `…UiSchema…` |
| `createAndEditWorkspace` (default) | `WorkspaceCreateOrEditRjsfSchemaV1Beta3` / `…UiSchema…` |
| `editWorkspace` (named) | derived locally: `{ ...canonical, required: ['organizationId'] }` (see below) |
| `kubernetesCredential` | `KubernetesCredentialRjsfSchemaV1Beta1` / `…UiSchema…` |
| `grafanaCredential` | `GrafanaCredentialRjsfSchemaV1Beta1` / `…UiSchema…` |
| `prometheusCredential` | `PrometheusCredentialRjsfSchemaV1Beta1` / `…UiSchema…` |

## Wire-level changes

The canonical form schemas use canonical field names; the hand-authored Sistent forms didn't. Submission payloads from the flipped forms now use:

- `organizationId` instead of `organization` (environment, workspace) — matches `WorkspacePayload.organizationId` / `EnvironmentPayload.organizationId`
- `name` instead of `credentialName` (kubernetes, grafana, prometheus) — matches `Credential.name`

The Meshery server's Environment / Workspace / Credential endpoints already accept the canonical keys per their OpenAPI; this brings the form payloads into alignment.

## `editWorkspace` derivation

Sistent ships a relaxed-required `editWorkspace` named export alongside the default create-or-edit schema. v1.2.8 only ships the strict variant; the edit-only relaxation isn't canonicalized yet. This PR derives `editWorkspace` locally by spreading the canonical and overriding `required: ['organizationId']`. Once `@meshery/schemas` ships an `WorkspaceEditRjsfSchemaV1Beta3` (per the [#866 roadmap](https://github.com/meshery/schemas/blob/master/docs/form-schemas-roadmap.md)), the derivation can be replaced with a direct re-export.

The derived const is intentionally typed `Record<string, unknown>` because `@meshery/schemas` declares `RJSFSchema` internally but doesn't yet re-export it as a public type — tsup's DTS bundler errors out when the emitted `.d.ts` references the un-exportable type. Filed [meshery/schemas#871](https://github.com/meshery/schemas/issues/871) to add the type export upstream; once that lands, the annotation can be tightened.

## Pending (out of scope here)

These 4 forms still carry TODO headers pointing at #866 and stay hand-authored until the canonical-side gaps are resolved:

- `importDesign`, `importFilter`, `importModel` — pending [meshery/schemas#868](https://github.com/meshery/schemas/issues/868) (`uploadType` discriminator vs canonical `oneOf` shape)
- `helmConnection` — pending [meshery/schemas#869](https://github.com/meshery/schemas/issues/869) (canonical Connection puts kind-specific fields under `metadata`, not top-level)

`helpAndSupportModal` stays Sistent-local — UI-only, no canonical construct.

## Bumps

- `@meshery/schemas`: `^1.2.7` → `^1.2.8`. v1.2.8 ships the canonical form-schema exports.
- `@sistent/sistent` package version: `0.21.0` → `0.22.0`. The public-export names are unchanged but the underlying schema source moves repos AND the wire-level field names change for several forms — that's a more significant semantic shift than a typical patch, so a minor bump is appropriate.

## Test plan

- [x] `npm install` — bumps `@meshery/schemas` to 1.2.8 cleanly
- [x] `npm test` — 11 suites / 29 tests pass
- [x] `npm run build` — tsup ESM/CJS + DTS green; `dist/index.d.ts` size **drops** from 95.89 KB to 91.66 KB (the re-exports are smaller than the hand-authored object literals they replaced)
- [x] Runtime resolution: `require('@meshery/schemas')` gives valid objects with the expected `required` fields:
      - Catalog: `[compatibility, patternCaveats, patternInfo, type]`
      - Environment: `[name]`
      - Workspace: `[name, organizationId]` (canonical key, not `organization`)
      - Each `*Credential`: `[name]` (canonical key, not `credentialName`)
- [x] `npx tsc --noEmit`: `src/schemas/` is clean. Pre-existing errors in `examples/next-16/lib/palette.ts` and `src/__testing__/*.test.tsx` are unrelated and present on master.
- [ ] Manual: confirm the flipped modals (catalog publish, environment / workspace create+edit, all 3 credential creates) still render and submit correctly in `meshery` and `meshery-cloud` after a `@sistent/sistent@0.22.0` bump in those repos. The Integration Test with Meshery UI on this PR exercises the catalog publish path end-to-end and was green on the first commit.

Refs: [meshery/schemas#866](https://github.com/meshery/schemas/issues/866), [meshery/schemas#867](https://github.com/meshery/schemas/pull/867), [meshery/schemas#871](https://github.com/meshery/schemas/issues/871).