### PR TITLE
fix(useRoomActivity): canonicalize provider_url → providerUrl

### DIFF
--- a/src/hooks/useRoomActivity.ts
+++ b/src/hooks/useRoomActivity.ts
@@ -13,7 +13,7 @@ interface UserProfile {
 }
 
 interface CollaborationConfigParams {
-  provider_url: string;
+  providerUrl: string;
   getUserProfile: () => Promise<{ data: UserProfile }>;
   getUserAccessToken: () => Promise<{ data: string }>;
 }
@@ -47,7 +47,7 @@ interface UserMapping {
 }
 
 interface UseRoomActivityParams {
-  provider_url?: string;
+  providerUrl?: string;
   getUserProfile?: () => Promise<{ data: UserProfile }>;
   getUserAccessToken?: () => Promise<{ data: string }>;
 }
@@ -100,7 +100,7 @@ const getSignalingUrlFromProviderUrl = (providerUrl: string): string => {
  * Gets collaboration configuration for WebRTC
  */
 export const getCollaborationConfig = async ({
-  provider_url,
+  providerUrl,
   getUserProfile,
   getUserAccessToken
 }: CollaborationConfigParams): Promise<CollaborationConfig> => {
@@ -116,7 +116,7 @@ export const getCollaborationConfig = async ({
   };
 
   return {
-    signalingUrl: [getSignalingUrlFromProviderUrl(provider_url)],
+    signalingUrl: [getSignalingUrlFromProviderUrl(providerUrl)],
     user: userProfile,
     authToken: accessToken,
     refreshAuthToken: refreshToken,
@@ -135,18 +135,18 @@ export const getCollaborationConfig = async ({
 const subscribeToRoomActivity = async (
   wsRef: React.MutableRefObject<WebSocket | null>,
   onUserMapChange: (userMap: UserMapping) => void,
-  provider_url: string,
+  providerUrl: string,
   getUserProfile: () => Promise<{ data: UserProfile }>,
   getUserAccessToken: () => Promise<{ data: string }>
 ): Promise<void> => {
-  if (!provider_url || !getUserProfile || !getUserAccessToken) {
+  if (!providerUrl || !getUserProfile || !getUserAccessToken) {
     console.warn('Missing required parameters for subscription');
     return;
   }
 
   try {
     const config = await getCollaborationConfig({
-      provider_url,
+      providerUrl,
       getUserProfile,
       getUserAccessToken
     });
@@ -187,7 +187,7 @@ const subscribeToRoomActivity = async (
  */
 export const useRoomActivity = (
   {
-    provider_url,
+    providerUrl,
     getUserProfile,
     getUserAccessToken
   }: UseRoomActivityParams = {} as UseRoomActivityParams
@@ -197,11 +197,11 @@ export const useRoomActivity = (
 
   useEffect(() => {
     // -> all parameters check
-    if (provider_url && getUserProfile && getUserAccessToken) {
+    if (providerUrl && getUserProfile && getUserAccessToken) {
       subscribeToRoomActivity(
         wsRef,
         setAllRoomsUserMapping,
-        provider_url,
+        providerUrl,
         getUserProfile,
         getUserAccessToken
       );
@@ -215,7 +215,7 @@ export const useRoomActivity = (
         ws.close();
       }
     };
-  }, [provider_url, getUserProfile, getUserAccessToken]);
+  }, [providerUrl, getUserProfile, getUserAccessToken]);
 
   return [allRoomsUserMapping, wsRef];
 };


### PR DESCRIPTION
## Summary

**BREAKING** — public hook parameter rename. The last surviving snake_case prop on sistent's public surface flipped to canonical camelCase per the cluster-wide identifier-naming contract ([\`meshery/schemas/AGENTS.md\`](https://github.com/meshery/schemas/blob/master/AGENTS.md), row 7: TypeScript property is camelCase).

### Affected exported surfaces
- \`UseRoomActivityParams.provider_url\` → \`providerUrl\`
- \`CollaborationConfigParams.provider_url\` → \`providerUrl\`

Internal renames (no public-API impact):
- Function arg / local var renames in \`subscribeToRoomActivity\` and \`useRoomActivity\` to match the public field name. No destructuring rename gymnastics.

## Downstream coordination

Known downstream consumer:
- [\`layer5labs/meshery-extensions#4228\`](https://github.com/layer5labs/meshery-extensions/pull/4228) — \`ExpandedDesignerDrawer\` calls \`useRoomActivity({ provider_url: ... })\` against the snake form. That call was kept on snake during the §21 deferred-slice work *precisely because this hook still exposed the snake parameter*.

The companion meshery-extensions commit that flips the outer key (`provider_url:` → `providerUrl:`) is a one-line rename. It needs to ride in the same release window as this PR — i.e., when this Sistent change ships, the next sistent bump in \`layer5labs/meshery-extensions\` should land the call-site flip.

## Test plan

- [x] \`jest\` — 29/29 tests pass.
- [ ] After merge: bump \`@sistent/sistent\` in \`layer5labs/meshery-extensions\` and confirm the call site at \`ExpandedDesignerDrawer/index.tsx\` is updated to use \`providerUrl:\` (otherwise \`useRoomActivity\` won't receive the URL and the collab signaling URL will be empty).
- [ ] After merge: bump \`@sistent/sistent\` in \`layer5io/meshery-cloud\` if any consumer there uses \`useRoomActivity\` (none currently — verified via grep, the cloud UI doesn't import this hook).

## References

- [\`meshery/schemas/docs/identifier-naming-migration.md §21.A\`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-migration.md) — this PR is the \"sistent useRoomActivity\" line item in the trailing follow-ups.
- [\`layer5labs/meshery-extensions#4228\`](https://github.com/layer5labs/meshery-extensions/pull/4228) — the §21 deferred-slice work that kept the call site on snake pending this rename.