### PR TITLE
Add CategoryIcon component and exports

### DIFF
--- a/src/icons/CategoryIcon/CategoryIcon.tsx
+++ b/src/icons/CategoryIcon/CategoryIcon.tsx
@@ -1,14 +1,9 @@
 import { FC } from 'react';
 import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { CARIBBEAN_GREEN, DARK_SLATE_GRAY, KEPPEL, useTheme } from '../../theme';
-import { IconProps } from '../types';
+import { CustomIconProps } from '../types';
 
-type CategoryIconProps = {
-  primaryFill?: string;
-  secondaryFill?: string;
-} & IconProps;
-
-export const CategoryIcon: FC<CategoryIconProps> = ({
+export const CategoryIcon: FC<CustomIconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   primaryFill,
@@ -39,5 +34,3 @@ export const CategoryIcon: FC<CategoryIconProps> = ({
     </svg>
   );
 };
-
-export default CategoryIcon;

--- a/src/icons/CategoryIcon/CategoryIcon.tsx
+++ b/src/icons/CategoryIcon/CategoryIcon.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { CARIBBEAN_GREEN, DARK_SLATE_GRAY, KEPPEL, useTheme } from '../../theme';
+import { IconProps } from '../types';
+
+type CategoryIconProps = {
+  primaryFill?: string;
+  secondaryFill?: string;
+} & IconProps;
+
+export const CategoryIcon: FC<CategoryIconProps> = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  primaryFill,
+  secondaryFill,
+  style = {},
+  ...props
+}) => {
+  const theme = useTheme();
+  const themeMode = theme?.palette?.mode ?? 'light';
+  const themePrimaryFill = primaryFill ?? (themeMode === 'dark' ? KEPPEL : DARK_SLATE_GRAY);
+  const themeSecondaryFill = secondaryFill ?? (themeMode === 'dark' ? CARIBBEAN_GREEN : KEPPEL);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      style={style}
+      {...props}
+    >
+      <path d="m12 2-5.5 9h11z" fill={themeSecondaryFill} />
+      <path
+        d="M17.5 13c-2.49 0-4.5 2.01-4.5 4.5s2.01 4.5 4.5 4.5 4.5-2.01 4.5-4.5-2.01-4.5-4.5-4.5z"
+        fill={themePrimaryFill}
+      />
+      <path d="M3 13h8v8H3z" fill={themePrimaryFill} />
+    </svg>
+  );
+};
+
+export default CategoryIcon;

--- a/src/icons/CategoryIcon/index.tsx
+++ b/src/icons/CategoryIcon/index.tsx
@@ -1,2 +1,1 @@
-export { default as CategoryIcon } from './CategoryIcon';
 export * from './CategoryIcon';

--- a/src/icons/CategoryIcon/index.tsx
+++ b/src/icons/CategoryIcon/index.tsx
@@ -1,1 +1,1 @@
-export * from './CategoryIcon';
+export { default as CategoryIcon } from './CategoryIcon';

--- a/src/icons/CategoryIcon/index.tsx
+++ b/src/icons/CategoryIcon/index.tsx
@@ -1,0 +1,2 @@
+export { default as CategoryIcon } from './CategoryIcon';
+export * from './CategoryIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -22,6 +22,7 @@ export * from './Calender';
 export * from './Cancel';
 export * from './CaretDown';
 export * from './CatalogIcon';
+export * from './CategoryIcon';
 export * from './Chain';
 export * from './Challenges';
 export * from './Chat';


### PR DESCRIPTION
Introduce a new CategoryIcon SVG component (src/icons/CategoryIcon/CategoryIcon.tsx) that accepts width, height, primaryFill, secondaryFill, and style, using theme defaults and constants for sizing and color fallbacks. Add an index re-export for the component (src/icons/CategoryIcon/index.tsx) and update the top-level icons barrel (src/icons/index.ts) to export CategoryIcon.

**Notes for Reviewers**

This PR fixes #1490 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
