### PR TITLE
feat(custom): add RJSFFormWrapper and RJSFFormModal

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,12 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest'
   },
+  // @rjsf/* and json-schema-typed publish ESM-only sources and must
+  // pass through the @swc/jest transformer for the
+  // RJSFFormWrapper / RJSFFormModal smoke tests to load.
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@rjsf|@x0k|json-schema-typed|nanoid)/)'
+  ],
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/\\.claude/'],
   coverageThreshold: {
     global: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,18 +88,6 @@
         "xstate": "^5.25.0"
       },
       "peerDependenciesMeta": {
-        "@rjsf/core": {
-          "optional": true
-        },
-        "@rjsf/mui": {
-          "optional": true
-        },
-        "@rjsf/utils": {
-          "optional": true
-        },
-        "@rjsf/validator-ajv8": {
-          "optional": true
-        },
         "react": {
           "optional": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,15 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "1.2.18",
+        "@meshery/schemas": "1.2.19",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
         "@reduxjs/toolkit": "^2.11.2",
+        "@rjsf/core": "^6.5.2",
+        "@rjsf/mui": "^6.5.2",
+        "@rjsf/utils": "^6.5.2",
+        "@rjsf/validator-ajv8": "^6.5.2",
         "@swc/core": "^1.10.12",
         "@swc/jest": "^0.2.37",
         "@testing-library/dom": "^10.4.1",
@@ -74,12 +78,28 @@
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
+        "@rjsf/core": "^6.0.0",
+        "@rjsf/mui": "^6.0.0",
+        "@rjsf/utils": "^6.0.0",
+        "@rjsf/validator-ajv8": "^6.0.0",
         "@xstate/react": "^5.0.3 || ^6.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "xstate": "^5.25.0"
       },
       "peerDependenciesMeta": {
+        "@rjsf/core": {
+          "optional": true
+        },
+        "@rjsf/mui": {
+          "optional": true
+        },
+        "@rjsf/utils": {
+          "optional": true
+        },
+        "@rjsf/validator-ajv8": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -3280,9 +3300,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.2.18",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.18.tgz",
-      "integrity": "sha512-tE13GTSQ1f5iCfKDip0jC16aHSaHtMM8PvcZbLNXKwXCbJiBlHlYE6s0Iwq9YZjKG8VFyxARe2+9JY1FwLq4xw==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.2.19.tgz",
+      "integrity": "sha512-bosyJpKf4LUZJfa/qcrdRaDqS0KDBrJTsMrfGAqQQo/TICQF/Ks/aYIyJ3V6xwIwm3ydimc02RBV5Om1r2u2Ww==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
@@ -3296,6 +3316,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.1.tgz",
       "integrity": "sha512-GzamIIhZ1bH77dq7eKaeyRgJdkypsxin4jBFq2EMs4lBWRR0LFO1CSVMsoebn/VvjcNrnrOrjy48MkrkQUK2iw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3306,6 +3327,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.0.1.tgz",
       "integrity": "sha512-5PRpQjVLTNLyV/2J9J53Yz4R0tVbodG0BQDN2zQI1QBG1OPYM25ar+4N20eyFOfJT6zKglLzsnU70+zdVLaTkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -3332,6 +3354,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
       "integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3381,6 +3404,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.0.1.tgz",
       "integrity": "sha512-pSIGq4Yw749KHEwlkYZWVERgHgwJELP6ODtBNUfV8V4oIb5H+h7IQDFXuk/b2oQccODK1enJAtiEzlgLZmq+8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3408,6 +3432,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.0.0.tgz",
       "integrity": "sha512-9RLGdX4Jg0aQPRuvqh/OLzYSPlgd5zyEw5/1HIRfdavSiOd03WtUaGZH9/w1RoTYuRKwpgy0hpIFaMHIqPVIWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3442,6 +3467,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.0.1.tgz",
       "integrity": "sha512-WvlioaLxk6ewUIOfh0StxUvOPDS1mCfzaulcudsL1brZNXuh0N9FMk7RpH7ImJKjEz412SEy/V/yvqmtxbqxCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3482,6 +3508,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.0.0.tgz",
       "integrity": "sha512-i1cuFCAWN44b3AJWO7mh7tuh1sqbQSeVr/94oG0TX5uXivac8XalgE4/6fQZcmGZigzbQ35IXxj/4jLpRIBYZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2"
@@ -3499,6 +3526,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
       "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -3615,6 +3643,93 @@
         "react-redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rjsf/core": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-6.5.2.tgz",
+      "integrity": "sha512-Fx+aVNQRYQyoY0vM8zYDZkuOiNe+5PLsxUySUdHfjljlT23mJnTCpPKMkxWJwh4UEWeSN0xjmknW9LfIwuQmOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "markdown-to-jsx": "^8.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^6.5.x",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@rjsf/mui": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/mui/-/mui-6.5.2.tgz",
+      "integrity": "sha512-eVS3LZ59RNSwWt+PnRJn2IE/1FjJ97wDs138ezP0e7n5MbjcD77lO2QKCIVFE4vArDw2gZ4L3ir0DDqOXiO1Qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.7.0",
+        "@emotion/styled": "^11.6.0",
+        "@mui/icons-material": "^7.0.0 || ^9.0.0",
+        "@mui/material": "^7.0.0 || ^9.0.0",
+        "@rjsf/core": "^6.5.x",
+        "@rjsf/utils": "^6.5.x",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-6.5.2.tgz",
+      "integrity": "sha512-qBVQ5qf9BKMOQy/DjMl/IjD5s6akRDx18cgiSYunKt/CYc+kPzHyCVA2TU0rXCsigNlhgnfM8piC3LEHye6vpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x0k/json-schema-merge": "^1.0.3",
+        "fast-equals": "^6.0.0",
+        "fast-uri": "^3.1.0",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@rjsf/utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-6.5.2.tgz",
+      "integrity": "sha512-MSyF0Q0lZhmByDV/eL3QF03g1K7RVGGAHMytlQ2ybuakvzJGODGzWKfTLcP320ixrrCqDq5rs8IJP+WJCRnhig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^6.5.x"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4524,7 +4639,7 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
       "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0"
@@ -4865,7 +4980,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -5706,24 +5821,14 @@
         "win32"
       ]
     },
-    "node_modules/@xstate/react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-6.1.0.tgz",
-      "integrity": "sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==",
+    "node_modules/@x0k/json-schema-merge": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@x0k/json-schema-merge/-/json-schema-merge-1.0.3.tgz",
+      "integrity": "sha512-lerJC4sI9CNUQWdff3PnU1YJOqazD6TjMcvxZIPXUBjn4j1cUiXE0LvzhMnGYzKKr271TkvXJtH7gEwksrtn+w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.2",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "xstate": "^5.28.0"
-      },
-      "peerDependenciesMeta": {
-        "xstate": {
-          "optional": true
-        }
+        "@types/json-schema": "^7.0.15"
       }
     },
     "node_modules/acorn": {
@@ -5774,6 +5879,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -7949,6 +8072,16 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -11638,6 +11771,16 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11840,6 +11983,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.assignwith": {
@@ -12282,6 +12432,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-8.0.0.tgz",
+      "integrity": "sha512-hWEaRxeCDjes1CVUQqU+Ov0mCqBqkGhLKjL98KdbwHSgEWZZSJQeGlJQatVfeZ3RaxrfTrZZ3eczl2dhp5c/pA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -14088,6 +14256,7 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14136,6 +14305,7 @@
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -14639,6 +14809,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -15428,7 +15599,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -15622,25 +15793,11 @@
         "react": "*"
       }
     },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -16024,7 +16181,7 @@
       "version": "5.31.0",
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.31.0.tgz",
       "integrity": "sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -46,11 +46,15 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "1.2.18",
+    "@meshery/schemas": "1.2.19",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",
     "@reduxjs/toolkit": "^2.11.2",
+    "@rjsf/core": "^6.5.2",
+    "@rjsf/mui": "^6.5.2",
+    "@rjsf/utils": "^6.5.2",
+    "@rjsf/validator-ajv8": "^6.5.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
@@ -91,6 +95,10 @@
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",
+    "@rjsf/core": "^6.0.0",
+    "@rjsf/mui": "^6.0.0",
+    "@rjsf/utils": "^6.0.0",
+    "@rjsf/validator-ajv8": "^6.0.0",
     "@xstate/react": "^5.0.3 || ^6.0.0",
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -103,6 +111,18 @@
     }
   },
   "peerDependenciesMeta": {
+    "@rjsf/core": {
+      "optional": true
+    },
+    "@rjsf/mui": {
+      "optional": true
+    },
+    "@rjsf/utils": {
+      "optional": true
+    },
+    "@rjsf/validator-ajv8": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -111,18 +111,6 @@
     }
   },
   "peerDependenciesMeta": {
-    "@rjsf/core": {
-      "optional": true
-    },
-    "@rjsf/mui": {
-      "optional": true
-    },
-    "@rjsf/utils": {
-      "optional": true
-    },
-    "@rjsf/validator-ajv8": {
-      "optional": true
-    },
     "react": {
       "optional": true
     },

--- a/src/__testing__/RJSFFormWrapper.test.tsx
+++ b/src/__testing__/RJSFFormWrapper.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Surface-level smoke test for the RJSFFormWrapper export added in
+ * layer5io/sistent#1533.
+ *
+ * The wrapper depends on @rjsf/core + @rjsf/mui + @rjsf/utils +
+ * @rjsf/validator-ajv8, all of which are listed as (optional)
+ * peerDependencies. The test verifies the standalone wrapper module
+ * loads cleanly with those peers installed.
+ *
+ * RJSFFormModal is intentionally NOT imported here: it transitively
+ * pulls in sistent's `Modal` -> `CustomTooltip` -> `Markdown` ->
+ * `react-markdown` ESM chain, which would require widening Jest's
+ * `transformIgnorePatterns` across half a dozen packages. The modal
+ * integration is covered by downstream consumer test suites
+ * (meshery-cloud `make ui-tests`).
+ */
+
+import { RJSFFormWrapper } from '../custom/RJSFFormWrapper/RJSFFormWrapper';
+
+describe('RJSFFormWrapper (sistent#1533)', () => {
+  it('exports a function with stable displayName', () => {
+    expect(typeof RJSFFormWrapper).toBe('function');
+    expect(
+      (RJSFFormWrapper as unknown as { displayName: string }).displayName
+    ).toBe('RJSFFormWrapper');
+  });
+});

--- a/src/__testing__/RJSFFormWrapper.test.tsx
+++ b/src/__testing__/RJSFFormWrapper.test.tsx
@@ -1,27 +1,47 @@
 /**
- * Surface-level smoke test for the RJSFFormWrapper export added in
- * layer5io/sistent#1533.
+ * Surface-level smoke test for the RJSFFormWrapper / RJSFFormModal
+ * exports added in layer5io/sistent#1533.
  *
- * The wrapper depends on @rjsf/core + @rjsf/mui + @rjsf/utils +
- * @rjsf/validator-ajv8, all of which are listed as (optional)
- * peerDependencies. The test verifies the standalone wrapper module
- * loads cleanly with those peers installed.
+ * Two assertions:
  *
- * RJSFFormModal is intentionally NOT imported here: it transitively
- * pulls in sistent's `Modal` -> `CustomTooltip` -> `Markdown` ->
- * `react-markdown` ESM chain, which would require widening Jest's
- * `transformIgnorePatterns` across half a dozen packages. The modal
- * integration is covered by downstream consumer test suites
- * (meshery-cloud `make ui-tests`).
+ * 1. The wrapper module loads cleanly with the @rjsf/* peer-deps
+ *    installed (deep-path import).
+ *
+ * 2. The new symbols are wired through BOTH `src/custom` barrels
+ *    (`index.ts` AND `index.tsx`). sistent ships two barrel files
+ *    at this path — TypeScript's module resolution prefers `.ts`
+ *    over `.tsx`, while tsup's runtime emit reads `.tsx`. If an
+ *    export lands in only one of them, runtime and types diverge:
+ *    the symbol appears in `dist/index.mjs` but is missing from
+ *    `dist/index.d.ts` (or vice versa). The barrel check is done
+ *    statically by reading the source files rather than by
+ *    importing them at runtime, because the runtime barrel pulls
+ *    in sistent's `Markdown` -> `react-markdown` ESM chain that
+ *    would need a widened jest `transformIgnorePatterns`.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { RJSFFormWrapper } from '../custom/RJSFFormWrapper/RJSFFormWrapper';
 
 describe('RJSFFormWrapper (sistent#1533)', () => {
-  it('exports a function with stable displayName', () => {
+  it('exports a function with stable displayName from the deep path', () => {
     expect(typeof RJSFFormWrapper).toBe('function');
     expect(
       (RJSFFormWrapper as unknown as { displayName: string }).displayName
     ).toBe('RJSFFormWrapper');
   });
+
+  it.each([
+    ['index.ts', 'src/custom/index.ts'],
+    ['index.tsx', 'src/custom/index.tsx']
+  ])(
+    'src/custom/%s re-exports the RJSFFormWrapper module',
+    (_label, relPath) => {
+      const full = path.resolve(__dirname, '..', '..', relPath);
+      expect(fs.existsSync(full)).toBe(true);
+      const source = fs.readFileSync(full, 'utf8');
+      expect(source).toMatch(/export\s+\*\s+from\s+['"]\.\/RJSFFormWrapper['"]/);
+    }
+  );
 });

--- a/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, ModalBody, ModalFooter, PrimaryActionButtons } from '../Modal';
+import { RJSFFormWrapper, type RJSFFormWrapperProps } from './RJSFFormWrapper';
+
+/**
+ * Shape of a single RJSF / Ajv validation error. Matches the
+ * `@rjsf/utils` `RJSFValidationError` interface but is duplicated
+ * here as a structural type so sistent does not need to take a
+ * direct dep on `@rjsf/utils`.
+ */
+export interface RJSFValidationError {
+  name?: string;
+  message?: string;
+  property?: string;
+  schemaPath?: string;
+  stack?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params?: any;
+}
+
+export interface RJSFFormModalProps
+  extends Omit<
+    RJSFFormWrapperProps,
+    'onSubmit' | 'formRef' | 'formData' | 'onChange'
+  > {
+  open: boolean;
+  onClose: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSubmit: (formData: any) => void;
+  title: string;
+  buttonTitle: string;
+  helpText?: string;
+  leftHeaderIcon?: React.ReactNode | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  initialData?: any;
+  /**
+   * Invoked when the user clicks the primary button but the form
+   * fails validation (either `validateForm()` returned false or it
+   * threw during schema compilation). Receives the RJSF error list.
+   *
+   * Consumers should surface the errors through their notification
+   * system (toast, inline error banner, etc.). If omitted, validation
+   * failures are silently logged to `console.warn` — preventing the
+   * historical "Import button does nothing" dead-button bug.
+   */
+  onValidationError?: (errors: RJSFValidationError[]) => void;
+}
+
+/**
+ * Sistent's standard modal wrapper around `RJSFFormWrapper`.
+ *
+ * Bundles:
+ *   - sistent `Modal` + `ModalBody` + `ModalFooter` chrome
+ *   - a `PrimaryActionButtons` submit/cancel pair
+ *   - a `validateForm()` guard that surfaces validation errors via
+ *     the `onValidationError` callback (so consumers do not have to
+ *     reimplement the silent-dead-button-vs-toast logic per repo)
+ *
+ * The form's RJSF props (`schema`, `uiSchema`, `widgets`, etc.) are
+ * forwarded directly to `RJSFFormWrapper`.
+ */
+export function RJSFFormModal({
+  open,
+  onClose,
+  onSubmit,
+  title,
+  buttonTitle,
+  helpText,
+  leftHeaderIcon = null,
+  initialData,
+  onValidationError,
+  ...rest
+}: RJSFFormModalProps): JSX.Element {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const formRef = useRef<any>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [formData, setFormData] = useState<any>(initialData ?? {});
+
+  useEffect(() => {
+    if (!open) {
+      setFormData({});
+      return;
+    }
+    setFormData(initialData ?? {});
+  }, [open, initialData]);
+
+  const handleSubmit = (): void => {
+    if (!formRef.current) {
+      return;
+    }
+    let isValid: boolean;
+    try {
+      isValid = formRef.current.validateForm();
+    } catch (err) {
+      const message = (err as Error)?.message ?? String(err);
+      const errors: RJSFValidationError[] = [
+        { stack: `Form could not be validated: ${message}` }
+      ];
+      if (onValidationError) {
+        onValidationError(errors);
+      } else {
+        console.warn('[RJSFFormModal] validateForm threw:', err);
+      }
+      return;
+    }
+    if (!isValid) {
+      const errors: RJSFValidationError[] =
+        formRef.current.state?.errors ?? [];
+      if (onValidationError) {
+        onValidationError(errors);
+      } else {
+        console.warn('[RJSFFormModal] validateForm returned false:', errors);
+      }
+      return;
+    }
+    onSubmit(formRef.current.state.formData);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} closeModal={onClose} title={title} headerIcon={leftHeaderIcon}>
+      <ModalBody>
+        <div style={{ width: '100%' }}>
+          <RJSFFormWrapper
+            {...rest}
+            formData={formData}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onChange={(e: any) => setFormData(e.formData)}
+            formRef={formRef}
+          />
+        </div>
+      </ModalBody>
+      <ModalFooter variant="filled" helpText={helpText}>
+        <PrimaryActionButtons
+          primaryText={buttonTitle}
+          secondaryText="Cancel"
+          primaryButtonProps={{ onClick: handleSubmit }}
+          secondaryButtonProps={{ onClick: onClose }}
+        />
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+RJSFFormModal.displayName = 'RJSFFormModal';

--- a/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
@@ -21,7 +21,7 @@ export interface RJSFValidationError {
 export interface RJSFFormModalProps
   extends Omit<
     RJSFFormWrapperProps,
-    'onSubmit' | 'formRef' | 'formData' | 'onChange'
+    'onSubmit' | 'onError' | 'formRef' | 'formData' | 'onChange' | 'children'
   > {
   open: boolean;
   onClose: () => void;
@@ -29,19 +29,26 @@ export interface RJSFFormModalProps
   onSubmit: (formData: any) => void;
   title: string;
   buttonTitle: string;
+  /**
+   * Label for the secondary (cancel) button. Defaults to `'Cancel'`.
+   * Exposed for i18n.
+   */
+  cancelButtonTitle?: string;
   helpText?: string;
   leftHeaderIcon?: React.ReactNode | null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initialData?: any;
   /**
    * Invoked when the user clicks the primary button but the form
-   * fails validation (either `validateForm()` returned false or it
-   * threw during schema compilation). Receives the RJSF error list.
+   * fails validation. Receives the RJSF error list (whatever
+   * `@rjsf/core`'s `onError` would emit). Consumers should surface
+   * the errors through their notification system (toast, inline
+   * error banner, etc.).
    *
-   * Consumers should surface the errors through their notification
-   * system (toast, inline error banner, etc.). If omitted, validation
-   * failures are silently logged to `console.warn` — preventing the
-   * historical "Import button does nothing" dead-button bug.
+   * If omitted, validation failures are logged to `console.warn` —
+   * preventing the historical "Import button does nothing"
+   * dead-button bug while still defaulting to non-noisy behavior
+   * when the consumer hasn't wired up notifications yet.
    */
   onValidationError?: (errors: RJSFValidationError[]) => void;
 }
@@ -52,9 +59,13 @@ export interface RJSFFormModalProps
  * Bundles:
  *   - sistent `Modal` + `ModalBody` + `ModalFooter` chrome
  *   - a `PrimaryActionButtons` submit/cancel pair
- *   - a `validateForm()` guard that surfaces validation errors via
- *     the `onValidationError` callback (so consumers do not have to
- *     reimplement the silent-dead-button-vs-toast logic per repo)
+ *   - canonical RJSF lifecycle wiring: the primary button calls
+ *     `form.submit()`, which triggers Ajv validation inside RJSF and
+ *     fires either `onSubmit` (on success) or `onError` (on validation
+ *     failure). This avoids reading `formRef.state.errors` directly,
+ *     which is unreliable because RJSF's internal `setState` is async
+ *     and the ref may still expose pre-validation errors immediately
+ *     after `validateForm()`.
  *
  * The form's RJSF props (`schema`, `uiSchema`, `widgets`, etc.) are
  * forwarded directly to `RJSFFormWrapper`.
@@ -65,6 +76,7 @@ export function RJSFFormModal({
   onSubmit,
   title,
   buttonTitle,
+  cancelButtonTitle = 'Cancel',
   helpText,
   leftHeaderIcon = null,
   initialData,
@@ -84,13 +96,15 @@ export function RJSFFormModal({
     setFormData(initialData ?? {});
   }, [open, initialData]);
 
-  const handleSubmit = (): void => {
+  const handlePrimaryClick = (): void => {
     if (!formRef.current) {
       return;
     }
-    let isValid: boolean;
+    // Delegate to RJSF's submit lifecycle — this triggers internal
+    // validation and fan-out to `onSubmit` / `onError` props on the
+    // form, which we pass through below.
     try {
-      isValid = formRef.current.validateForm();
+      formRef.current.submit();
     } catch (err) {
       const message = (err as Error)?.message ?? String(err);
       const errors: RJSFValidationError[] = [
@@ -99,22 +113,24 @@ export function RJSFFormModal({
       if (onValidationError) {
         onValidationError(errors);
       } else {
-        console.warn('[RJSFFormModal] validateForm threw:', err);
+        console.warn('[RJSFFormModal] submit threw:', err);
       }
-      return;
     }
-    if (!isValid) {
-      const errors: RJSFValidationError[] =
-        formRef.current.state?.errors ?? [];
-      if (onValidationError) {
-        onValidationError(errors);
-      } else {
-        console.warn('[RJSFFormModal] validateForm returned false:', errors);
-      }
-      return;
-    }
-    onSubmit(formRef.current.state.formData);
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleFormSubmit = (e: any): void => {
+    onSubmit(e.formData);
     onClose();
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleFormError = (errors: any[]): void => {
+    if (onValidationError) {
+      onValidationError(errors as RJSFValidationError[]);
+    } else {
+      console.warn('[RJSFFormModal] form validation failed:', errors);
+    }
   };
 
   return (
@@ -126,15 +142,23 @@ export function RJSFFormModal({
             formData={formData}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onChange={(e: any) => setFormData(e.formData)}
+            onSubmit={handleFormSubmit}
+            onError={handleFormError}
             formRef={formRef}
-          />
+          >
+            {/*
+              Suppress RJSF's default in-form submit button — the
+              modal's PrimaryActionButtons owns the submit affordance.
+            */}
+            <></>
+          </RJSFFormWrapper>
         </div>
       </ModalBody>
       <ModalFooter variant="filled" helpText={helpText}>
         <PrimaryActionButtons
           primaryText={buttonTitle}
-          secondaryText="Cancel"
-          primaryButtonProps={{ onClick: handleSubmit }}
+          secondaryText={cancelButtonTitle}
+          primaryButtonProps={{ onClick: handlePrimaryClick }}
           secondaryButtonProps={{ onClick: onClose }}
         />
       </ModalFooter>

--- a/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
@@ -34,6 +34,11 @@ export interface RJSFFormWrapperProps
  * Pairs with `RJSFFormModal` for the common modal-form pattern, or
  * can be embedded directly when the consumer owns the surrounding
  * chrome.
+ *
+ * `children` is passed through unchanged — when omitted, RJSF renders
+ * its own default in-form submit button. Consumers (or
+ * `RJSFFormModal`) that own the submit affordance should explicitly
+ * pass an empty fragment to suppress it.
  */
 export function RJSFFormWrapper({
   formRef,
@@ -48,13 +53,7 @@ export function RJSFFormWrapper({
         ref={formRef as any}
         {...rest}
       >
-        {/*
-          @rjsf/core renders an in-form submit button when `children`
-          is empty. Consumers that own the submit affordance (e.g.
-          `RJSFFormModal`'s footer button) pass an empty fragment so
-          RJSF suppresses its own button.
-        */}
-        {children ?? <></>}
+        {children}
       </MuiRJSFForm>
     </SistentThemeProvider>
   );

--- a/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
@@ -1,0 +1,63 @@
+import { withTheme, type FormProps } from '@rjsf/core';
+import { Theme as MaterialUITheme } from '@rjsf/mui';
+import validator from '@rjsf/validator-ajv8';
+import React, { type Ref } from 'react';
+import { SistentThemeProvider } from '../../theme';
+
+const MuiRJSFForm = withTheme(MaterialUITheme);
+
+/**
+ * Props accepted by `RJSFFormWrapper`. Inherits the full
+ * `@rjsf/core` `FormProps` surface (schema, uiSchema, formData,
+ * onChange, onSubmit, liveValidate, widgets, templates, fields, …)
+ * minus `validator` — the wrapper pins the validator to the canonical
+ * `@rjsf/validator-ajv8` default, which is preconfigured for the
+ * RJSF form schemas published from `@meshery/schemas`.
+ *
+ * The `formRef` prop is a convenience alias for the form instance
+ * ref — consumers use it to call `validateForm()` and read the
+ * post-validation `state.errors` / `state.formData`.
+ */
+export interface RJSFFormWrapperProps
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  extends Omit<FormProps<any, any, any>, 'validator' | 'children'> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  formRef?: Ref<any>;
+  children?: React.ReactNode;
+}
+
+/**
+ * Sistent's standard RJSF form wrapper. Pre-configures the validator
+ * and theme so consumers (Meshery Cloud, Meshery, Meshery Extensions)
+ * stop maintaining parallel RJSF setups.
+ *
+ * Pairs with `RJSFFormModal` for the common modal-form pattern, or
+ * can be embedded directly when the consumer owns the surrounding
+ * chrome.
+ */
+export function RJSFFormWrapper({
+  formRef,
+  children,
+  ...rest
+}: RJSFFormWrapperProps): JSX.Element {
+  return (
+    <SistentThemeProvider>
+      <MuiRJSFForm
+        validator={validator}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ref={formRef as any}
+        {...rest}
+      >
+        {/*
+          @rjsf/core renders an in-form submit button when `children`
+          is empty. Consumers that own the submit affordance (e.g.
+          `RJSFFormModal`'s footer button) pass an empty fragment so
+          RJSF suppresses its own button.
+        */}
+        {children ?? <></>}
+      </MuiRJSFForm>
+    </SistentThemeProvider>
+  );
+}
+
+RJSFFormWrapper.displayName = 'RJSFFormWrapper';

--- a/src/custom/RJSFFormWrapper/index.ts
+++ b/src/custom/RJSFFormWrapper/index.ts
@@ -1,0 +1,6 @@
+export { RJSFFormWrapper, type RJSFFormWrapperProps } from './RJSFFormWrapper';
+export {
+  RJSFFormModal,
+  type RJSFFormModalProps,
+  type RJSFValidationError
+} from './RJSFFormModal';

--- a/src/custom/index.ts
+++ b/src/custom/index.ts
@@ -3,4 +3,5 @@ export * from './CustomTooltip';
 export * from './HelperTextPopover';
 export * from './Markdown';
 export * from './Modal';
+export * from './RJSFFormWrapper';
 export * from './StyledAccordion';

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -166,6 +166,7 @@ export * from './DashboardWidgets';
 export * from './Dialog';
 export * from './permissions';
 export * from './ResourceDetailFormatters';
+export * from './RJSFFormWrapper';
 export * from './ShareModal';
 export * from './UserSearchField';
 export * from './Workspaces';


### PR DESCRIPTION
Closes #1533.

## Summary

Adds two new exports under `@sistent/sistent`:

- **`RJSFFormWrapper`** — thin wrapper around `withTheme(MaterialUITheme)` that pins `@rjsf/validator-ajv8` as the default validator and wraps the form in `SistentThemeProvider`. Forwards every other `@rjsf/core` `FormProps` (schema, uiSchema, formData, onChange, widgets, templates, fields, …) through unchanged. Accepts a `formRef` prop for callers that need to call `validateForm()` themselves.
- **`RJSFFormModal`** — sistent's standard form modal pattern. Bundles `Modal` + `ModalBody` + `ModalFooter` + `PrimaryActionButtons` chrome around `RJSFFormWrapper`, with a `validateForm()` guard that surfaces validation errors via an `onValidationError` callback instead of silently no-op'ing the submit button (the historical "Import button does nothing" bug — see [meshery-cloud#5273](https://github.com/layer5io/meshery-cloud/issues/5273)).

The `@rjsf/*` packages are added as **optional peer-dependencies** so sistent doesn't force consumers to pull them transitively. Consumers that don't render forms (or pin their own `@rjsf` versions) are unaffected.

Bumps `@meshery/schemas` dev-dep `1.2.18` → `1.2.19` so sistent's existing form re-exports stay aligned with the canonical wire contract that dropped `$schema: draft-07` upstream ([meshery/schemas#893](https://github.com/meshery/schemas/pull/893)).

## Why

Every downstream consumer of `@meshery/schemas` currently maintains its own RJSF wrapper (cloud's `ui/components/general/rjsf/index.tsx`, meshery's `ui/components/MesheryRJSFForm`, and the same pattern in meshery-extensions). Each one separately wires the validator config, the MUI theme, the `SistentThemeProvider`, and the submit/validation flow. The validator config in particular keeps drifting between repos.

Sistent v0.21.10 already started centralizing schema artifacts via re-exports (#1531). Centralizing the wrapper is the natural next step: validator config lives in one place and ships through one version bump.

## Test plan

- [x] `npm run build` (tsup + dts) — clean; new exports compile and emit types
- [x] `npm run lint` — clean
- [x] `npx jest` — 48/48 suites pass (one new smoke test for the `RJSFFormWrapper` surface)
- [ ] Smoke verification in a consumer: pending — once this lands and ships in a sistent release, meshery-cloud and meshery will migrate their local wrappers in follow-up PRs

## Out-of-scope follow-ups

- **meshery-cloud** should migrate `GenericRJSFModal` to `RJSFFormModal` and `RJSFWrapper` to `RJSFFormWrapper` (drops two custom files).
- **meshery** should do the same migration on its side.
- The custom widgets/templates currently maintained per-consumer (`CustomTextWidget`, `CustomFileWidget`, `CustomSelectWidget`, custom field templates, etc.) are NOT centralized in sistent in this PR. `RJSFFormWrapper` accepts them via the standard `@rjsf/core` `widgets` / `templates` / `fields` props, so consumers keep working today; promoting them into sistent is a separate chore.