### PR TITLE
fix(collab): rename useRoomActivity param provider_url → providerUrl

### DIFF
--- a/src/hooks/useRoomActivity.ts
+++ b/src/hooks/useRoomActivity.ts
@@ -13,7 +13,7 @@ interface UserProfile {
 }
 
 interface CollaborationConfigParams {
-  provider_url: string;
+  providerUrl: string;
   getUserProfile: () => Promise<{ data: UserProfile }>;
   getUserAccessToken: () => Promise<{ data: string }>;
 }
@@ -47,7 +47,7 @@ interface UserMapping {
 }
 
 interface UseRoomActivityParams {
-  provider_url?: string;
+  providerUrl?: string;
   getUserProfile?: () => Promise<{ data: UserProfile }>;
   getUserAccessToken?: () => Promise<{ data: string }>;
 }
@@ -100,7 +100,7 @@ const getSignalingUrlFromProviderUrl = (providerUrl: string): string => {
  * Gets collaboration configuration for WebRTC
  */
 export const getCollaborationConfig = async ({
-  provider_url,
+  providerUrl,
   getUserProfile,
   getUserAccessToken
 }: CollaborationConfigParams): Promise<CollaborationConfig> => {
@@ -116,7 +116,7 @@ export const getCollaborationConfig = async ({
   };
 
   return {
-    signalingUrl: [getSignalingUrlFromProviderUrl(provider_url)],
+    signalingUrl: [getSignalingUrlFromProviderUrl(providerUrl)],
     user: userProfile,
     authToken: accessToken,
     refreshAuthToken: refreshToken,
@@ -135,18 +135,18 @@ export const getCollaborationConfig = async ({
 const subscribeToRoomActivity = async (
   wsRef: React.MutableRefObject<WebSocket | null>,
   onUserMapChange: (userMap: UserMapping) => void,
-  provider_url: string,
+  providerUrl: string,
   getUserProfile: () => Promise<{ data: UserProfile }>,
   getUserAccessToken: () => Promise<{ data: string }>
 ): Promise<void> => {
-  if (!provider_url || !getUserProfile || !getUserAccessToken) {
+  if (!providerUrl || !getUserProfile || !getUserAccessToken) {
     console.warn('Missing required parameters for subscription');
     return;
   }
 
   try {
     const config = await getCollaborationConfig({
-      provider_url,
+      providerUrl,
       getUserProfile,
       getUserAccessToken
     });
@@ -187,7 +187,7 @@ const subscribeToRoomActivity = async (
  */
 export const useRoomActivity = (
   {
-    provider_url,
+    providerUrl,
     getUserProfile,
     getUserAccessToken
   }: UseRoomActivityParams = {} as UseRoomActivityParams
@@ -197,11 +197,11 @@ export const useRoomActivity = (
 
   useEffect(() => {
     // -> all parameters check
-    if (provider_url && getUserProfile && getUserAccessToken) {
+    if (providerUrl && getUserProfile && getUserAccessToken) {
       subscribeToRoomActivity(
         wsRef,
         setAllRoomsUserMapping,
-        provider_url,
+        providerUrl,
         getUserProfile,
         getUserAccessToken
       );
@@ -215,7 +215,7 @@ export const useRoomActivity = (
         ws.close();
       }
     };
-  }, [provider_url, getUserProfile, getUserAccessToken]);
+  }, [providerUrl, getUserProfile, getUserAccessToken]);
 
   return [allRoomsUserMapping, wsRef];
 };


### PR DESCRIPTION
## Summary

- Renames `provider_url` → `providerUrl` in the `UseRoomActivityParams` interface (public hook API)
- Renames `provider_url` → `providerUrl` in the `CollaborationConfigParams` interface (exported `getCollaborationConfig` API)
- Updates all internal usages throughout the hook: destructuring, null-guard, effect dependency array, and forwarding to `getCollaborationConfig`

## Motivation

The `provider_url` snake_case parameter violates the canonical camelCase wire-format contract defined in [`meshery/schemas`](https://github.com/meshery/schemas). All hook parameters must be `camelCase` per that contract (`providerUrl`, not `provider_url`).

This unblocks [meshery-extensions#4228](https://github.com/layer5labs/meshery-extensions/pull/4228) (merged 2026-05-06), which canonicalized all `provider_url` reads in Kanvas to `providerUrl` and left a single intentional call-site workaround pending this sistent rename:
```ts
// Before (workaround in ExpandedDesignerDrawer/index.tsx):
useRoomActivity({ provider_url: providerUrl, ... })
// After (follow-up PR in extensions):
useRoomActivity({ providerUrl, ... })
```

## Notes

- `user_map` in `UserMapChangeMessage` is intentionally **not** renamed — it is an incoming WebSocket message field name dictated by the server protocol, not a hook parameter.
- No test or story files call `useRoomActivity` directly; the 48 existing unit tests all pass.

## Test plan

- [x] `npm test` passes (48 tests, 17 suites)
- [x] TypeScript compiles without errors (pre-commit hook clean)
- [ ] Callers updated in `layer5labs/meshery-extensions` follow-up PR