### PR TITLE
fix(redux-persist): render children immediately to avoid SSR hydration mismatch

### DIFF
--- a/src/redux-persist/PersistedStateProvider.tsx
+++ b/src/redux-persist/PersistedStateProvider.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ThunkDispatch } from '@reduxjs/toolkit';
-import { FC, ReactNode, useEffect, useState } from 'react';
+import { FC, ReactNode, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Dispatch } from 'redux';
 import { RehydrateStateAction } from './initReduxPersist';
@@ -10,43 +10,44 @@ interface PersistedStateProviderProps {
   loadPersistedState: () => (dispatch: Dispatch<RehydrateStateAction>) => void;
 }
 
+/**
+ * Dispatches the persisted-state rehydration action on mount and renders
+ * children immediately. Returning a different tree on the first render
+ * (e.g. `null` while a `loading` flag flips) breaks server-side hydration
+ * for any host application that statically pre-renders pages: the server-
+ * generated HTML contains the page DOM, the client's first render returns
+ * `null`, and the resulting mismatch triggers React's recovery path —
+ * which, in Next.js's Pages Router, calls `Router.change` against the
+ * current URL and throws "Invariant: attempted to hard navigate to the
+ * same URL". The downstream symptom in host apps is a page that never
+ * completes its first paint; observed against Meshery Cloud's /login
+ * static export (Next.js 16, React 19), where the unhandled promise
+ * rejection out of `Router.change` short-circuited `useAuthFlow`'s
+ * fetch and left a `<CircularProgress />` running indefinitely.
+ *
+ * Behaviour change for consumers: components that read rehydrated slices
+ * will render once with their initial-state defaults, then re-render
+ * after the rehydrate action commits. That's identical to how
+ * `redux-persist`'s own `PersistGate` operates in its default
+ * (non-blocking) mode, and to how React-Redux selectors behave during
+ * a normal mount cycle. If a specific consumer needs to block UI on
+ * persisted-state availability it should gate locally on a selector
+ * (`useSelector(state => state.<slice>.hydrated)`) rather than have this
+ * provider gate the whole tree.
+ */
 export const PersistedStateProvider: FC<PersistedStateProviderProps> = ({
   children,
   loadPersistedState
 }) => {
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
   const dispatch = useDispatch<ThunkDispatch<any, unknown, RehydrateStateAction>>();
 
   useEffect(() => {
-    if (!loading) {
-      return;
-    }
-
-    let error: Error | null = null;
     try {
       dispatch(loadPersistedState());
     } catch (e) {
-      error = e as Error;
+      console.error('Error Loading Persisted State', e);
     }
-
-    // Use queueMicrotask to defer state updates and avoid cascading renders
-    queueMicrotask(() => {
-      setLoading(false);
-      if (error) {
-        setError(error);
-      }
-    });
-  }, [loading, dispatch, loadPersistedState]);
-
-  if (error) {
-    console.error('Error Loading Persisted State', error);
-  }
-
-  if (loading) {
-    return null;
-  }
+  }, [dispatch, loadPersistedState]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
The previous implementation returned `null` on the first render while a
`loading` state flag flipped, then mounted children on the next tick
after dispatching `loadPersistedState`. That broke server-side hydration
for any host application that statically pre-renders pages:

  - Server-generated HTML contains the page DOM (rendered with default
    Redux state, since persisted-state lookup is browser-only).
  - Client's first render returns `null` from this provider.
  - React detects the hydration mismatch and triggers its recovery path.
  - In Next.js's Pages Router, recovery calls `Router.change` against
    the current URL and throws "Invariant: attempted to hard navigate
    to the same URL".
  - The unhandled promise rejection out of `Router.change` short-
    circuits any in-flight effect on the page.

Observed against Meshery Cloud's /login static export (Next.js 16, React
19): the `useAuthFlow` hook's data fetch never fired, and the page sat
on its loading spinner indefinitely. Strip the conditional null-return,
dispatch the rehydrate on mount, render children unconditionally. Same
final state, no hydration discrepancy.

Behavior change for consumers: components that read rehydrated slices
render once with initial-state defaults, then re-render after the
rehydrate action commits — identical to redux-persist's own PersistGate
in its default (non-blocking) mode. Consumers that need to block on
persisted-state availability should gate locally via a selector
(`useSelector(state => state.<slice>.hydrated)`) rather than depending
on this provider to gate the whole tree.


