### PR TITLE
feat(schemas): re-export helpAndSupportModal schemas from @meshery/schemas (closes #866)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "1.2.9",
+        "@meshery/schemas": "1.2.11",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3119,9 +3119,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.9.tgz",
-      "integrity": "sha512-OyK2S1nCoGYG1Iws1NtMXzL2xoBgVRaiisd57ipZC+4DWjp5RC9lFY4TqL2APITyHTqdYu1qeSRByywWaDDN1Q==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.11.tgz",
+      "integrity": "sha512-3084t111ZMeoLbuNuMlQDYcR8ZMzQ9Ip31QtHpL7h5HpkycWUurNgf05J1vHmIKUSVgUIqYSNN1Op/FVwzaO4g==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
@@ -3135,7 +3135,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
       "integrity": "sha512-uwQNGkhv0lf7ufxw6QXev77BW6pWbW+7uxYjU5+rfp4lBkFtMEgJCsarTM3Tn+i0lGx6+Ol2u88JdGXr0GDskA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3146,7 +3145,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.0.tgz",
       "integrity": "sha512-oDwyvI6LgjWRC9MBcSGvLkPud9S9ELgSBQFYxa1rYcZn6Br55dn22SyvsPDMsn0G8OndFk53iMT45W5mNqrogw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -3173,7 +3171,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.0.tgz",
       "integrity": "sha512-+VP/oQCDhDR87NQQgXnNBG8dwy6GNuQLnenS1pZvkbn2dKFSxRSRMybTpH9xUxXP+316mlYDy5CSbYtusnCWtw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3223,7 +3220,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.0.tgz",
       "integrity": "sha512-JtuZoaiCqwD6vjgYu6Xp3T7DZkrxJlgtDz5yESzhI34fEX5hHMh2VJUbuL9UOg8xrfIFMrq6dcYoH/7Zi4G0RA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3251,7 +3247,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
       "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3286,7 +3281,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.0.tgz",
       "integrity": "sha512-YnC5Zg6j04IxiLc/boAKs0464jfZlLFVa7mf5E8lF0XOtZVUvG6R6gJK50lgUYdaaLdyLfxF6xR7LaPuEpeT/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3327,7 +3321,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
       "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -3345,7 +3338,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.0.tgz",
       "integrity": "sha512-bQcqyg/gjULUqTuyUjSAFr6LQGLvtkNtDbJerAtoUn9kGZ0hg5QJiN1PLHMLbeFpe3te1831uq7GFl2ITokGdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -4091,7 +4083,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
       "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0"
@@ -4432,7 +4424,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -5272,6 +5264,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@xstate/react": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
+      "integrity": "sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "xstate": "^5.28.0"
+      },
+      "peerDependenciesMeta": {
+        "xstate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -13669,7 +13681,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13718,7 +13729,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -14206,7 +14216,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -15076,7 +15085,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -15270,11 +15279,25 @@
         "react": "*"
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -15665,7 +15688,7 @@
       "version": "5.31.0",
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.31.0.tgz",
       "integrity": "sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
 
-    "@meshery/schemas": "1.2.9",
+    "@meshery/schemas": "1.2.11",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",

--- a/src/schemas/helpAndSupportModal/schema.tsx
+++ b/src/schemas/helpAndSupportModal/schema.tsx
@@ -1,38 +1,9 @@
 /**
- * Represents the JSON Schema for the Help and Support modal form.
- * This schema is designed to capture information for support request.
+ * Re-exports the canonical RJSF form schema for the help-and-support modal
+ * from @meshery/schemas. This is the authoritative source validated against
+ * the v1beta1 SupportRequest OpenAPI construct.
  *
- * Playground link -
+ * @see meshery/schemas#866 — migration from hand-authored to canonical
+ * @see meshery/schemas schemas/constructs/v1beta1/support/forms/helpAndSupport.json
  */
-const helpAndSupportModalSchema = {
-  title: 'Support Form',
-  properties: {
-    subject: {
-      type: 'string',
-      title: 'Subject',
-      description:
-        'Enter a concise and descriptive title for your support request. This will help us quickly understand the nature of your inquiry.',
-      minLength: 1,
-      'x-rjsf-grid-area': '12'
-    },
-    message: {
-      type: 'string',
-      title: 'Description',
-      description:
-        'Please provide a detailed description of your issue or question. Include any relevant information that you think will help us assist you more effectively. The more details you provide, the better we can understand and address your concerns.',
-      minLength: 10,
-      format: 'textarea',
-      'x-rjsf-grid-area': '12'
-    },
-    scope: {
-      type: 'string',
-      enum: ['Support', 'Community', 'Account', 'Commercial'],
-      title: 'Scope of Questions',
-      description: 'Select the category that best represents the nature of your inquiry.',
-      default: 'Technical'
-    }
-  },
-  required: ['subject', 'message']
-};
-
-export default helpAndSupportModalSchema;
+export { SupportRequestRjsfSchemaV1Beta1 as default } from '@meshery/schemas';

--- a/src/schemas/helpAndSupportModal/uiSchema.tsx
+++ b/src/schemas/helpAndSupportModal/uiSchema.tsx
@@ -1,16 +1,7 @@
 /**
- * Represents UI schema for help and support modal
+ * Re-exports the canonical RJSF UI schema for the help-and-support modal
+ * from @meshery/schemas.
+ *
+ * @see meshery/schemas#866
  */
-const helpAndSupportModalUiSchema = {
-  subject: {
-    'ui:placeholder': 'Summary or title for your support request'
-  },
-  message: {
-    'ui:placeholder': 'Detailed description of your support request'
-  },
-  scope: {
-    'ui:widget': 'radio'
-  }
-};
-
-export default helpAndSupportModalUiSchema;
+export { SupportRequestRjsfUiSchemaV1Beta1 as default } from '@meshery/schemas';


### PR DESCRIPTION
## Summary

- Replaces the hand-authored `helpAndSupportModalSchema` and `helpAndSupportModalUiSchema` with canonical re-exports from `@meshery/schemas@1.2.11` (`SupportRequestRjsfSchemaV1Beta1` / `SupportRequestRjsfUiSchemaV1Beta1`).
- Bumps `devDependencies["@meshery/schemas"]` from `1.2.9` to `1.2.11` (pinned exact, matching the pattern from commit `b8c7a204`).
- Regenerates `package-lock.json` to reflect the version bump.
- Completes the full migration of all sistent RJSF form schemas to `@meshery/schemas` as the canonical source (meshery/schemas#866).

## Bug fixed

The hand-authored schema had `default: 'Technical'` on the `scope` field, but `'Technical'` is not a member of the declared `enum: ['Support', 'Community', 'Account', 'Commercial']`. The canonical schema from `@meshery/schemas` omits this invalid default, resolving a latent RJSF validation inconsistency.

## Related

- meshery/schemas#866 — canonical SupportRequest RJSF schema
- Previous migration PRs: #1482, #1486 (all other form schemas already migrated)

## Test plan

- [ ] `npm install` completes cleanly (lockfile updated)
- [ ] All 18 test suites pass (verified locally: 50 tests, 0 failures)
- [ ] `src/schemas/index.tsx` continues to export `helpAndSupportModalSchema` and `helpAndSupportModalUiSchema` as default re-exports (no consumer-side changes required)
- [ ] Help and Support modal renders correctly in Meshery UI with the canonical schema fields: `subject`, `message`, `scope` (radio widget)