### PR TITLE
fix: Add default size to InfoOutlinedIcon

### DIFF
--- a/src/icons/InfoOutlined/InfoOutlined.tsx
+++ b/src/icons/InfoOutlined/InfoOutlined.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, FC } from 'react';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, DEFAULT_FILL_NONE } from '../../constants/constants';
 
 interface InfoOutlinedIconProps {
   height?: number;
@@ -9,9 +10,9 @@ interface InfoOutlinedIconProps {
 }
 
 const InfoOutlinedIcon: FC<InfoOutlinedIconProps> = ({
-  height,
-  width,
-  fill = 'currentColor',
+  height= DEFAULT_HEIGHT,
+  width= DEFAULT_WIDTH,
+  fill = DEFAULT_FILL_NONE,
   style = {},
   className = ''
 }) => {


### PR DESCRIPTION
**Notes for Reviewers**

Issue: The InfoOutlinedIcon did not have default height and width values. When used without passing size props, it collapsed to size 0x0 and became invisible (e.g. in the design table menu).

Fix: Added DEFAULT_HEIGHT and DEFAULT_WIDTH as default values so the icon renders properly at standard size by default.

| Before | After |
|--------|-------|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/1ec31e61-02a7-4b86-ba19-999c71e2f3c2" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/a8a7b50b-b65f-4152-9235-8d9f0ab92a32" /> |


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
