### PR TITLE
Normalize ChevronLeft and ChevronRight exports with Icon suffix

### DIFF
--- a/src/icons/ChevronLeft/ChevronLeft.tsx
+++ b/src/icons/ChevronLeft/ChevronLeft.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { ONYX_BLACK } from '../../theme';
 import { IconProps } from '../types';
 
-export const ChevronLeft = ({
+export const ChevronLeftIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   fill,
@@ -24,4 +24,5 @@ export const ChevronLeft = ({
   );
 };
 
-export default ChevronLeft;
+export default ChevronLeftIcon;
+

--- a/src/icons/ChevronLeft/index.ts
+++ b/src/icons/ChevronLeft/index.ts
@@ -1,1 +1,1 @@
-export { default as ChevronLeft } from './ChevronLeft';
+export { default as ChevronLeftIcon } from './ChevronLeft';

--- a/src/icons/ChevronRight/ChevronRight.tsx
+++ b/src/icons/ChevronRight/ChevronRight.tsx
@@ -2,7 +2,7 @@ import { DEFAULT_HEIGHT, DEFAULT_WIDTH,DEFAULT_FILL_NONE } from
 '../../constants/constants';
 import { IconProps } from '../types';
 
-export const ChevronRight = ({
+export const ChevronRightIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   fill = DEFAULT_FILL_NONE,
@@ -25,4 +25,5 @@ export const ChevronRight = ({
   );
 };
 
-export default ChevronRight;
+export default ChevronRightIcon;
+

--- a/src/icons/ChevronRight/index.ts
+++ b/src/icons/ChevronRight/index.ts
@@ -1,1 +1,1 @@
-export { default as ChevronRight } from './ChevronRight';
+export { default as ChevronRightIcon } from './ChevronRight';


### PR DESCRIPTION
**Notes for Reviewers**

Renamed `ChevronLeft` → `ChevronLeftIcon` and `ChevronRight` → `ChevronRightIcon` to match the `*Icon` naming convention used by every other icon in this package.

Related to #1584 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
