### PR TITLE
fix: migrate Box and Grid2 system props to sx for MUI v9

### DIFF
--- a/examples/next-16/components/Icon/index.jsx
+++ b/examples/next-16/components/Icon/index.jsx
@@ -58,7 +58,7 @@ export default function IconColorDemo() {
       <Dialog open={open} onClose={handleClose} maxWidth="lg" fullWidth>
         <DialogTitle>Light Mode Icon Palette</DialogTitle>
         <DialogContent dividers>
-          <Grid container spacing={2} alignItems="center">
+          <Grid container spacing={2} sx={{ alignItems: 'center' }}>
             {allColors.map(({ token, color }) => (
               <Grid item xs={3} sm={2} md={1} key={token}>
                 <Tooltip title={`${token} (${color})`} arrow>

--- a/src/custom/CatalogDesignTable/AuthorCell.tsx
+++ b/src/custom/CatalogDesignTable/AuthorCell.tsx
@@ -32,7 +32,7 @@ const AuthorCell: React.FC<AuthorCellProps> = ({
     <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
       <Grid2
         container
-        alignItems="center"
+        sx={{ alignItems: 'center' }}
         style={maxWidth ? { width: 'max-content' } : { width: '' }}
       >
         <Grid2>

--- a/src/custom/CatalogDesignTable/AuthorCell.tsx
+++ b/src/custom/CatalogDesignTable/AuthorCell.tsx
@@ -32,8 +32,7 @@ const AuthorCell: React.FC<AuthorCellProps> = ({
     <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
       <Grid2
         container
-        sx={{ alignItems: 'center' }}
-        style={maxWidth ? { width: 'max-content' } : { width: '' }}
+        sx={{ alignItems: 'center', width: maxWidth ? 'max-content' : undefined }}
       >
         <Grid2>
           <Box sx={{ color: 'text.secondary', mr: 1 }}>

--- a/src/custom/InputSearchField/InputSearchField.tsx
+++ b/src/custom/InputSearchField/InputSearchField.tsx
@@ -147,7 +147,7 @@ const InputSearchField: React.FC<InputSearchFieldProps> = ({
         renderOption={(props, option: Option) => (
           <li {...props} key={option.id}>
             <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
-              <Grid2 container alignItems="center">
+              <Grid2 container sx={{ alignItems: 'center' }}>
                 <Grid2>
                   <Box sx={{ color: 'text.secondary', mr: 2 }}>{iconComponent}</Box>
                 </Grid2>

--- a/src/custom/Panel/Panel.tsx
+++ b/src/custom/Panel/Panel.tsx
@@ -81,7 +81,7 @@ const Panel_: React.FC<PanelProps> = ({
             <ErrorBoundary>
               <div className="drag-handle">
                 <DrawerHeader>
-                  <Box display="flex" justifyContent="flex-end" padding="8px">
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end', padding: '8px' }}>
                     {toggleExpandAll && (
                       <Tooltip title={areAllExpanded ? 'Collapse All' : 'Expand All'}>
                         <CustomIconButton onClick={toggleExpandAll}>

--- a/src/custom/PerformersSection/PerformersSection.tsx
+++ b/src/custom/PerformersSection/PerformersSection.tsx
@@ -260,7 +260,7 @@ const PerformersSection: React.FC<PerformersSectionProps> = ({
     <ErrorBoundary>
       <MainContainer>
         <TitleBox>
-          <Box display={'flex'} alignItems="center" gap={1}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Title>Top Performers</Title>
             <TropyIcon
               style={{

--- a/src/custom/ResourceDetailFormatters/Formatter.tsx
+++ b/src/custom/ResourceDetailFormatters/Formatter.tsx
@@ -774,7 +774,7 @@ export const CollapsibleSectionFormatter: React.FC<CollapsibleSectionProps> = ({
     <CollapsibleSectionContainer style={{ marginLeft: margin }}>
       <CollapsibleSectionTitle openSection={openSection} onClick={toggleOpen}>
         <StyledTitle variant="body1">{title}</StyledTitle>
-        <Box sx={{ display: 'flex', gap: 1 }} style={{ marginRight: margin }}>
+        <Box sx={{ display: 'flex', gap: 1, marginRight: `${margin}px` }}>
           <StyledTitle
             variant="body2"
             style={{

--- a/src/custom/ResourceDetailFormatters/Formatter.tsx
+++ b/src/custom/ResourceDetailFormatters/Formatter.tsx
@@ -151,7 +151,7 @@ export const PortsFormatter: React.FC<PortsFormatterProps> = ({ data }) => {
     <Box>
       {data?.map((item, index) => (
         <Details noPadding key={index}>
-          <Box display="flex" alignItems="center">
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
             {item.name && <Typography variant="body1">{`${item.name}: `} </Typography>}
             <ElementData>{`(${item.containerPort || item.port}/${item.protocol})`}</ElementData>
           </Box>
@@ -311,7 +311,7 @@ export const LabelFormatter: React.FC<LabelFormatterProps> = ({
   };
 
   return (
-    <Box display="flex" gap={1} flexWrap={'wrap'}>
+    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
       {data.map((item, index) => {
         return (
           <ElementData key={index}>
@@ -501,12 +501,14 @@ export const TableDataFormatter: React.FC<TableDataFormatterProps> = ({
 
   return (
     <Box
-      width={'100%'}
-      display={'flex'}
-      flexDirection={'column'}
-      gap={1}
-      minWidth={'30rem'}
-      marginBlock={1}
+      sx={{
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        minWidth: '30rem',
+        marginBlock: 1
+      }}
     >
       {title && <Typography variant="body1">{title}</Typography>}
 
@@ -546,7 +548,14 @@ export const TextWithLinkFormatter: React.FC<TextWithLinkFormatterProps> = ({
   return variant === 'row' ? (
     <KeyValueInRow Key={title} Value={LinkComponent} />
   ) : (
-    <Box display={'flex'} flexDirection={'column'} gap={'0.3rem'} marginBlock={'0.4rem'}>
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.3rem',
+        marginBlock: '0.4rem'
+      }}
+    >
       <Typography variant="body1">{title}</Typography>
       {LinkComponent}
     </Box>
@@ -562,7 +571,7 @@ const DetailSection: React.FC<DetailSectionProps> = ({
     return null;
   }
   return (
-    <Box width={'100%'}>
+    <Box sx={{ width: '100%' }}>
       <KeyValueInRow
         Key={title}
         Value={
@@ -584,7 +593,7 @@ export const ContainerFormatter: React.FC<ContainerFormatterProps> = ({
   const stateValues = Object.values(state)?.[0] || {};
   const startedAt = stateValues ? stateValues?.startedAt : null;
   return (
-    <Box display="flex" flexDirection="column" gap={'0.5rem'}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
       <KeyValueInRow
         Key={'Status'}
         Value={<StatusFormatter status={status} rightPosition="1rem" />}
@@ -631,11 +640,11 @@ export const ContainerFormatter: React.FC<ContainerFormatterProps> = ({
       <KeyValueInRow
         Key="Volume Mounts"
         Value={
-          <Box display={'flex'} flexDirection={'column'} gap={1}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
             {containerSpec?.volumeMounts?.map((item, index) => {
               const roStatus = item?.readOnly ? ' (RO)' : ' (RW)';
               return (
-                <Box display={'flex'} key={index} flexWrap={'wrap'} gap={'0.25rem 0.5rem'}>
+                <Box key={index} sx={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem 0.5rem' }}>
                   <ElementData key={index}>
                     <StyledChip label={item?.mountPath} size="small" />
                   </ElementData>
@@ -716,11 +725,11 @@ export const SecretFormatter: React.FC<SecretFormatterProps> = ({ data }) => {
   const keys = Object.keys(parsedData);
 
   return (
-    <Box display="flex" flexDirection="column" gap={1}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       {keys.map((key) => (
-        <Box key={key} display="flex" gap={4} alignItems={'center'}>
+        <Box key={key} sx={{ display: 'flex', gap: 4, alignItems: 'center' }}>
           <Typography variant="body1">{key}</Typography>
-          <Box display="flex" alignItems="center" gap={1}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Typography>{showSecret[key] ? parsedData[key] : '••••••••'}</Typography>
             <IconButton
               size="small"
@@ -765,7 +774,7 @@ export const CollapsibleSectionFormatter: React.FC<CollapsibleSectionProps> = ({
     <CollapsibleSectionContainer style={{ marginLeft: margin }}>
       <CollapsibleSectionTitle openSection={openSection} onClick={toggleOpen}>
         <StyledTitle variant="body1">{title}</StyledTitle>
-        <Box display={'flex'} gap={1} style={{ marginRight: margin }}>
+        <Box sx={{ display: 'flex', gap: 1 }} style={{ marginRight: margin }}>
           <StyledTitle
             variant="body2"
             style={{

--- a/src/custom/TransferModal/TransferList/TransferList.tsx
+++ b/src/custom/TransferModal/TransferList/TransferList.tsx
@@ -290,7 +290,7 @@ function TransferList({
   );
 
   return (
-    <Grid2 container justifyContent="center" alignItems="center">
+    <Grid2 container sx={{ justifyContent: 'center', alignItems: 'center' }}>
       <ListGrid>
         <ListHeading>
           Available {name} ({left.length})
@@ -298,7 +298,7 @@ function TransferList({
         {customList(left, emptyStateIconLeft, emtyStateMessageLeft, 'leftList')}
       </ListGrid>
       <ButtonGrid>
-        <Grid2 container direction="column" alignItems="center">
+        <Grid2 container direction="column" sx={{ alignItems: 'center' }}>
           <TransferButton
             variant="outlined"
             size="small"

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -108,7 +108,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
 
   return (
     <>
-      <Box display="flex" alignItems="center" justifyContent="space-between" gap={1}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
         <Autocomplete
           id="user-search-field"
           sx={{ width: '100%' }}
@@ -170,7 +170,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           renderOption={(props: React.HTMLAttributes<HTMLLIElement>, option) => (
             // @ts-expect-error Props need to be passed to BOX component to make sure styles getting updated
             <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
-              <Grid2 container alignItems="center">
+              <Grid2 container sx={{ alignItems: 'center' }}>
                 <Grid2>
                   <Box sx={{ color: 'text.secondary', mr: 2 }}>
                     <Avatar alt={option.firstName} src={option.avatarUrl}>

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -203,7 +203,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
           <li {...props} id={option.userId}>
             <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
               {' '}
-              <Grid2 container alignItems="center">
+              <Grid2 container sx={{ alignItems: 'center' }}>
                 <Grid2>
                   <Box sx={{ color: 'text.secondary', mr: 2 }}>
                     <Avatar alt={option.firstName} src={option.avatarUrl}>

--- a/src/custom/UsersTable/UserTableAvatarInfo.tsx
+++ b/src/custom/UsersTable/UserTableAvatarInfo.tsx
@@ -23,7 +23,7 @@ const UserTableAvatarInfo: React.FC<UserTableAvatarInfoProps> = ({
   };
 
   return (
-    <Grid2 container alignItems="center">
+    <Grid2 container sx={{ alignItems: 'center' }}>
       <Grid2>
         <Box
           sx={{

--- a/src/custom/Workspaces/WorkspaceContentMoveModal.tsx
+++ b/src/custom/Workspaces/WorkspaceContentMoveModal.tsx
@@ -178,7 +178,7 @@ const WorkspaceContentMoveModal: React.FC<WorkspaceContentMoveModalProps> = ({
           Current Workspace: <strong>{currentWorkspace.name}</strong>
         </CurrentWorkspaceSection>
         <Divider />
-        <Box display="flex" flexDirection="column" marginTop={'1rem'}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', marginTop: '1rem' }}>
           {isLoading ? (
             <CircularProgress size={24} />
           ) : !filteredWorkspaces?.length ? (

--- a/src/custom/Workspaces/WorkspaceRecentActivityModal.tsx
+++ b/src/custom/Workspaces/WorkspaceRecentActivityModal.tsx
@@ -152,7 +152,7 @@ const WorkspaceRecentActivityModal: React.FC<RecentActivityModalProps> = ({
       >
         <ModalBody style={{ maxHeight: '40rem' }}>
           {page === 0 && isEventsLoading ? (
-            <Box display="flex" justifyContent="center" padding={4}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', padding: 4 }}>
               <CircularProgress />
             </Box>
           ) : allEvents.length > 0 ? (
@@ -166,7 +166,14 @@ const WorkspaceRecentActivityModal: React.FC<RecentActivityModalProps> = ({
                     style={{ padding: '0' }}
                     alignItems="flex-start"
                     secondaryAction={
-                      <Box display={'flex'} flexDirection="column" alignItems="flex-end" gap={0.2}>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'flex-end',
+                          gap: 0.2
+                        }}
+                      >
                         {getImage(data.description)}
                         <CustomTooltip title={getFullFormattedTime(data.createdAt)}>
                           <div>
@@ -210,7 +217,10 @@ const WorkspaceRecentActivityModal: React.FC<RecentActivityModalProps> = ({
               />
 
               {isFetching && (
-                <Box display="flex" justifyContent="center" padding={2} ref={_loaderRef}>
+                <Box
+                  sx={{ display: 'flex', justifyContent: 'center', padding: 2 }}
+                  ref={_loaderRef}
+                >
                   <CircularProgress size={24} />
                 </Box>
               )}
@@ -222,7 +232,7 @@ const WorkspaceRecentActivityModal: React.FC<RecentActivityModalProps> = ({
               )}
             </>
           ) : (
-            <Box display="flex" justifyContent="center" padding={4}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', padding: 4 }}>
               <Typography variant="body2" color="textSecondary">
                 No recent activity found for this workspace.
               </Typography>


### PR DESCRIPTION


**Notes for Reviewers**

MUI v9 no longer supports layout/system props directly on Box and Grid2 components. Moved all such props (display, p, py, alignItems, etc.) into the sx prop. Grid-specific props (container, spacing, xs, sm, md, etc.) left unchanged.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
