### PR TITLE
Standardize Icon Dimensions Using DEFAULT_WIDTH and DEFAULT_HEIGHT

### DIFF
--- a/src/icons/Calender/CalenderIcon.tsx
+++ b/src/icons/Calender/CalenderIcon.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 import { useTheme } from './../../theme/index';
 
-const CalenderIcon: FC<IconProps> = ({ width, height, ...props }) => {
+const CalenderIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   const theme = useTheme();
   return (
     <svg

--- a/src/icons/Chain/ChainIcon.tsx
+++ b/src/icons/Chain/ChainIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface ChainIconProps {
   width: string;
@@ -8,7 +9,7 @@ interface ChainIconProps {
   secondaryFill?: string;
 }
 
-const ChainIcon: React.FC<ChainIconProps> = ({ width, height, style, fill = '#3C494F' }) => (
+const ChainIcon: React.FC<ChainIconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, style, fill = '#3C494F' }) => (
   <svg
     width={width}
     height={height}

--- a/src/icons/Challenges/ChallengesIcon.tsx
+++ b/src/icons/Challenges/ChallengesIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface ChallengesIconProps {
   width?: string;
@@ -10,8 +11,8 @@ interface ChallengesIconProps {
 }
 
 const ChallengesIcon: React.FC<ChallengesIconProps> = ({
-  width = '32px',
-  height = '32px',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   primaryFill = '#B1B9BC',
   brandFill = '#00B39F',
   secondaryFill = '#51636B',

--- a/src/icons/CollapseAll/CollapseAllIcon.tsx
+++ b/src/icons/CollapseAll/CollapseAllIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface CollapsAllIconProps {
   height?: string;
@@ -9,8 +10,8 @@ interface CollapsAllIconProps {
 }
 
 const CollapsAllIcon: React.FC<CollapsAllIconProps> = ({
-  height = '24',
-  width = '24',
+  height = DEFAULT_HEIGHT,
+  width = DEFAULT_WIDTH,
   fill = 'none',
   strokeWidth = '2',
   style

--- a/src/icons/ContentClassIcons/CommunityClassIcon.tsx
+++ b/src/icons/ContentClassIcons/CommunityClassIcon.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { CustomIconProps } from '../types';
 export const CommunityClassIcon: FC<CustomIconProps> = ({
-  width = '16',
-  height = '13',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill = '#293B43',
   secondaryFill = '#647176',
   style = {}

--- a/src/icons/ContentClassIcons/OfficialClassIcon.tsx
+++ b/src/icons/ContentClassIcons/OfficialClassIcon.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 export const OfficialClassIcon: FC<IconProps> = ({
-  width = '16',
-  height = '13',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill = '#293B43',
   style = {}
 }) => (

--- a/src/icons/ContentClassIcons/VerificationClassIcon.tsx
+++ b/src/icons/ContentClassIcons/VerificationClassIcon.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 export const VerificationClassIcon: FC<IconProps> = ({
-  width = '16',
-  height = '13',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill = '#F6F8F8',
   style = {}
 }) => (

--- a/src/icons/Copy/CopyIcon.tsx
+++ b/src/icons/Copy/CopyIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface CopyIconProps {
   width: number;
@@ -8,7 +9,7 @@ interface CopyIconProps {
   secondaryFill?: string;
 }
 
-const CopyIcon: React.FC<CopyIconProps> = ({ width, height, fill = '#3C494F', style }) => (
+const CopyIcon: React.FC<CopyIconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, fill = '#3C494F', style }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     width={width}

--- a/src/icons/DataObject/OutlinedDataObjectIcon.tsx
+++ b/src/icons/DataObject/OutlinedDataObjectIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedDataObjectIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedDataObjectIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Deploy/OutlinedDeployIcon.tsx
+++ b/src/icons/Deploy/OutlinedDeployIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedDeployIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedDeployIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Designer/DesignerBottomRightIcon.tsx
+++ b/src/icons/Designer/DesignerBottomRightIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const DesignerBottomRightIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const DesignerBottomRightIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Detail/DetailIcon.tsx
+++ b/src/icons/Detail/DetailIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-const DetailIcon: FC<IconProps> = ({ width, height, ...props }) => {
+const DetailIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Detail/DetailsIcon.tsx
+++ b/src/icons/Detail/DetailsIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-const DetailsIcon: FC<IconProps> = ({ width, height, ...props }) => {
+const DetailsIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/DiscussForum/DiscussForumIcon.tsx
+++ b/src/icons/DiscussForum/DiscussForumIcon.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { DiscussForumIconProps } from './types';
 
 const DiscussForumIcon: React.FC<DiscussForumIconProps> = ({
-  width = '24px',
-  height = '24px',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   primaryColor = '#231f20',
   secondaryColor = '#fff9ae',

--- a/src/icons/EmptyStyle/EmptyStyleIcon.tsx
+++ b/src/icons/EmptyStyle/EmptyStyleIcon.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface EmptyStyleIconProps {
   width?: string;
@@ -9,8 +10,8 @@ interface EmptyStyleIconProps {
 }
 
 const EmptyStyleIcon: FC<EmptyStyleIconProps> = ({
-  width = '24px',
-  height = '24px',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   style = {},
   onClick = () => {}

--- a/src/icons/ExpandAll/ExpandAllIcon.tsx
+++ b/src/icons/ExpandAll/ExpandAllIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface ExpandAllIconProps {
   height?: string;
@@ -9,8 +10,8 @@ interface ExpandAllIconProps {
 }
 
 const ExpandAllIcon: React.FC<ExpandAllIconProps> = ({
-  height = '24',
-  width = '24',
+  height = DEFAULT_HEIGHT,
+  width = DEFAULT_WIDTH,
   fill = 'none',
   strokeWidth = '2',
   style

--- a/src/icons/FilledCircleIcon.tsx
+++ b/src/icons/FilledCircleIcon.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../constants/constants';
 import { IconProps } from './types';
 
-export const FilledCircleIcon: FC<IconProps> = ({
-  width,
-  height,
+export const FilledCircleIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT,
   fill = 'currentColor',
   ...props
 }) => {

--- a/src/icons/Google/GoogleIcon.tsx
+++ b/src/icons/Google/GoogleIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface GoogleIconProps {
   height: number;
@@ -6,7 +7,7 @@ interface GoogleIconProps {
   style?: React.CSSProperties;
 }
 
-const GoogleIcon: React.FC<GoogleIconProps> = ({ height, width, style }) => {
+const GoogleIcon: React.FC<GoogleIconProps> = ({ height = DEFAULT_HEIGHT, width = DEFAULT_WIDTH, style }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/icons/GridView/GridViewIcon.tsx
+++ b/src/icons/GridView/GridViewIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface GridViewIconProps {
   width?: string;
@@ -9,8 +10,8 @@ interface GridViewIconProps {
 }
 
 export const GridViewIcon: React.FC<GridViewIconProps> = ({
-  width = '24',
-  height = '28.8',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   opacity,
   style = {}

--- a/src/icons/Hierarchical/OutlinedHierarchicalIcon.tsx
+++ b/src/icons/Hierarchical/OutlinedHierarchicalIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedHierarchicalIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedHierarchicalIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/InfoOutlined/InfoOutlined.tsx
+++ b/src/icons/InfoOutlined/InfoOutlined.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface InfoOutlinedIconProps {
   height?: number;
@@ -9,8 +10,7 @@ interface InfoOutlinedIconProps {
 }
 
 const InfoOutlinedIcon: FC<InfoOutlinedIconProps> = ({
-  height,
-  width,
+  height = DEFAULT_HEIGHT, width = DEFAULT_WIDTH,
   fill = 'currentColor',
   style = {},
   className = ''

--- a/src/icons/InsertChartIcon.tsx
+++ b/src/icons/InsertChartIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../constants/constants';
 import { IconProps } from './types';
 
-export const InsertChartIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const InsertChartIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Kanvas/KanvasIcon.tsx
+++ b/src/icons/Kanvas/KanvasIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface KanvasIconProps {
   width: number;
@@ -9,9 +10,7 @@ interface KanvasIconProps {
   secondaryFill?: string;
 }
 
-const KanvasIcon: React.FC<KanvasIconProps> = ({
-  width,
-  height,
+const KanvasIcon: React.FC<KanvasIconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT,
   fill,
   style,
   primaryFill = 'white'

--- a/src/icons/Learning/LearningIcon.tsx
+++ b/src/icons/Learning/LearningIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface LearningIconProps {
   width?: string;
@@ -9,8 +10,8 @@ interface LearningIconProps {
 }
 
 const LearningIcon: React.FC<LearningIconProps> = ({
-  width = '32px',
-  height = '32px',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   primaryFill = '#FDFDFD',
   secondaryFill = '#FDFDFD',
   style = {}

--- a/src/icons/Logout/LogOutIcon.tsx
+++ b/src/icons/Logout/LogOutIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface LogoutIconProps {
   width?: number;
@@ -9,8 +10,8 @@ interface LogoutIconProps {
 }
 
 const LogoutIcon: React.FC<LogoutIconProps> = ({
-  width = 24,
-  height = 24,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   style = {},
   secondaryFill = '#00B39F'

--- a/src/icons/Mesh/OutlinedMesh.tsx
+++ b/src/icons/Mesh/OutlinedMesh.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedMeshIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedMeshIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/MesheryOperator/MesheryOperator.tsx
+++ b/src/icons/MesheryOperator/MesheryOperator.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { CARIBBEAN_GREEN } from '../../theme';
 import { IconProps } from '../types';
 
-export const MesheryOperator: FC<IconProps> = ({ width = '24px', height = '24px', ...props }) => {
+export const MesheryOperator: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/ModifiedApplicationFileIcon.tsx
+++ b/src/icons/ModifiedApplicationFileIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../constants/constants';
 import { IconProps } from './types';
 
-export const ModifiedApplicationFileIcon: FC<IconProps> = ({ width, height, ...props }) => (
+export const ModifiedApplicationFileIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => (
   <svg
     width={width}
     height={height}

--- a/src/icons/Open/OpenFileIcon.tsx
+++ b/src/icons/Open/OpenFileIcon.tsx
@@ -1,10 +1,10 @@
 import { FC } from 'react';
-import { DEFAULT_WIDTH } from '../../constants/constants';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
 
 export const OpenFileIcon: FC<IconProps> = ({
   width = DEFAULT_WIDTH,
-  height = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill = 'currentColor',
   ...props
 }) => (

--- a/src/icons/OpenInNew/OpenInNewIcon.tsx
+++ b/src/icons/OpenInNew/OpenInNewIcon.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
 const OpenInNewIcon: FC<IconProps> = ({
-  width = '24px',
-  height = '24px',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   style = {},
   onClick

--- a/src/icons/OriginalApplicationFileIcon.tsx
+++ b/src/icons/OriginalApplicationFileIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../constants/constants';
 import { IconProps } from './types';
 
-export const OriginalApplicationFileIcon: FC<IconProps> = ({ width, height, ...props }) => (
+export const OriginalApplicationFileIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => (
   <svg
     width={width}
     height={height}

--- a/src/icons/PanTool/PanToolIcon.tsx
+++ b/src/icons/PanTool/PanToolIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const PanToolIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const PanToolIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/PanelDragHandle/PanelDragHandleIcon.tsx
+++ b/src/icons/PanelDragHandle/PanelDragHandleIcon.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
 export const PanelDragHandleIcon: FC<IconProps> = ({
-  height = 24,
-  width = 24,
+  height = DEFAULT_HEIGHT,
+  width = DEFAULT_WIDTH,
   fill = '#E8EFF3',
   ...props
 }) => {

--- a/src/icons/Pattern/OutlinedPatternIcon.tsx
+++ b/src/icons/Pattern/OutlinedPatternIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-const OutlinedPatternIcon: FC<IconProps> = ({ width, height, ...props }) => {
+const OutlinedPatternIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Pattern/OutlinedPatternSwitchIcon.tsx
+++ b/src/icons/Pattern/OutlinedPatternSwitchIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedPatternSwitchIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedPatternSwitchIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg width={width} height={height} xmlns="http://www.w3.org/2000/svg" {...props}>
       <path

--- a/src/icons/Person/PersonIcon.tsx
+++ b/src/icons/Person/PersonIcon.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const PersonIcon: FC<IconProps> = ({
-  width,
-  height,
+export const PersonIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT,
   fill = '#5f6368',
   ...props
 }: IconProps) => {

--- a/src/icons/Pod/OutlinedPodIcon.tsx
+++ b/src/icons/Pod/OutlinedPodIcon.tsx
@@ -1,7 +1,12 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedPodIcon: FC<IconProps> = ({ width, height, ...props }) => (
+export const OutlinedPodIcon: FC<IconProps> = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  ...props
+}) => (
   <svg
     width={width}
     height={height}

--- a/src/icons/Redo/OutlinedRedoIcon.tsx
+++ b/src/icons/Redo/OutlinedRedoIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedRedoIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedRedoIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Reset/OutlinedResetIcon.tsx
+++ b/src/icons/Reset/OutlinedResetIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedResetIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedResetIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Ring/OutlinedRingIcon.tsx
+++ b/src/icons/Ring/OutlinedRingIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedRingIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedRingIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Save/OutlinedCloudSavingIcon.tsx
+++ b/src/icons/Save/OutlinedCloudSavingIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedCloudSavingIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedCloudSavingIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Screenshot/OutlinedScreenshotIcon.tsx
+++ b/src/icons/Screenshot/OutlinedScreenshotIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedScreenshotIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedScreenshotIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Settings/OutlinedSettingsIcon.tsx
+++ b/src/icons/Settings/OutlinedSettingsIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedSettingsIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedSettingsIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Share/ShareLineIcon.tsx
+++ b/src/icons/Share/ShareLineIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface ShareLineIconProps {
   width: string;
@@ -8,9 +9,7 @@ interface ShareLineIconProps {
   secondaryFill?: string;
 }
 
-const ShareLineIcon: React.FC<ShareLineIconProps> = ({
-  width,
-  height,
+const ShareLineIcon: React.FC<ShareLineIconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT,
   style,
   fill = '#3C494F'
 }) => (

--- a/src/icons/Star/OutlinedStarIcon.tsx
+++ b/src/icons/Star/OutlinedStarIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedStarIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedStarIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Success/SuccessIcon.tsx
+++ b/src/icons/Success/SuccessIcon.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react';
-import { KEPPEL_GREEN_FILL } from '../../constants/constants';
+import { KEPPEL_GREEN_FILL, DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { WHITE } from '../../theme';
 import { IconProps } from '../types';
 
-const SuccessIcon: FC<IconProps> = ({ width, height, ...props }) => {
+const SuccessIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/TableView/TableViewIcon.tsx
+++ b/src/icons/TableView/TableViewIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface TableViewIconProps {
   width?: string;
@@ -9,8 +10,8 @@ interface TableViewIconProps {
 }
 
 export const TableViewIcon: React.FC<TableViewIconProps> = ({
-  width = '24',
-  height = '28.8',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill,
   opacity,
   style = {}

--- a/src/icons/Teams/TeamsIcon.tsx
+++ b/src/icons/Teams/TeamsIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface TeamsIconProps {
   width: string | number;
@@ -9,9 +10,7 @@ interface TeamsIconProps {
   style?: React.CSSProperties;
 }
 
-const TeamsIcon: React.FC<TeamsIconProps> = ({
-  width,
-  height,
+const TeamsIcon: React.FC<TeamsIconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT,
   fill,
   primaryFill = '#51636B',
   secondaryFill = '#00B39F',

--- a/src/icons/TerminalIcon/TerminalIcon.tsx
+++ b/src/icons/TerminalIcon/TerminalIcon.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { ONYX_BLACK } from '../../theme';
 import { IconProps } from '../types';
 
-const TerminalIcon: FC<IconProps> = ({ width, height, fill, ...props }) => {
+const TerminalIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, fill, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Toolkit/ToolkitIcon.tsx
+++ b/src/icons/Toolkit/ToolkitIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const ToolkitIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const ToolkitIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Touch/TouchAppIcon.tsx
+++ b/src/icons/Touch/TouchAppIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const TouchAppIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const TouchAppIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Triangle/TriangleIcon.tsx
+++ b/src/icons/Triangle/TriangleIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const TriangleIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const TriangleIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Tropy/TropyIcon.tsx
+++ b/src/icons/Tropy/TropyIcon.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 
 interface TrophyIconProps {
   width?: string;
@@ -8,8 +9,8 @@ interface TrophyIconProps {
 }
 
 const TrophyIcon: React.FC<TrophyIconProps> = ({
-  width = '24',
-  height = '24',
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   fill = 'currentColor',
   style = {}
 }) => (

--- a/src/icons/Undeploy/OutlinedUndeployIcon.tsx
+++ b/src/icons/Undeploy/OutlinedUndeployIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedUndeployIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedUndeployIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Undo/OutlinedUndoIcon.tsx
+++ b/src/icons/Undo/OutlinedUndoIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedUndoIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedUndoIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Validate/OutlinedValidateIcon.tsx
+++ b/src/icons/Validate/OutlinedValidateIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedValidateIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedValidateIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/View/ViewIcon.tsx
+++ b/src/icons/View/ViewIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-const ViewsIcon: FC<IconProps> = ({ width, height, style = {}, fill }) => (
+const ViewsIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, style = {}, fill }) => (
   <svg
     style={style}
     xmlns="http://www.w3.org/2000/svg"

--- a/src/icons/Visibility/OutlinedVisibilityOffIcon.tsx
+++ b/src/icons/Visibility/OutlinedVisibilityOffIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedVisibilityOffIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedVisibilityOffIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Visibility/OutlinedVisibilityOnIcon.tsx
+++ b/src/icons/Visibility/OutlinedVisibilityOnIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedVisibilityOnIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedVisibilityOnIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}

--- a/src/icons/Visualizer/OutlinedVisualizerSwitcherIcon.tsx
+++ b/src/icons/Visualizer/OutlinedVisualizerSwitcherIcon.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../../constants/constants';
 import { IconProps } from '../types';
 
-export const OutlinedVisualizerSwitcherIcon: FC<IconProps> = ({ width, height, ...props }) => {
+export const OutlinedVisualizerSwitcherIcon: FC<IconProps> = ({ width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT, ...props }) => {
   return (
     <svg
       width={width}


### PR DESCRIPTION
**Notes for Reviewers**

Ensured every icon consistently defaults to DEFAULT_WIDTH and DEFAULT_HEIGHT.
Many icons were either missing fallback values entirely or using hardcoded dimensions (such as '24px' or '32px'). This update standardizes them all for consistency.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
