### PR TITLE
feat: add AccountTreeIcon component

### DIFF
--- a/src/icons/AccountTree/AccountTreeIcon.tsx
+++ b/src/icons/AccountTree/AccountTreeIcon.tsx
@@ -1,0 +1,22 @@
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const AccountTreeIcon = ({
+    width = DEFAULT_WIDTH,
+    height = DEFAULT_HEIGHT,
+    ...props
+}: IconProps): JSX.Element => {
+    return (
+        <svg
+            width={width}
+            height={height}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            {...props}
+            >
+            <path d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z" />
+            </svg>
+    );
+};
+
+export default AccountTreeIcon;

--- a/src/icons/AccountTree/index.ts
+++ b/src/icons/AccountTree/index.ts
@@ -1,0 +1,1 @@
+export { default as AccountTreeIcon } from './AccountTreeIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -5,7 +5,8 @@ export * from './Add';
 export * from './AddCircle';
 export * from './Alert';
 export * from './Application';
-export * from './AppRegistration'
+export * from './AppRegistration';
+export * from './AccountTree';
 export * from './ArrowBack';
 export * from './ArrowCompress';
 export * from './ArrowDownward';


### PR DESCRIPTION
## **Description**

This PR adds the `AccountTreeIcon` component to Sistent to reduce dependency on `@mui/icons-material` and ensure design consistency across Layer5 products. The icon preserves the exact UX in Meshery's index.ts component without visual regression.

## **Changes Made**

- Created `AccountTreeIcon` component in `src/icons/AccountTree/`
- Added SVG path from Material-UI's AccountTree icon
- Updated `src/icons/index.ts` to export the new icon
- Verified component works with existing tests and build process

## **Related Issues**

Fixes #1548

## **Testing**

- ✅ `npm run build` - Build succeeds
- ✅ `npm test` - All 266 tests pass
- ✅ `npm run lint` - Code formatting verified
- ✅ No breaking changes to existing components

## **Notes for Reviewers**

The AccountTreeIcon follows the existing Sistent icon pattern:
- Single SVG path from MUI's Material Icons
- Supports width/height customization via props
- Consistent with other icon implementations in the library

## **[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits with `git commit -s`