### PR TITLE
Fix CSS-in-JS warning for msOverflowStyle

### DIFF
--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -122,10 +122,10 @@ export const ModalBody = styled(Paper)(({ theme }) => ({
   overflowY: 'auto',
   height: '100%',
   scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
   '&::-webkit-scrollbar': {
     display: 'none'
-  },
-  '-ms-overflow-style': 'none'
+  }
 }));
 
 const StyledFooter = styled('div', {

--- a/src/custom/Workspaces/styles.tsx
+++ b/src/custom/Workspaces/styles.tsx
@@ -399,10 +399,10 @@ export const RecentActivityGrid = styled(Grid2)({
   maxHeight: '14.5rem',
   overflowY: 'scroll',
   scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
   '&::-webkit-scrollbar': {
     display: 'none'
-  },
-  '-ms-overflow-style': 'none'
+  }
 });
 
 export const DateGrid = styled(Grid2)(({ theme }) => ({


### PR DESCRIPTION
**Notes for Reviewers**
### Description
This PR fixes a CSS-in-JS warning caused by using the kebab-case vendor-prefixed property -ms-overflow-style inside the ModalBody styled component.
### Changes
**Replaced:**
```ts
'-ms-overflow-style': 'none'
```
With:
```ts
msOverflowStyle: 'none'
```
### Result
Removes the React/MUI CSS-in-JS warning.
Preserves the intended scrollbar hiding behavior for legacy Microsoft browsers.
Keeps existing ::-webkit-scrollbar and scrollbarWidth behavior unchanged.



This PR fixes #1571

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
