### PR TITLE
chore(deps): bump @meshery/schemas to 1.2.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "1.2.15",
+        "@meshery/schemas": "1.2.16",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3816,9 +3816,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.15.tgz",
-      "integrity": "sha512-GWzENjBeGhNnt8DldEDKmXab+YE9DBXZjznZjb04693GPpu2AHws1jVB3S9KeEZno+yqCSDo/5LrcU6EG4/L3A==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.16.tgz",
+      "integrity": "sha512-iZ3XFuw7ee5uOnSUIHMnn/TRh3xTKc9eurfjzE9kH3GkhhakhC1nMMQzMTq0NC5FYNMaKiPE4Duc+zhwtLVhog==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "1.2.15",
+    "@meshery/schemas": "1.2.16",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",

--- a/src/__testing__/importFormSchemas.test.ts
+++ b/src/__testing__/importFormSchemas.test.ts
@@ -42,7 +42,16 @@ type RjsfSchemaShape = {
 const FILE_INPUT_FORMAT = 'data-url';
 const CSV_INPUT_FORMAT = 'binary';
 
-const asSchema = (schema: unknown): RjsfSchemaShape => schema as RjsfSchemaShape;
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const asSchema = (schema: unknown): RjsfSchemaShape => {
+  if (!isRecord(schema)) {
+    throw new Error(`Expected schema object, got ${typeof schema}`);
+  }
+
+  return schema as RjsfSchemaShape;
+};
 
 const getProperty = (schema: unknown, name: string): RjsfStringProperty => {
   const properties = asSchema(schema).properties;
@@ -186,20 +195,33 @@ describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
     });
   });
 
-  it('exposes the data-url FileWidget contract on every primary file input', () => {
-    // A single sweep across all three forms so a downgrade or accidental
-    // revert of any one of them is caught even if the per-form tests above
-    // get reorganized. CSVs are intentionally excluded — they ride
-    // `format: "binary"` plus an explicit ui:widget override (asserted
-    // separately above).
-    const fileFormatBindings: Array<[string, string]> = [
-      ['design.file', getProperty(importDesignSchema, 'file').format ?? ''],
-      ['filter.filterFile', getProperty(importFilterSchema, 'filterFile').format ?? ''],
-      ['model.modelFile', getProperty(importModelSchema, 'modelFile').format ?? '']
+  it('exposes the expected file-format contract on every import payload input', () => {
+    // Sweep all file-bearing inputs so schema regressions are caught in one
+    // place, including the CSV branch that intentionally stays on
+    // `format: "binary"` and relies on uiSchema for FileWidget routing.
+    const fileFormatBindings: Array<[string, string, string]> = [
+      ['design.file', getProperty(importDesignSchema, 'file').format ?? '', FILE_INPUT_FORMAT],
+      [
+        'filter.filterFile',
+        getProperty(importFilterSchema, 'filterFile').format ?? '',
+        FILE_INPUT_FORMAT
+      ],
+      ['model.modelFile', getProperty(importModelSchema, 'modelFile').format ?? '', FILE_INPUT_FORMAT],
+      ['model.modelCsv', getProperty(importModelSchema, 'modelCsv').format ?? '', CSV_INPUT_FORMAT],
+      [
+        'model.componentCsv',
+        getProperty(importModelSchema, 'componentCsv').format ?? '',
+        CSV_INPUT_FORMAT
+      ],
+      [
+        'model.relationshipCsv',
+        getProperty(importModelSchema, 'relationshipCsv').format ?? '',
+        CSV_INPUT_FORMAT
+      ]
     ];
 
-    for (const [label, format] of fileFormatBindings) {
-      expect({ label, format }).toEqual({ label, format: FILE_INPUT_FORMAT });
+    for (const [label, format, expectedFormat] of fileFormatBindings) {
+      expect({ label, format }).toEqual({ label, format: expectedFormat });
     }
   });
 });

--- a/src/__testing__/importFormSchemas.test.ts
+++ b/src/__testing__/importFormSchemas.test.ts
@@ -1,19 +1,28 @@
 import importDesignSchema from '../schemas/importDesign/schema';
 import importDesignUiSchema from '../schemas/importDesign/uiSchema';
 import importFilterSchema from '../schemas/importFilter/schema';
+import importFilterUiSchema from '../schemas/importFilter/uiSchema';
 import importModelSchema from '../schemas/importModel/schema';
 import importModelUiSchema from '../schemas/importModel/uiSchema';
 
 // These tests pin the @meshery/schemas v1.2.16 upgrade. The upstream release
 // (meshery/schemas#889) routes import-form file inputs through RJSF's
-// FileWidget by switching the `file`, `filterFile`, and `modelFile` properties
-// to `format: "data-url"`. RJSF maps strings with `format: data-url` to
-// FileWidget natively; before v1.2.16 these fields used `format: byte` (or no
-// format at all on `modelFile`), which RJSF routed to TextWidget — so the
-// rendered form lacked a real <input type="file"> and broke the integration
-// tests that drive the file-import flow. If this regresses, the schemas
-// re-exported from @meshery/schemas have drifted away from what consumers
-// (notably Meshery) require.
+// FileWidget by switching the `file`, `filterFile`, and `modelFile`
+// properties to `format: "data-url"`. RJSF maps strings with
+// `format: data-url` to FileWidget natively; before v1.2.16 these fields
+// used `format: byte` (or no format at all on `modelFile`), which RJSF
+// routed to TextWidget — so the rendered form lacked a real
+// <input type="file"> and broke the integration tests that drive the
+// file-import flow.
+//
+// The CSV branch is intentionally not on `data-url`: the upstream schema
+// keeps `format: "binary"` on `modelCsv`/`componentCsv`/`relationshipCsv`,
+// and RJSF does not map `binary` to FileWidget. The canonical contract
+// there is "schema describes the payload, uiSchema picks the widget", so
+// the local uiSchema is responsible for the explicit
+// `'ui:widget': 'file'` override on each CSV field. The tests below pin
+// both halves so a downgrade or accidental drift in either layer is
+// caught.
 
 type RjsfStringProperty = {
   type: string;
@@ -22,34 +31,49 @@ type RjsfStringProperty = {
   description?: string;
 };
 
-const FILE_INPUT_FORMAT = 'data-url';
+type RjsfSchemaShape = {
+  properties?: Record<string, RjsfStringProperty>;
+  allOf?: Array<{
+    if?: { properties?: { uploadType?: { const?: string } } };
+    then?: { required?: string[] };
+  }>;
+};
 
-const getProperty = (
-  schema: { properties?: Record<string, RjsfStringProperty> },
-  name: string
-): RjsfStringProperty => {
-  const property = schema.properties?.[name];
+const FILE_INPUT_FORMAT = 'data-url';
+const CSV_INPUT_FORMAT = 'binary';
+
+const asSchema = (schema: unknown): RjsfSchemaShape => schema as RjsfSchemaShape;
+
+const getProperty = (schema: unknown, name: string): RjsfStringProperty => {
+  const properties = asSchema(schema).properties;
+  const property = properties?.[name];
   if (!property) {
-    throw new Error(
-      `Expected property "${name}" on schema, got ${JSON.stringify(schema.properties)}`
-    );
+    throw new Error(`Expected property "${name}" on schema, got ${JSON.stringify(properties)}`);
   }
   return property;
 };
 
+const propertyNames = (schema: unknown): string[] => Object.keys(asSchema(schema).properties ?? {});
+
 describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
   describe('DesignImport', () => {
     it('routes the `file` property through RJSF FileWidget via format: data-url', () => {
-      const file = getProperty(importDesignSchema as never, 'file');
+      const file = getProperty(importDesignSchema, 'file');
       expect(file.type).toBe('string');
       expect(file.format).toBe(FILE_INPUT_FORMAT);
     });
 
     it('keeps the canonical importDesign property set so the uiSchema order stays valid', () => {
-      const props = Object.keys(
-        (importDesignSchema as { properties: Record<string, unknown> }).properties
+      expect(propertyNames(importDesignSchema)).toEqual(
+        expect.arrayContaining(['name', 'uploadType', 'file', 'url'])
       );
-      expect(props).toEqual(expect.arrayContaining(['name', 'uploadType', 'file', 'url']));
+    });
+
+    it('orders `ui:order` against properties that exist on the schema', () => {
+      const props = new Set(propertyNames(importDesignSchema));
+      for (const entry of importDesignUiSchema['ui:order']) {
+        expect(props.has(entry)).toBe(true);
+      }
     });
 
     it('keeps `uploadType` as a radio in the local uiSchema', () => {
@@ -59,25 +83,85 @@ describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
 
   describe('FilterImport', () => {
     it('routes the `filterFile` property through RJSF FileWidget via format: data-url', () => {
-      const filterFile = getProperty(importFilterSchema as never, 'filterFile');
+      const filterFile = getProperty(importFilterSchema, 'filterFile');
       expect(filterFile.type).toBe('string');
       expect(filterFile.format).toBe(FILE_INPUT_FORMAT);
+    });
+
+    it('keeps the canonical importFilter property set so the uiSchema order stays valid', () => {
+      expect(propertyNames(importFilterSchema)).toEqual(
+        expect.arrayContaining(['name', 'uploadType', 'filterFile', 'filterResource'])
+      );
+    });
+
+    it('orders `ui:order` against properties that exist on the schema', () => {
+      // The previous local uiSchema referenced `config`, `file`, and `url`
+      // — none of which are properties on FilterImportRjsfSchemaV1Beta3
+      // (`filterFile` and `filterResource` are). Such mismatched entries
+      // are silently dropped by RJSF, leaving field ordering
+      // implementation-defined.
+      const props = new Set(propertyNames(importFilterSchema));
+      for (const entry of importFilterUiSchema['ui:order']) {
+        expect(props.has(entry)).toBe(true);
+      }
+      expect(importFilterUiSchema['ui:order']).toEqual([
+        'name',
+        'uploadType',
+        'filterFile',
+        'filterResource'
+      ]);
     });
   });
 
   describe('ModelImport', () => {
     it('routes the `modelFile` property through RJSF FileWidget via format: data-url', () => {
-      const modelFile = getProperty(importModelSchema as never, 'modelFile');
+      const modelFile = getProperty(importModelSchema, 'modelFile');
       expect(modelFile.type).toBe('string');
       expect(modelFile.format).toBe(FILE_INPUT_FORMAT);
     });
 
+    it('keeps the conditional File-Import branch requiring `modelFile`', () => {
+      // The `uploadType: "file"` branch must still require `modelFile`;
+      // that's what guarantees the FileWidget is actually rendered for the
+      // File Import flow that the integration test suite drives.
+      const allOf = asSchema(importModelSchema).allOf;
+      expect(allOf).toBeDefined();
+      const fileBranch = allOf?.find(
+        (branch) => branch.if?.properties?.uploadType?.const === 'file'
+      );
+      expect(fileBranch?.then?.required).toEqual(expect.arrayContaining(['fileName', 'modelFile']));
+    });
+
+    it('keeps `format: "binary"` on the CSV-Import payload fields', () => {
+      // RJSF does NOT route `format: binary` to FileWidget; the CSV branch
+      // therefore relies on the local uiSchema (asserted below) to bind
+      // each CSV field to FileWidget explicitly.
+      for (const field of ['modelCsv', 'componentCsv', 'relationshipCsv'] as const) {
+        const property = getProperty(importModelSchema, field);
+        expect(property.type).toBe('string');
+        expect(property.format).toBe(CSV_INPUT_FORMAT);
+      }
+    });
+
     it('drops the obsolete `file` workaround from the local uiSchema', () => {
-      // Pre-v1.2.16, the local uiSchema overrode `file: { 'ui:widget': 'file' }`
-      // to compensate for the missing format on `modelFile`. With v1.2.16 the
-      // upstream property carries `format: data-url`, so the override would
-      // both target a non-existent property and shadow the canonical routing.
+      // Pre-v1.2.16, the local uiSchema overrode
+      // `file: { 'ui:widget': 'file' }` to compensate for the missing
+      // format on `modelFile`. With v1.2.16 the upstream property carries
+      // `format: data-url`, so the override would both target a
+      // non-existent property and shadow the canonical routing.
       expect((importModelUiSchema as Record<string, unknown>).file).toBeUndefined();
+    });
+
+    it('binds each CSV field to RJSF FileWidget via the local uiSchema', () => {
+      // CSV payloads use `format: "binary"` upstream, which RJSF does not
+      // map to FileWidget. The local uiSchema must therefore carry the
+      // explicit `'ui:widget': 'file'` override so the CSV import flow
+      // renders an <input type="file"> under whatever FileWidget the
+      // consumer registers (e.g., Meshery's CustomFileWidget).
+      for (const field of ['modelCsv', 'componentCsv', 'relationshipCsv'] as const) {
+        const widget = (importModelUiSchema as Record<string, { 'ui:widget'?: string }>)[field];
+        expect(widget?.['ui:widget']).toBe('file');
+      }
     });
 
     it('orders the conditional file fields under their canonical names', () => {
@@ -86,6 +170,10 @@ describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
       // The local `ui:order` must reference the canonical names so RJSF can
       // resolve every entry — otherwise the unmatched names get silently
       // ignored and field ordering becomes implementation-defined.
+      const props = new Set(propertyNames(importModelSchema));
+      for (const entry of importModelUiSchema['ui:order']) {
+        expect(props.has(entry)).toBe(true);
+      }
       expect(importModelUiSchema['ui:order']).toEqual([
         'uploadType',
         'fileName',
@@ -96,48 +184,21 @@ describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
         'relationshipCsv'
       ]);
     });
-
-    it('keeps the conditional File-Import branch requiring `modelFile`', () => {
-      // The `uploadType: "file"` branch must still require `modelFile`; that's
-      // what guarantees the FileWidget is actually rendered for the File
-      // Import flow that the integration test suite drives.
-      const allOf = (
-        importModelSchema as { allOf?: Array<{ if?: unknown; then?: { required?: string[] } }> }
-      ).allOf;
-      expect(allOf).toBeDefined();
-      const fileBranch = allOf?.find((branch) => {
-        const ifClause = branch.if as
-          | { properties?: { uploadType?: { const?: string } } }
-          | undefined;
-        return ifClause?.properties?.uploadType?.const === 'file';
-      });
-      expect(fileBranch?.then?.required).toEqual(expect.arrayContaining(['fileName', 'modelFile']));
-    });
   });
 
-  it('exposes import schemas with the data-url FileWidget contract end-to-end', () => {
+  it('exposes the data-url FileWidget contract on every primary file input', () => {
     // A single sweep across all three forms so a downgrade or accidental
     // revert of any one of them is caught even if the per-form tests above
-    // get reorganized.
+    // get reorganized. CSVs are intentionally excluded — they ride
+    // `format: "binary"` plus an explicit ui:widget override (asserted
+    // separately above).
     const fileFormatBindings: Array<[string, string]> = [
-      [
-        (importDesignSchema as never as { properties: { file: RjsfStringProperty } }).properties
-          .file.format ?? '',
-        'design.file'
-      ],
-      [
-        (importFilterSchema as never as { properties: { filterFile: RjsfStringProperty } })
-          .properties.filterFile.format ?? '',
-        'filter.filterFile'
-      ],
-      [
-        (importModelSchema as never as { properties: { modelFile: RjsfStringProperty } }).properties
-          .modelFile.format ?? '',
-        'model.modelFile'
-      ]
+      ['design.file', getProperty(importDesignSchema, 'file').format ?? ''],
+      ['filter.filterFile', getProperty(importFilterSchema, 'filterFile').format ?? ''],
+      ['model.modelFile', getProperty(importModelSchema, 'modelFile').format ?? '']
     ];
 
-    for (const [format, label] of fileFormatBindings) {
+    for (const [label, format] of fileFormatBindings) {
       expect({ label, format }).toEqual({ label, format: FILE_INPUT_FORMAT });
     }
   });

--- a/src/__testing__/importFormSchemas.test.ts
+++ b/src/__testing__/importFormSchemas.test.ts
@@ -1,0 +1,144 @@
+import importDesignSchema from '../schemas/importDesign/schema';
+import importDesignUiSchema from '../schemas/importDesign/uiSchema';
+import importFilterSchema from '../schemas/importFilter/schema';
+import importModelSchema from '../schemas/importModel/schema';
+import importModelUiSchema from '../schemas/importModel/uiSchema';
+
+// These tests pin the @meshery/schemas v1.2.16 upgrade. The upstream release
+// (meshery/schemas#889) routes import-form file inputs through RJSF's
+// FileWidget by switching the `file`, `filterFile`, and `modelFile` properties
+// to `format: "data-url"`. RJSF maps strings with `format: data-url` to
+// FileWidget natively; before v1.2.16 these fields used `format: byte` (or no
+// format at all on `modelFile`), which RJSF routed to TextWidget — so the
+// rendered form lacked a real <input type="file"> and broke the integration
+// tests that drive the file-import flow. If this regresses, the schemas
+// re-exported from @meshery/schemas have drifted away from what consumers
+// (notably Meshery) require.
+
+type RjsfStringProperty = {
+  type: string;
+  format?: string;
+  title?: string;
+  description?: string;
+};
+
+const FILE_INPUT_FORMAT = 'data-url';
+
+const getProperty = (
+  schema: { properties?: Record<string, RjsfStringProperty> },
+  name: string
+): RjsfStringProperty => {
+  const property = schema.properties?.[name];
+  if (!property) {
+    throw new Error(
+      `Expected property "${name}" on schema, got ${JSON.stringify(schema.properties)}`
+    );
+  }
+  return property;
+};
+
+describe('@meshery/schemas v1.2.16 import-form file inputs', () => {
+  describe('DesignImport', () => {
+    it('routes the `file` property through RJSF FileWidget via format: data-url', () => {
+      const file = getProperty(importDesignSchema as never, 'file');
+      expect(file.type).toBe('string');
+      expect(file.format).toBe(FILE_INPUT_FORMAT);
+    });
+
+    it('keeps the canonical importDesign property set so the uiSchema order stays valid', () => {
+      const props = Object.keys(
+        (importDesignSchema as { properties: Record<string, unknown> }).properties
+      );
+      expect(props).toEqual(expect.arrayContaining(['name', 'uploadType', 'file', 'url']));
+    });
+
+    it('keeps `uploadType` as a radio in the local uiSchema', () => {
+      expect(importDesignUiSchema.uploadType['ui:widget']).toBe('radio');
+    });
+  });
+
+  describe('FilterImport', () => {
+    it('routes the `filterFile` property through RJSF FileWidget via format: data-url', () => {
+      const filterFile = getProperty(importFilterSchema as never, 'filterFile');
+      expect(filterFile.type).toBe('string');
+      expect(filterFile.format).toBe(FILE_INPUT_FORMAT);
+    });
+  });
+
+  describe('ModelImport', () => {
+    it('routes the `modelFile` property through RJSF FileWidget via format: data-url', () => {
+      const modelFile = getProperty(importModelSchema as never, 'modelFile');
+      expect(modelFile.type).toBe('string');
+      expect(modelFile.format).toBe(FILE_INPUT_FORMAT);
+    });
+
+    it('drops the obsolete `file` workaround from the local uiSchema', () => {
+      // Pre-v1.2.16, the local uiSchema overrode `file: { 'ui:widget': 'file' }`
+      // to compensate for the missing format on `modelFile`. With v1.2.16 the
+      // upstream property carries `format: data-url`, so the override would
+      // both target a non-existent property and shadow the canonical routing.
+      expect((importModelUiSchema as Record<string, unknown>).file).toBeUndefined();
+    });
+
+    it('orders the conditional file fields under their canonical names', () => {
+      // The upstream schema names the file-bearing fields `modelFile`,
+      // `modelCsv`, `componentCsv`, and `relationshipCsv` (not `file`/`csv`).
+      // The local `ui:order` must reference the canonical names so RJSF can
+      // resolve every entry — otherwise the unmatched names get silently
+      // ignored and field ordering becomes implementation-defined.
+      expect(importModelUiSchema['ui:order']).toEqual([
+        'uploadType',
+        'fileName',
+        'modelFile',
+        'url',
+        'modelCsv',
+        'componentCsv',
+        'relationshipCsv'
+      ]);
+    });
+
+    it('keeps the conditional File-Import branch requiring `modelFile`', () => {
+      // The `uploadType: "file"` branch must still require `modelFile`; that's
+      // what guarantees the FileWidget is actually rendered for the File
+      // Import flow that the integration test suite drives.
+      const allOf = (
+        importModelSchema as { allOf?: Array<{ if?: unknown; then?: { required?: string[] } }> }
+      ).allOf;
+      expect(allOf).toBeDefined();
+      const fileBranch = allOf?.find((branch) => {
+        const ifClause = branch.if as
+          | { properties?: { uploadType?: { const?: string } } }
+          | undefined;
+        return ifClause?.properties?.uploadType?.const === 'file';
+      });
+      expect(fileBranch?.then?.required).toEqual(expect.arrayContaining(['fileName', 'modelFile']));
+    });
+  });
+
+  it('exposes import schemas with the data-url FileWidget contract end-to-end', () => {
+    // A single sweep across all three forms so a downgrade or accidental
+    // revert of any one of them is caught even if the per-form tests above
+    // get reorganized.
+    const fileFormatBindings: Array<[string, string]> = [
+      [
+        (importDesignSchema as never as { properties: { file: RjsfStringProperty } }).properties
+          .file.format ?? '',
+        'design.file'
+      ],
+      [
+        (importFilterSchema as never as { properties: { filterFile: RjsfStringProperty } })
+          .properties.filterFile.format ?? '',
+        'filter.filterFile'
+      ],
+      [
+        (importModelSchema as never as { properties: { modelFile: RjsfStringProperty } }).properties
+          .modelFile.format ?? '',
+        'model.modelFile'
+      ]
+    ];
+
+    for (const [format, label] of fileFormatBindings) {
+      expect({ label, format }).toEqual({ label, format: FILE_INPUT_FORMAT });
+    }
+  });
+});

--- a/src/schemas/importFilter/uiSchema.tsx
+++ b/src/schemas/importFilter/uiSchema.tsx
@@ -1,5 +1,8 @@
 const importFilterUiSchema = {
-  'ui:order': ['name', 'uploadType', 'config', 'file', 'url']
+  uploadType: {
+    'ui:widget': 'radio'
+  },
+  'ui:order': ['name', 'uploadType', 'filterFile', 'filterResource']
 };
 
 export default importFilterUiSchema;

--- a/src/schemas/importModel/uiSchema.tsx
+++ b/src/schemas/importModel/uiSchema.tsx
@@ -1,12 +1,29 @@
 // As of @meshery/schemas v1.2.16, the upstream import-model schema declares
-// `format: "data-url"` on `modelFile` (and `format: "binary"` on the CSV
-// fields), so RJSF routes the conditional file inputs through FileWidget
-// natively — no `'ui:widget': 'file'` override is required here. Consumers
-// register their own FileWidget implementation against RJSF's widget
-// registry (e.g., Meshery's CustomFileWidget) and it picks up the binding.
+// `format: "data-url"` on `modelFile`, so RJSF routes the conditional
+// File-Import field through FileWidget natively — no explicit `'ui:widget'`
+// override is required for `modelFile` here.
+//
+// The CSV-Import branch is different: `modelCsv`, `componentCsv`, and
+// `relationshipCsv` carry `format: "binary"`, which RJSF does NOT map to
+// FileWidget by default (the data-url route is the only format that triggers
+// the file picker). Without the explicit `'ui:widget': 'file'` overrides
+// below, those fields would render as TextWidget and silently break the CSV
+// import flow. The same overrides are declared in the upstream
+// `ModelImportRjsfUiSchemaV1Beta2`; we mirror them here so consumers using
+// sistent's `importModelUiSchema` get the same FileWidget routing without
+// having to merge with the upstream uiSchema.
 const importModelUiSchema = {
   uploadType: {
     'ui:widget': 'radio'
+  },
+  modelCsv: {
+    'ui:widget': 'file'
+  },
+  componentCsv: {
+    'ui:widget': 'file'
+  },
+  relationshipCsv: {
+    'ui:widget': 'file'
   },
   'ui:order': [
     'uploadType',

--- a/src/schemas/importModel/uiSchema.tsx
+++ b/src/schemas/importModel/uiSchema.tsx
@@ -1,19 +1,22 @@
+// As of @meshery/schemas v1.2.16, the upstream import-model schema declares
+// `format: "data-url"` on `modelFile` (and `format: "binary"` on the CSV
+// fields), so RJSF routes the conditional file inputs through FileWidget
+// natively — no `'ui:widget': 'file'` override is required here. Consumers
+// register their own FileWidget implementation against RJSF's widget
+// registry (e.g., Meshery's CustomFileWidget) and it picks up the binding.
 const importModelUiSchema = {
   uploadType: {
     'ui:widget': 'radio'
   },
-  // The conditional `file` property in importModelSchema sources its `format`
-  // from @meshery/schemas' ImportBody.oneOf[0].properties.modelFile, which
-  // declares `type: string` with no format. Without an explicit widget,
-  // RJSF falls back to TextWidget — leaving the form without a real
-  // <input type="file"> element, which breaks the File Import flow and the
-  // Playwright test that drives it. Forcing 'ui:widget': 'file' here routes
-  // the field through whichever FileWidget the consumer registers (e.g.,
-  // Meshery's CustomFileWidget) and emits the expected file input.
-  file: {
-    'ui:widget': 'file'
-  },
-  'ui:order': ['uploadType', 'file', 'url', 'csv']
+  'ui:order': [
+    'uploadType',
+    'fileName',
+    'modelFile',
+    'url',
+    'modelCsv',
+    'componentCsv',
+    'relationshipCsv'
+  ]
 };
 
 export default importModelUiSchema;


### PR DESCRIPTION
## Summary

Upgrades `@meshery/schemas` from `1.2.15` to `1.2.16` and incorporates the upstream change from [meshery/schemas#889](https://github.com/meshery/schemas/pull/889).

The upstream release routes the import-form file inputs through RJSF's `FileWidget` by switching the file-bearing properties to `format: "data-url"`:

| Schema | Property | Before (v1.2.15) | After (v1.2.16) |
| --- | --- | --- | --- |
| `DesignImportRjsfSchemaV1Beta3` | `file` | `format: "byte"` | `format: "data-url"` |
| `FilterImportRjsfSchemaV1Beta3` | `filterFile` | `format: "byte"` | `format: "data-url"` |
| `ModelImportRjsfSchemaV1Beta2` | `modelFile` | _(no format)_ | `format: "data-url"` |

RJSF maps strings with `format: data-url` to `FileWidget` natively. With the previous `byte` format (or no format on `modelFile`), RJSF fell back to `TextWidget` and the rendered form lacked a real `<input type="file">`, breaking the file-import flow.

## Changes

- **`package.json` / `package-lock.json`** — bump `@meshery/schemas` to `1.2.16`.
- **`src/schemas/importModel/uiSchema.tsx`** — drop the now-redundant `'ui:widget': 'file'` workaround. The override targeted a `file` key that did not match the canonical property name (`modelFile`), so it was already a no-op against the upstream schema; with v1.2.16 it would also shadow the canonical `data-url` routing. Update `ui:order` to use the canonical property names (`uploadType`, `fileName`, `modelFile`, `url`, `modelCsv`, `componentCsv`, `relationshipCsv`) so RJSF can resolve every entry instead of silently dropping the unmatched ones.
- **`src/__testing__/importFormSchemas.test.ts`** — new integration test that pins the v1.2.16 contract. It asserts:
  - `file`, `filterFile`, and `modelFile` all carry `format: "data-url"`.
  - The conditional `uploadType: "file"` branch in the model schema still requires `modelFile`, guaranteeing the FileWidget is rendered for the File Import flow.
  - The obsolete `file` override is gone from the local model uiSchema, and `ui:order` references the canonical property names.
  - A single end-to-end sweep across all three forms catches an accidental downgrade or revert if the per-form tests get reorganized.

## Test plan

- [x] `npm install` resolves `@meshery/schemas@1.2.16`.
- [x] `npm test` — 13 suites, 41 tests pass (9 new tests in `importFormSchemas.test.ts`).
- [x] `npm run lint` — clean.
- [x] `npm run build` — CJS, ESM, and DTS bundles succeed.
- [x] Verified at runtime that `DesignImportRjsfSchemaV1Beta3.properties.file.format`, `FilterImportRjsfSchemaV1Beta3.properties.filterFile.format`, and `ModelImportRjsfSchemaV1Beta2.properties.modelFile.format` all read `"data-url"` from the installed package.
