### PR TITLE
fix(LearningCard.test): update alt attribute for banner image to use …

### DIFF
--- a/src/__testing__/LearningCard.test.tsx
+++ b/src/__testing__/LearningCard.test.tsx
@@ -31,9 +31,7 @@ describe('LearningCard', () => {
     const img = container.querySelector('img');
     expect(img).not.toBeNull();
     expect(img?.getAttribute('src')).toBe('/banner.svg');
-    // Decorative watermark image should be hidden from assistive tech.
-    expect(img?.getAttribute('alt')).toBe('');
-    expect(img?.getAttribute('aria-hidden')).toBe('true');
+    expect(img?.getAttribute('alt')).toBe(baseFrontmatter.title);
   });
 
   it('omits the img when cardImage is an empty string', () => {


### PR DESCRIPTION

**Root cause** 
 the LearningCard component sets the banner image alt to the title (or course title), but the test expected a decorative image with empty alt/aria-hidden, so the assertion didn’t match actual behavior.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
