### PR TITLE
feat(rjsf): suppress the duplicative top-level object title in RJSF forms

### DIFF
--- a/src/__testing__/hideRootObjectTitle.test.tsx
+++ b/src/__testing__/hideRootObjectTitle.test.tsx
@@ -1,0 +1,114 @@
+import Form from '@rjsf/core';
+import validator from '@rjsf/validator-ajv8';
+import { render } from '@testing-library/react';
+import { hideRootObjectTitle } from '../custom/RJSFFormWrapper/hideRootObjectTitle';
+import importDesignSchema from '../schemas/importDesign/schema';
+import importDesignUiSchema from '../schemas/importDesign/uiSchema';
+
+describe('hideRootObjectTitle', () => {
+  it('adds ui:options.label=false when no uiSchema is provided', () => {
+    expect(hideRootObjectTitle()).toEqual({ 'ui:options': { label: false } });
+  });
+
+  it('adds ui:options.label=false to an empty uiSchema', () => {
+    expect(hideRootObjectTitle({})).toEqual({ 'ui:options': { label: false } });
+  });
+
+  it('preserves ui:order and per-field overrides while suppressing the root title', () => {
+    const ui = {
+      'ui:order': ['name', 'uploadType'],
+      uploadType: { 'ui:widget': 'radio' }
+    };
+
+    expect(hideRootObjectTitle(ui)).toEqual({
+      'ui:order': ['name', 'uploadType'],
+      uploadType: { 'ui:widget': 'radio' },
+      'ui:options': { label: false }
+    });
+  });
+
+  it('merges into existing ui:options rather than clobbering them', () => {
+    const ui = { 'ui:options': { classNames: 'root', orderable: true } };
+
+    expect(hideRootObjectTitle(ui)).toEqual({
+      'ui:options': { classNames: 'root', orderable: true, label: false }
+    });
+  });
+
+  it('forces label to false even if it was explicitly true', () => {
+    expect(hideRootObjectTitle({ 'ui:options': { label: true } })).toEqual({
+      'ui:options': { label: false }
+    });
+  });
+
+  it('does not mutate the input uiSchema', () => {
+    const ui = { 'ui:order': ['name'], 'ui:options': { classNames: 'root' } };
+    const snapshot = JSON.parse(JSON.stringify(ui));
+
+    hideRootObjectTitle(ui);
+
+    expect(ui).toEqual(snapshot);
+  });
+
+  it('keeps the canonical import-design UI schema intact apart from the new option', () => {
+    const result = hideRootObjectTitle(importDesignUiSchema);
+
+    // Canonical directives survive untouched...
+    expect(result['ui:order']).toEqual(importDesignUiSchema['ui:order']);
+    expect(result.uploadType).toEqual(importDesignUiSchema.uploadType);
+    // ...and the only addition is the root-title suppression.
+    expect(result['ui:options']).toEqual({ label: false });
+  });
+});
+
+/**
+ * End-to-end proof that the UI-schema lever actually reaches RJSF and zeroes
+ * out the title RJSF hands to the `ObjectFieldTemplate`. Rendered through
+ * `@rjsf/core` directly with a trivial recording template (NOT `@rjsf/mui`,
+ * which has an ESM-interop edge under the jest/swc transform — see the
+ * RJSFFormWrapper smoke test), so the assertion is about RJSF's own
+ * title/description derivation, independent of any theme.
+ */
+describe('hideRootObjectTitle — RJSF root title/description derivation', () => {
+  type Recorded = { title: unknown; description: unknown; properties: string[] };
+  const recordRootRender = (uiSchema: Record<string, unknown>): Recorded => {
+    const recorded: Recorded = { title: undefined, description: undefined, properties: [] };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function RecordingObjectFieldTemplate(props: any): JSX.Element {
+      if (props.fieldPathId?.$id === 'root') {
+        recorded.title = props.title;
+        recorded.description = props.description;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        recorded.properties = props.properties.map((p: any) => p.name);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return <div>{props.properties.map((p: any) => p.content)}</div>;
+    }
+
+    render(
+      <Form
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        schema={importDesignSchema as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        uiSchema={uiSchema as any}
+        validator={validator}
+        templates={{ ObjectFieldTemplate: RecordingObjectFieldTemplate }}
+      />
+    );
+    return recorded;
+  };
+
+  it('renders the canonical root title by default (the duplicative heading)', () => {
+    const recorded = recordRootRender(importDesignUiSchema);
+    expect(recorded.title).toBe('Import Design');
+  });
+
+  it('suppresses the root title and description after hideRootObjectTitle', () => {
+    const recorded = recordRootRender(hideRootObjectTitle(importDesignUiSchema));
+    expect(recorded.title).toBe('');
+    expect(recorded.description).toBeUndefined();
+    // The contents (child fields) are still rendered — we hide the object
+    // header, not the object's fields.
+    expect(recorded.properties).toEqual(expect.arrayContaining(['name', 'uploadType']));
+  });
+});

--- a/src/__testing__/hideRootObjectTitle.test.tsx
+++ b/src/__testing__/hideRootObjectTitle.test.tsx
@@ -41,6 +41,12 @@ describe('hideRootObjectTitle', () => {
     });
   });
 
+  it('ignores a malformed (array) ui:options and still suppresses the title', () => {
+    expect(hideRootObjectTitle({ 'ui:options': ['nonsense'] })).toEqual({
+      'ui:options': { label: false }
+    });
+  });
+
   it('does not mutate the input uiSchema', () => {
     const ui = { 'ui:order': ['name'], 'ui:options': { classNames: 'root' } };
     const snapshot = JSON.parse(JSON.stringify(ui));

--- a/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormModal.tsx
@@ -18,13 +18,27 @@ export interface RJSFValidationError {
   params?: any;
 }
 
-export interface RJSFFormModalProps
-  extends Omit<
-    RJSFFormWrapperProps,
-    'onSubmit' | 'onError' | 'formRef' | 'formData' | 'onChange' | 'children'
-  > {
+export interface RJSFFormModalProps extends Omit<
+  RJSFFormWrapperProps,
+  'onSubmit' | 'onError' | 'formRef' | 'formData' | 'onChange' | 'children'
+> {
   open: boolean;
   onClose: () => void;
+  /**
+   * Suppress the form's ROOT object title and description so its child
+   * fields render directly inside the modal body.
+   *
+   * Defaults to `true`: the modal header (`title` prop) already names
+   * the form, so the canonical schema's root object title would
+   * otherwise be drawn a second time — as a duplicate heading in the
+   * default theme, or as a collapsed accordion in the custom RJSF
+   * templates used downstream. Set to `false` only if you genuinely
+   * want the root object's own title rendered inside the body.
+   *
+   * Implemented through the UI schema (`ui:options.label = false`), so
+   * the canonical `@meshery/schemas` JSON schema is consumed unmodified.
+   */
+  hideRootTitle?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSubmit: (formData: any) => void;
   title: string;
@@ -81,6 +95,7 @@ export function RJSFFormModal({
   leftHeaderIcon = null,
   initialData,
   onValidationError,
+  hideRootTitle = true,
   ...rest
 }: RJSFFormModalProps): JSX.Element {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,9 +122,7 @@ export function RJSFFormModal({
       formRef.current.submit();
     } catch (err) {
       const message = (err as Error)?.message ?? String(err);
-      const errors: RJSFValidationError[] = [
-        { stack: `Form could not be validated: ${message}` }
-      ];
+      const errors: RJSFValidationError[] = [{ stack: `Form could not be validated: ${message}` }];
       if (onValidationError) {
         onValidationError(errors);
       } else {
@@ -139,6 +152,7 @@ export function RJSFFormModal({
         <div style={{ width: '100%' }}>
           <RJSFFormWrapper
             {...rest}
+            hideRootTitle={hideRootTitle}
             formData={formData}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onChange={(e: any) => setFormData(e.formData)}

--- a/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
+++ b/src/custom/RJSFFormWrapper/RJSFFormWrapper.tsx
@@ -3,6 +3,7 @@ import { Theme as MaterialUITheme } from '@rjsf/mui';
 import validator from '@rjsf/validator-ajv8';
 import React, { type Ref } from 'react';
 import { SistentThemeProvider } from '../../theme';
+import { hideRootObjectTitle } from './hideRootObjectTitle';
 
 const MuiRJSFForm = withTheme(MaterialUITheme);
 
@@ -24,6 +25,21 @@ export interface RJSFFormWrapperProps
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formRef?: Ref<any>;
   children?: React.ReactNode;
+  /**
+   * Suppress the form's ROOT object title and description so its child
+   * fields render directly, without the duplicative object "header".
+   *
+   * This is the standard pattern for rendering the contents of a
+   * schema's top-level object inside a surface that already names it
+   * (most commonly a modal — see `RJSFFormModal`, which defaults this
+   * to `true`). It is implemented purely through the UI schema
+   * (`ui:options.label = false`), so the canonical `@meshery/schemas`
+   * JSON schema is consumed unmodified. See `hideRootObjectTitle`.
+   *
+   * Defaults to `false` here to preserve the behavior of the
+   * general-purpose wrapper when it is embedded with its own chrome.
+   */
+  hideRootTitle?: boolean;
 }
 
 /**
@@ -43,14 +59,18 @@ export interface RJSFFormWrapperProps
 export function RJSFFormWrapper({
   formRef,
   children,
+  hideRootTitle = false,
+  uiSchema,
   ...rest
 }: RJSFFormWrapperProps): JSX.Element {
+  const resolvedUiSchema = hideRootTitle ? hideRootObjectTitle(uiSchema) : uiSchema;
   return (
     <SistentThemeProvider>
       <MuiRJSFForm
         validator={validator}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ref={formRef as any}
+        uiSchema={resolvedUiSchema}
         {...rest}
       >
         {children}

--- a/src/custom/RJSFFormWrapper/hideRootObjectTitle.ts
+++ b/src/custom/RJSFFormWrapper/hideRootObjectTitle.ts
@@ -80,7 +80,9 @@ export function hideRootObjectTitle<T extends Record<string, unknown> = Record<s
 ): T {
   const existing = uiSchema?.['ui:options'];
   const existingOptions =
-    typeof existing === 'object' && existing !== null ? (existing as Record<string, unknown>) : {};
+    typeof existing === 'object' && existing !== null && !Array.isArray(existing)
+      ? (existing as Record<string, unknown>)
+      : {};
 
   return {
     ...(uiSchema ?? ({} as T)),

--- a/src/custom/RJSFFormWrapper/hideRootObjectTitle.ts
+++ b/src/custom/RJSFFormWrapper/hideRootObjectTitle.ts
@@ -1,0 +1,94 @@
+/**
+ * Standard pattern: render the CONTENTS of an RJSF form's root object
+ * without the object's own title/description "header".
+ *
+ * ## Why this exists
+ *
+ * Sistent's RJSF form schemas are imported verbatim from `@meshery/schemas`
+ * (the schema-driven-development mandate — see `src/schemas/readme.md`).
+ * Those canonical schemas put a human-readable `title` on the root object
+ * (e.g. the import-design schema's root `title: "Import Design"`). When the
+ * form is rendered inside a titled surface — most commonly a modal whose
+ * header ALREADY shows that title — RJSF draws the root object's title a
+ * second time, directly above the fields. In the default `@rjsf/mui`
+ * `ObjectFieldTemplate` that renders as a duplicate heading; in the custom
+ * collapsible `ObjectFieldTemplate`s used by Meshery / Meshery Cloud /
+ * Meshery Extensions it renders as a collapsed accordion the user has to
+ * expand before they can even see the form.
+ *
+ * Neither is desired. We want the root object's *contents* (its child
+ * fields) shown directly, and the duplicative root title gone — while still
+ * consuming the canonical UI schema directly (no hand-edited fork, no
+ * mutation of the JSON schema).
+ *
+ * ## How it works
+ *
+ * RJSF's `@rjsf/core` `ObjectField` derives the title it hands to the
+ * registered `ObjectFieldTemplate` as:
+ *
+ * ```ts
+ * title: uiOptions.label === false ? '' : (uiOptions.title ?? schema.title ?? ...)
+ * description: uiOptions.label === false ? undefined : (uiOptions.description ?? schema.description)
+ * ```
+ *
+ * So setting `ui:options.label = false` on the root of the UI schema forces
+ * RJSF to pass an empty title (and no description) to *whatever*
+ * `ObjectFieldTemplate` is in use. Every template in the ecosystem then
+ * skips its header and renders the child properties directly:
+ *
+ *   - default `@rjsf/mui`: `title && <TitleFieldTemplate/>` → skipped
+ *   - Meshery / Meshery Cloud custom templates: `uiSchema['ui:title'] || title`
+ *     → `''` (falsy) → no collapsible header, children render inline
+ *
+ * Because the lever is the UI schema rather than the JSON schema, this keeps
+ * the canonical schema pristine (validation, `required`, conditional
+ * `allOf` branches are untouched) and is theme/template agnostic — the one
+ * pattern works across the default Sistent form and every downstream
+ * consumer's custom RJSF stack.
+ *
+ * @see https://github.com/rjsf-team/react-jsonschema-form `ObjectField`
+ *      title/description derivation (`uiOptions.label === false`).
+ */
+
+/**
+ * Returns a shallow copy of `uiSchema` with `ui:options.label` set to
+ * `false`, suppressing the root object's title and description while
+ * leaving its child fields (and every other UI-schema directive —
+ * `ui:order`, per-field widget/options overrides, etc.) intact.
+ *
+ * The input is never mutated. Any pre-existing `ui:options` are preserved
+ * and merged, with `label: false` taking precedence.
+ *
+ * @example
+ * ```tsx
+ * import { RJSFFormWrapper, hideRootObjectTitle } from '@sistent/sistent';
+ * import { DesignImportRjsfSchemaV1Beta3 as schema,
+ *          DesignImportRjsfUiSchemaV1Beta3 as uiSchema } from '@meshery/schemas';
+ *
+ * // Renders the import-design fields directly, no duplicate "Import Design"
+ * // heading, while still using the canonical UI schema as-is.
+ * <RJSFFormWrapper schema={schema} uiSchema={hideRootObjectTitle(uiSchema)} />
+ * ```
+ *
+ * Prefer the `hideRootTitle` prop on `RJSFFormWrapper` / `RJSFFormModal`
+ * (which calls this for you) for the common case; reach for the helper
+ * directly when you assemble the UI schema yourself before handing it to a
+ * different RJSF surface.
+ */
+export function hideRootObjectTitle<T extends Record<string, unknown> = Record<string, unknown>>(
+  uiSchema?: T
+): T {
+  const existing = uiSchema?.['ui:options'];
+  const existingOptions =
+    typeof existing === 'object' && existing !== null ? (existing as Record<string, unknown>) : {};
+
+  return {
+    ...(uiSchema ?? ({} as T)),
+    'ui:options': {
+      ...existingOptions,
+      label: false
+    }
+  } as T;
+}
+
+export default hideRootObjectTitle;

--- a/src/custom/RJSFFormWrapper/index.ts
+++ b/src/custom/RJSFFormWrapper/index.ts
@@ -1,6 +1,3 @@
+export { hideRootObjectTitle } from './hideRootObjectTitle';
+export { RJSFFormModal, type RJSFFormModalProps, type RJSFValidationError } from './RJSFFormModal';
 export { RJSFFormWrapper, type RJSFFormWrapperProps } from './RJSFFormWrapper';
-export {
-  RJSFFormModal,
-  type RJSFFormModalProps,
-  type RJSFValidationError
-} from './RJSFFormModal';

--- a/src/schemas/readme.md
+++ b/src/schemas/readme.md
@@ -26,6 +26,70 @@ RJSF Schemas, based on the React JSON Schema Form library, define the structure,
 1. **Customization:**
    Adjust the schema properties to tailor the form's appearance and behavior. Refer to the specific schema's documentation for customization options.
 
+### Rendering a form without its top-level object title (the standard pattern)
+
+The canonical schemas from `@meshery/schemas` carry a human-readable `title`
+(and `description`) on their **root object** — for example the import-design
+schema's root `title: "Import Design"`. That is correct for the schema, but
+when the form is rendered inside a surface that already names it — most
+commonly a modal whose header shows the very same title — RJSF draws that root
+title a second time, directly above the fields:
+
+- in the default `@rjsf/mui` template it shows as a **duplicate heading**;
+- in the collapsible `ObjectFieldTemplate`s used downstream (Meshery, Meshery
+  Cloud, Meshery Extensions) it shows as a **collapsed accordion** the user has
+  to expand before they can even see the form.
+
+Neither is desired. We want the root object's _contents_ (its child fields)
+shown directly and the duplicative title gone — **while still consuming the
+canonical UI schema verbatim** (no hand-edited fork, no mutation of the JSON
+schema).
+
+The standard, theme-agnostic way to do this is to set `ui:options.label = false`
+on the **root** of the UI schema. RJSF's `ObjectField` then hands an empty
+title (and no description) to whatever `ObjectFieldTemplate` is registered, so
+every template skips its header and renders the child fields inline. Because
+the lever is the UI schema and not the JSON schema, validation, `required`, and
+conditional `allOf` branches stay untouched.
+
+You rarely write that option by hand. Use whichever is convenient:
+
+1. **`RJSFFormModal`** already does this for you — `hideRootTitle` defaults to
+   `true`, because a modal always shows the title in its header:
+
+   ```jsx
+   import { RJSFFormModal, importDesignSchema, importDesignUiSchema } from '@sistent/sistent';
+
+   <RJSFFormModal
+     open={open}
+     onClose={onClose}
+     title="Import Design" // shown once, in the modal header
+     buttonTitle="Import"
+     schema={importDesignSchema}
+     uiSchema={importDesignUiSchema} // used as-is; root title auto-suppressed
+     onSubmit={handleImport}
+   />;
+   ```
+
+2. **`RJSFFormWrapper`** exposes the same `hideRootTitle` prop (defaulting to
+   `false`, so the standalone wrapper is unchanged unless you opt in):
+
+   ```jsx
+   <RJSFFormWrapper schema={schema} uiSchema={uiSchema} hideRootTitle />
+   ```
+
+3. **`hideRootObjectTitle(uiSchema)`** is the underlying helper, for when you
+   assemble the UI schema yourself before handing it to a different RJSF
+   surface (e.g. a consumer's own modal/wrapper). It returns a shallow copy —
+   the input is never mutated and all other directives (`ui:order`, per-field
+   overrides, existing `ui:options`) are preserved:
+
+   ```jsx
+   import { hideRootObjectTitle } from '@sistent/sistent';
+
+   <SomeRjsfForm schema={schema} uiSchema={hideRootObjectTitle(uiSchema)} />;
+   ```
+
 ### File Conventions for Schemas
 
 Follow a consistent file structure convention to enhance clarity and organization when adding new schema:


### PR DESCRIPTION
## Description

The RJSF form schemas we consume from `@meshery/schemas` carry a human‑readable `title` on their **root object** — e.g. the import‑design schema's root `title: "Import Design"`. When that form is rendered inside a surface that already names it (most commonly a modal whose header shows the very same title), RJSF draws the root title a **second time**, directly above the fields:

- **Import Design** modal — the top‑level object is rendered as its own section that is **collapsed by default**, so users have to click to expand it before they can see (or use) the form. The heading is also duplicative of the modal title.

We want the root object's **contents** shown directly, with the duplicative title gone — **while still consuming the canonical UI schema verbatim** (no hand‑edited fork, no mutation of the JSON schema). This establishes a reusable standard for that situation across Sistent and its downstream consumers (Meshery, Meshery Cloud, Meshery Extensions).

## The standard pattern

Set `ui:options.label = false` on the **root** of the UI schema. Per `@rjsf/core`'s `ObjectField`, when `label === false` the title handed to the `ObjectFieldTemplate` is forced to `''` (and the description to `undefined`), so **every** template — the default `@rjsf/mui` one and the custom collapsible templates used downstream — skips its header and renders the child fields inline. Because the lever is the UI schema and not the JSON schema, validation, `required`, and conditional `allOf` branches stay untouched.

## What changed

- **`hideRootObjectTitle(uiSchema)`** — new exported helper that merges `ui:options.label = false` into the root of a UI schema. Returns a shallow copy (never mutates input); preserves `ui:order`, per‑field overrides, and any existing `ui:options`.
- **`RJSFFormModal`** — new `hideRootTitle` prop, **defaulting to `true`**: the modal header already names the form, so the root object title is suppressed automatically. This fixes the Import Design modal out of the box.
- **`RJSFFormWrapper`** — same `hideRootTitle` prop, defaulting to `false` so the general‑purpose wrapper is unchanged unless a consumer opts in.
- **Docs** — `src/schemas/readme.md` documents the pattern and the three ways to apply it.

## How it was verified

- New `hideRootObjectTitle` unit tests (merge correctness, preservation, no‑mutation).
- An end‑to‑end test renders the **canonical import‑design schema** through `@rjsf/core` with a recording `ObjectFieldTemplate` and asserts the root title RJSF derives is `"Import Design"` by default and `""` after `hideRootObjectTitle` (with the child fields still present).
- Full suite green (`jest`: 12 suites / 295 tests), `eslint` clean on changed files, `tsup` build succeeds and the new symbol/prop appear in both the runtime (`dist/index.mjs`, `dist/index.js`) and type (`dist/index.d.ts`) outputs.

## Notes for reviewers

Downstream PRs in `meshery/meshery` and `layer5io/meshery-cloud` adopt the same UI‑schema‑driven approach in their own RJSF stacks (replacing a schema‑mutating `hideTitle` hack). They inline a local mirror of `hideRootObjectTitle` until they consume a release of Sistent that exports it.

- [x] Signed commits (DCO)
