### PR TITLE
Fix category icon export

### DIFF
--- a/src/icons/CategoryIcon/index.tsx
+++ b/src/icons/CategoryIcon/index.tsx
@@ -1,1 +1,1 @@
-export { default as CategoryIcon } from './CategoryIcon';
+export { CategoryIcon } from './CategoryIcon';


### PR DESCRIPTION
### **PR Title**
`[Fix] Correct named export for CategoryIcon`

---

### **PR Description**

**Notes for Reviewers**

This PR fixes a bug in `src/icons/CategoryIcon/index.tsx` that was causing compatibility check failures in the CI pipeline. 

**The Issue:**
The `index.tsx` file was attempting to export `CategoryIcon` as a `default` member from the adjacent `CategoryIcon.tsx` file. However, the component is actually defined as a **named export**.

**The Fix:**
Updated the export statement to correctly reference the named export:
`export { CategoryIcon } from './CategoryIcon';`

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!
-->

