### PR TITLE
 fix(Stepper): use slots API for custom step icons and fix alignment (MUI v9)

### DIFF
--- a/src/custom/Stepper/index.tsx
+++ b/src/custom/Stepper/index.tsx
@@ -135,6 +135,7 @@ const CustomizedStepper: React.FC<CustomizedStepperPropsI> = ({
           activeStep={activeStep}
           connector={<ColorlibConnector />}
           data-testid="stepper-container"
+          sx={{ flex: 1 }}
         >
           {stepLabels.map((label, index) => (
             <Step key={label} data-testid={`step-${index}`}>

--- a/src/custom/Stepper/index.tsx
+++ b/src/custom/Stepper/index.tsx
@@ -112,6 +112,10 @@ function ColorlibStepIcon(props: ColorlibStepIconPropsI) {
   );
 }
 
+const stepLabelSlots = {
+  stepIcon: ColorlibStepIcon
+};
+
 const CustomizedStepper: React.FC<CustomizedStepperPropsI> = ({
   stepLabels,
   activeStep,
@@ -121,6 +125,13 @@ const CustomizedStepper: React.FC<CustomizedStepperPropsI> = ({
   'data-testid': testId = 'customized-stepper'
 }) => {
   const theme = useTheme();
+
+  const stepLabelSlotProps = useMemo(
+    () => ({
+      stepIcon: { icons } as Partial<ColorlibStepIconPropsI>
+    }),
+    [icons]
+  );
 
   return (
     <Stack data-testid={testId}>
@@ -141,12 +152,8 @@ const CustomizedStepper: React.FC<CustomizedStepperPropsI> = ({
             <Step key={label} data-testid={`step-${index}`}>
               <StyledStepLabel
                 data-testid={`step-label-${index}`}
-                slots={{
-                  stepIcon: ColorlibStepIcon
-                }}
-                slotProps={{
-                  stepIcon: { icons } as Partial<ColorlibStepIconPropsI>
-                }}
+                slots={stepLabelSlots}
+                slotProps={stepLabelSlotProps}
               >
                 {label}
               </StyledStepLabel>

--- a/src/custom/Stepper/index.tsx
+++ b/src/custom/Stepper/index.tsx
@@ -140,7 +140,12 @@ const CustomizedStepper: React.FC<CustomizedStepperPropsI> = ({
             <Step key={label} data-testid={`step-${index}`}>
               <StyledStepLabel
                 data-testid={`step-label-${index}`}
-                StepIconComponent={(props) => <ColorlibStepIcon {...props} icons={icons} />}
+                slots={{
+                  stepIcon: ColorlibStepIcon
+                }}
+                slotProps={{
+                  stepIcon: { icons } as Partial<ColorlibStepIconPropsI>
+                }}
               >
                 {label}
               </StyledStepLabel>


### PR DESCRIPTION
**Root Cause:**
- **Missing Icons:** MUI v9 deprecated the `StepIconComponent` prop on StepLabel and replaced it with the slots/slotProps API. The old prop is silently ignored, causing the stepper to fall back to default numbered circles.
- **Misalignment:** For accessibility, MUI v9 changed the <Stepper> component to render as an `<ol>` element instead of a `<div> `Because of this, it no longer defaults to a full-width block-level element, causing the stepper to shrink and misalign to the left.

**Fix:**
- Replaced StepIconComponent with slots={{ stepIcon: ColorlibStepIcon }} and passed the icons array via slotProps.
- Added sx={{ flex: 1 }} to the <Stepper> so it naturally grows to fill the flexbox container, accounting for the `<div>` to `<ol>` DOM change and restoring proper centering.

**Screenshots**
| Before | After |
|--------|--------|
| <img width="420" height="325" alt="before" src="https://github.com/user-attachments/assets/9a8aa755-c1e9-4964-92d6-606832b71c0c" /> | <img width="420" height="325" alt="after" src="https://github.com/user-attachments/assets/23d4eae5-a2aa-4e93-9410-d64f1ea19e55" /> |


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
