### PR TITLE
Add HandymanIcon component and export

### DIFF
--- a/src/icons/HandymanIcon/HandymanIcon.tsx
+++ b/src/icons/HandymanIcon/HandymanIcon.tsx
@@ -1,0 +1,31 @@
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const HandymanIcon = ({
+	width = DEFAULT_WIDTH,
+	height = DEFAULT_HEIGHT,
+	fill = DEFAULT_FILL_NONE,
+	...props
+}: IconProps): JSX.Element => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width={width}
+			height={height}
+			data-testid="handyman-icon-svg"
+			{...props}
+		>
+			<path
+				d="m21.67 18.17-5.3-5.3h-.99l-2.54 2.54v.99l5.3 5.3c.39.39 1.02.39 1.41 0l2.12-2.12c.39-.38.39-1.02 0-1.41"
+				fill={fill}
+			/>
+			<path
+				d="m17.34 10.19 1.41-1.41 2.12 2.12c1.17-1.17 1.17-3.07 0-4.24l-3.54-3.54-1.41 1.41V1.71l-.7-.71-3.54 3.54.71.71h2.83l-1.41 1.41 1.06 1.06-2.89 2.89-4.13-4.13V5.06L4.83 2.04 2 4.87 5.03 7.9h1.41l4.13 4.13-.85.85H7.6l-5.3 5.3c-.39.39-.39 1.02 0 1.41l2.12 2.12c.39.39 1.02.39 1.41 0l5.3-5.3v-2.12l5.15-5.15z"
+				fill={fill}
+			/>
+		</svg>
+	);
+};
+
+export default HandymanIcon;

--- a/src/icons/HandymanIcon/index.tsx
+++ b/src/icons/HandymanIcon/index.tsx
@@ -1,0 +1,1 @@
+export { default as HandymanIcon } from './HandymanIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -99,6 +99,7 @@ export * from './GridOn';
 export * from './GridView';
 export * from './Group';
 export * from './GroupAdd';
+export * from './HandymanIcon';
 export * from './HelpIcon';
 export * from './Hierarchical';
 export * from './Idea';


### PR DESCRIPTION
Introduce a new HandymanIcon SVG component (src/icons/HandymanIcon/HandymanIcon.tsx) with default sizing/fill constants and IconProps support, including a data-testid for testing. Add barrel export (src/icons/HandymanIcon/index.tsx) and update src/icons/index.ts to export the new icon so it's available from the icon library.

**Notes for Reviewers**

This PR fixes #1526

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
