### PR TITLE
Migrate deprecated InputProps, inputProps, and InputLabelProps to slotProps API for MUI v9

### DIFF
--- a/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
@@ -146,9 +146,11 @@ const TeamSearchField: React.FC<TeamSearchFieldProps> = ({
             error={error}
             helperText={error ? 'Team Already Selected' : ''}
             fullWidth
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: isLoading ? <CircularProgress color="inherit" size={20} /> : null
+            slotProps={{
+              input: {
+                ...params.slotProps?.input,
+                endAdornment: isLoading ? <CircularProgress color="inherit" size={20} /> : null
+              }
             }}
           />
         )}

--- a/src/custom/InputSearchField/InputSearchField.tsx
+++ b/src/custom/InputSearchField/InputSearchField.tsx
@@ -127,18 +127,20 @@ const InputSearchField: React.FC<InputSearchFieldProps> = ({
             error={!!error}
             helperText={error}
             fullWidth
-            InputLabelProps={{
-              style: {
-                fontFamily: 'inherit'
+            slotProps={{
+              inputLabel: {
+                style: {
+                  fontFamily: 'inherit'
+                }
+              },
+              input: {
+                ...params.slotProps?.input,
+                endAdornment: (
+                  <React.Fragment>
+                    {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                  </React.Fragment>
+                )
               }
-            }}
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: (
-                <React.Fragment>
-                  {isLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                </React.Fragment>
-              )
             }}
           />
         )}

--- a/src/custom/TransferModal/TransferList/TransferList.tsx
+++ b/src/custom/TransferModal/TransferList/TransferList.tsx
@@ -258,8 +258,10 @@ function TransferList({
                   checked={checked.indexOf(item) !== -1}
                   tabIndex={-1}
                   disableRipple
-                  inputProps={{
-                    'aria-labelledby': labelId
+                  slotProps={{
+                    input: {
+                      'aria-labelledby': labelId
+                    }
                   }}
                 />
               </ListItem>

--- a/src/custom/TypingFilter/index.tsx
+++ b/src/custom/TypingFilter/index.tsx
@@ -116,33 +116,35 @@ export function TypingFilter({ filterSchema, handleFilter, autoFilter = false }:
         value={filterState.context?.value}
         onChange={handleFilterChange}
         onFocus={handleFocus}
-        InputProps={{
-          startAdornment: (
-            <InputAdornment position="start">
-              {' '}
-              <ContentFilterIcon
-              /*
-                  fill={(theme) => {
-                    theme.palette.iconMain;
-                  }}
-                  */
-              />{' '}
-            </InputAdornment>
-          ),
-          endAdornment: (
-            <InputAdornment position="end">
-              <IconButton onClick={handleClear}>
-                {filterState.state !== FilteringState.IDLE && (
-                  <CrossCircleIcon
-                  /*fill={(theme) => {
-                        theme.palette.iconMain;
-                      }}
-                      */
-                  />
-                )}
-              </IconButton>
-            </InputAdornment>
-          )
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                {' '}
+                <ContentFilterIcon
+                /*
+                    fill={(theme) => {
+                      theme.palette.iconMain;
+                    }}
+                    */
+                />{' '}
+              </InputAdornment>
+            ),
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton onClick={handleClear}>
+                  {filterState.state !== FilteringState.IDLE && (
+                    <CrossCircleIcon
+                    /*fill={(theme) => {
+                          theme.palette.iconMain;
+                        }}
+                        */
+                    />
+                  )}
+                </IconButton>
+              </InputAdornment>
+            )
+          }
         }}
       />
       <Popper

--- a/src/custom/UniversalFilter.tsx
+++ b/src/custom/UniversalFilter.tsx
@@ -109,9 +109,10 @@ function UniversalFilter({
                 width: '20rem',
                 marginBottom: '1rem'
               }}
-              inputProps={{
-                'aria-label': 'Without label',
-                'data-testid': `${testId}-select-${filterColumn}`
+              slotProps={{
+                input: {
+                  'aria-label': 'Without label'
+                }
               }}
               displayEmpty
             >

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -155,11 +155,15 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
                   paddingBlock: '0.1rem'
                 }
               }}
-              InputProps={{
-                ...params.InputProps,
-                endAdornment: (
-                  <>{searchUserLoading ? <CircularProgress color="inherit" size={20} /> : null}</>
-                )
+              slotProps={{
+                input: {
+                  ...params.slotProps?.input,
+                  endAdornment: (
+                    <>
+                      {searchUserLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                    </>
+                  )
+                }
               }}
             />
           )}

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -182,18 +182,20 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             label={label}
             error={!!error}
             helperText={error}
-            InputLabelProps={{
-              style: {
-                fontFamily: 'inherit'
+            slotProps={{
+              inputLabel: {
+                style: {
+                  fontFamily: 'inherit'
+                }
+              },
+              input: {
+                ...params.slotProps?.input,
+                endAdornment: (
+                  <React.Fragment>
+                    {isUserSearchLoading ? <CircularProgress color="inherit" size={20} /> : null}
+                  </React.Fragment>
+                )
               }
-            }}
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: (
-                <React.Fragment>
-                  {isUserSearchLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                </React.Fragment>
-              )
             }}
           />
         )}


### PR DESCRIPTION
**Notes for Reviewers**

   Migrated deprecated MUI props to the new `slotProps` API 
 
- **TextField**: `InputProps` → `slotProps.input`, `InputLabelProps` → `slotProps.inputLabel`
- **Checkbox**: `inputProps` → `slotProps.input`
- **Select**: `inputProps` → `slotProps.input`

Also updated Autocomplete `renderInput` params from `params.InputProps` to `params.slotProps?.input`.

**References**
- https://mui.com/material-ui/migration/upgrade-to-v9/#input-props
- https://mui.com/material-ui/migration/migrating-from-deprecated-apis/#textfield
- https://mui.com/material-ui/api/text-field/


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
