### PR TITLE
fix(CollaboratorAvatarGroup): canonicalize User.border_color → borderColor

### DIFF
--- a/src/custom/CollaboratorAvatarGroup/CollaboratorAvatarGroup.tsx
+++ b/src/custom/CollaboratorAvatarGroup/CollaboratorAvatarGroup.tsx
@@ -16,7 +16,7 @@ import { CustomTooltip } from '../CustomTooltip';
  *   'client1': {
  *     name: 'John Doe',
  *     avatarUrl: 'https://example.com/avatar1.jpg',
- *     border_color: '#00B39F',
+ *     borderColor: '#00B39F',
  *     userId: 'user123'
  *   }
  * };
@@ -33,13 +33,13 @@ import { CustomTooltip } from '../CustomTooltip';
  * @interface User
  * @property {string} name - Display name of the user
  * @property {string} avatarUrl - URL to the user's avatar image
- * @property {string} border_color - Color code for the avatar border (e.g., '#00B39F')
+ * @property {string} borderColor - Color code for the avatar border (e.g., '#00B39F')
  * @property {string} userId - Unique identifier for the user
  */
 interface User {
   name: string;
   avatarUrl: string;
-  border_color: string;
+  borderColor: string;
   userId: string;
 }
 
@@ -193,7 +193,7 @@ const CollaboratorAvatarGroup = ({
                 key={clientID}
                 alt={user.name}
                 src={user.avatarUrl}
-                borderColor={user.border_color}
+                borderColor={user.borderColor}
                 imgProps={{ referrerPolicy: 'no-referrer' }}
                 onClick={() => openInNewTab(`${providerUrl}/user/${user.userId}`)}
               />
@@ -242,7 +242,7 @@ const CollaboratorAvatarGroup = ({
                   <StyledAvatar
                     alt={user.name}
                     src={user.avatarUrl}
-                    borderColor={user.border_color}
+                    borderColor={user.borderColor}
                     imgProps={{ referrerPolicy: 'no-referrer' }}
                   />
                   <UserName variant="body1">{user.name}</UserName>


### PR DESCRIPTION
## Summary

Renames the last remaining snake_case identifier on Sistent's consumer-facing API: \`User.border_color\` → \`User.borderColor\` on the \`Users\` prop interface for \`CollaboratorAvatarGroup\`.

Phase 7c (commit \`3a18882d\`) deferred this rename on the grounds that it would be a public Sistent API break. That carve-out has stopped being load-bearing now that we've established the coordinated-rename pattern via [#1484](https://github.com/layer5io/sistent/pull/1484) (\`useRoomActivity({ provider_url → providerUrl })\`): rename the Sistent contract → ship a Sistent release → bump consumers in lockstep. We own the project; canonicalizing the last consumer-facing snake_case identifier is exactly what the contract is for.

## Changes

- \`User.border_color: string\` → \`User.borderColor: string\` on the exported \`Users\` prop interface (\`CollaboratorAvatarGroup.tsx:42\`).
- Both \`<StyledAvatar>\` call sites updated to read \`user.borderColor\` (visible avatar group at line 196, popup-overflow list at line 245).
- JSDoc example + \`@property\` doc comments updated to match.

Diff: 5 lines changed in 1 file.

## Test plan

- [x] \`npx jest\` — 29/29 passing.
- [x] \`grep -rn "border_color" src/\` — no matches.
- [ ] Once the next Sistent release ships, smoke-test \`CollaboratorAvatarGroup\` in Kanvas: open a design in two tabs and verify the borders on collaborator avatars render with their assigned colors.

## Coordinated consumer flips

After this PR ships in a Sistent release and \`@sistent/sistent\` is bumped in extensions:

- \`meshery-extensions/meshmap/collaborators/app.tsx:59\` is the only call site building a \`Users\` map for \`<CollaboratorAvatarGroup>\` — flips \`border_color: user.border_color\` → \`borderColor: user.borderColor\` in the same PR as the Sistent bump (matching the pattern in [meshery-extensions#4221](https://github.com/layer5labs/meshery-extensions/pull/4221)).

No other downstream consumers identified by cluster-wide audit.

## References

- [layer5io/sistent#1484](https://github.com/layer5io/sistent/pull/1484) — coordinated-rename pattern this PR follows.
- [\`meshery/schemas\` identifier-naming contract](https://github.com/meshery/schemas/blob/master/AGENTS.md) — TypeScript property: camelCase everywhere.