### PR TITLE
fix(UserSearchField): restore type-ahead broken by MUI v9 slotProps migration

### DIFF
--- a/src/__testing__/UserSearchFieldInput.test.tsx
+++ b/src/__testing__/UserSearchFieldInput.test.tsx
@@ -1,19 +1,21 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { SistentThemeProvider } from '../../theme';
-import UserSearchField from './UserSearchFieldInput';
+import UserSearchField from '../custom/UserSearchField/UserSearchFieldInput';
+import { SistentThemeProvider } from '../theme';
 
 // Regression guard for the user-picker type-ahead.
 //
-// The picker is a controlled MUI Autocomplete. In MUI v9 the
-// `renderInput` params expose the native <input> wiring (value, onChange,
-// onKeyDown, focus handlers and the anchor ref from `getInputProps`) under
+// The picker is a controlled MUI Autocomplete. In MUI v9 the `renderInput`
+// params expose the native <input> wiring (value, onChange, onKeyDown, focus
+// handlers and the anchor ref from `getInputProps`) under
 // `params.slotProps.htmlInput`. If the TextField is handed an explicit
 // `slotProps` object that omits `htmlInput`, that object REPLACES the one
 // spread from `{...params}` and the input is silently disconnected from the
 // Autocomplete: keystrokes no longer reach `onInputChange`, the search never
 // fires and the suggestion list never opens. These tests assert the wiring
 // survives so the type-ahead keeps working.
+
+type FieldProps = React.ComponentProps<typeof UserSearchField>;
 
 const renderWithTheme = (ui: React.ReactElement) =>
   render(<SistentThemeProvider>{ui}</SistentThemeProvider>);
@@ -25,8 +27,8 @@ const jane = {
   email: 'jane@example.com'
 };
 
-const renderField = (overrides: Record<string, unknown> = {}) => {
-  const props = {
+const renderField = (overrides: Partial<FieldProps> = {}) => {
+  const props: FieldProps = {
     usersData: [],
     setUsersData: jest.fn(),
     currentUserData: null,
@@ -37,11 +39,8 @@ const renderField = (overrides: Record<string, unknown> = {}) => {
     setUsersSearch: jest.fn(),
     ...overrides
   };
-  const utils = renderWithTheme(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    <UserSearchField {...(props as any)} />
-  );
-  const input = utils.container.querySelector('input') as HTMLInputElement;
+  const utils = renderWithTheme(<UserSearchField {...props} />);
+  const input = screen.getByRole('combobox') as HTMLInputElement;
   return { props, input, ...utils };
 };
 

--- a/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
@@ -147,6 +147,7 @@ const TeamSearchField: React.FC<TeamSearchFieldProps> = ({
             helperText={error ? 'Team Already Selected' : ''}
             fullWidth
             slotProps={{
+              ...params.slotProps,
               input: {
                 ...params.slotProps?.input,
                 endAdornment: isLoading ? <CircularProgress color="inherit" size={20} /> : null

--- a/src/custom/InputSearchField/InputSearchField.tsx
+++ b/src/custom/InputSearchField/InputSearchField.tsx
@@ -128,7 +128,9 @@ const InputSearchField: React.FC<InputSearchFieldProps> = ({
             helperText={error}
             fullWidth
             slotProps={{
+              ...params.slotProps,
               inputLabel: {
+                ...params.slotProps?.inputLabel,
                 style: {
                   fontFamily: 'inherit'
                 }

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -156,12 +156,11 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
                 }
               }}
               slotProps={{
+                ...params.slotProps,
                 input: {
                   ...params.slotProps?.input,
                   endAdornment: (
-                    <>
-                      {searchUserLoading ? <CircularProgress color="inherit" size={20} /> : null}
-                    </>
+                    <>{searchUserLoading ? <CircularProgress color="inherit" size={20} /> : null}</>
                   )
                 }
               }}

--- a/src/custom/UserSearchField/UserSearchFieldInput.test.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { SistentThemeProvider } from '../../theme';
+import UserSearchField from './UserSearchFieldInput';
+
+// Regression guard for the user-picker type-ahead.
+//
+// The picker is a controlled MUI Autocomplete. In MUI v9 the
+// `renderInput` params expose the native <input> wiring (value, onChange,
+// onKeyDown, focus handlers and the anchor ref from `getInputProps`) under
+// `params.slotProps.htmlInput`. If the TextField is handed an explicit
+// `slotProps` object that omits `htmlInput`, that object REPLACES the one
+// spread from `{...params}` and the input is silently disconnected from the
+// Autocomplete: keystrokes no longer reach `onInputChange`, the search never
+// fires and the suggestion list never opens. These tests assert the wiring
+// survives so the type-ahead keeps working.
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<SistentThemeProvider>{ui}</SistentThemeProvider>);
+
+const jane = {
+  userId: 'u-jane',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com'
+};
+
+const renderField = (overrides: Record<string, unknown> = {}) => {
+  const props = {
+    usersData: [],
+    setUsersData: jest.fn(),
+    currentUserData: null,
+    searchedUsers: [jane],
+    isUserSearchLoading: false,
+    fetchSearchedUsers: jest.fn(),
+    usersSearch: '',
+    setUsersSearch: jest.fn(),
+    ...overrides
+  };
+  const utils = renderWithTheme(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    <UserSearchField {...(props as any)} />
+  );
+  const input = utils.container.querySelector('input') as HTMLInputElement;
+  return { props, input, ...utils };
+};
+
+describe('UserSearchField type-ahead wiring', () => {
+  it('forwards keystrokes to the search callback', () => {
+    const { props, input } = renderField();
+
+    fireEvent.change(input, { target: { value: 'jane' } });
+
+    // Only reachable when the Autocomplete's htmlInput slot is forwarded to
+    // the TextField; a dropped slot leaves the input inert and this stays 0.
+    expect(props.fetchSearchedUsers).toHaveBeenCalledWith('jane');
+  });
+
+  it('opens the suggestion list with matching users as the query is typed', async () => {
+    const { input } = renderField({ usersSearch: 'jane' });
+
+    fireEvent.change(input, { target: { value: 'jane' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('jane@example.com')).not.toBeNull();
+    });
+    expect(screen.queryByText('Jane Doe')).not.toBeNull();
+  });
+});

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -183,7 +183,9 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             error={!!error}
             helperText={error}
             slotProps={{
+              ...params.slotProps,
               inputLabel: {
+                ...params.slotProps?.inputLabel,
                 style: {
                   fontFamily: 'inherit'
                 }


### PR DESCRIPTION
## Problem

Every user/team picker that offers a type-ahead — **Add User**, **Add Team Member**, the **share-modal people picker**, and the dashboard team picker — stopped suggesting as you type. The input still accepted text, but no search fired and the suggestion list never opened.

## Root cause

The MUI v9 `slotProps` migration (`b81e4dc`) rewrote each picker's `renderInput` to hand the `TextField` an explicit `slotProps` object:

```tsx
<TextField
  {...params}
  slotProps={{ input: { ...params.slotProps?.input, endAdornment } }}
/>
```

In MUI v9, the Autocomplete's `renderInput` params expose the native `<input>` wiring under **`params.slotProps.htmlInput`** (the `value`/`onChange`/`onKeyDown`/focus handlers and the anchor `ref` from `getInputProps()`), alongside the `input` and `inputLabel` slots.

A second `slotProps` prop **replaces** — it does not merge with — the `slotProps` spread by `{...params}`. Because the explicit object only set `input` (and sometimes `inputLabel`), `params.slotProps.htmlInput` was dropped. `TextField` sources the native input props solely from that slot (`inputProps: htmlInputProps` ← `slotProps.htmlInput`), so the field rendered a bare `<input>` with none of the Autocomplete's wiring: keystrokes never reached `onInputChange`, the query never ran, and the listbox never opened.

## Fix

Spread `...params.slotProps` into the explicit object so `htmlInput` survives, and **merge** (rather than replace) the `input`/`inputLabel` slots:

```tsx
slotProps={{
  ...params.slotProps,
  inputLabel: { ...params.slotProps?.inputLabel, style: { fontFamily: 'inherit' } },
  input: { ...params.slotProps?.input, endAdornment },
}}
```

Applied to all four affected pickers:

- `UserSearchField` — Add User / Add Team Member
- `UserShareSearch` — share-modal people picker
- `TeamSearchField` — dashboard getting-started widget
- `InputSearchField` — generic search field

## Test plan

- [x] New `UserSearchFieldInput.test.tsx` — types into the picker and asserts the search callback fires with the typed value **and** the matching user renders in the suggestion list. Verified both assertions fail on the pre-fix code and pass after.
- [x] Full suite: 13 suites / 299 tests green.
- [x] `npm run build` (incl. DTS typecheck), `eslint`, and `prettier --check` all clean.

## Downstream

`@sistent/sistent` consumers (e.g. meshery-cloud, currently on `^0.21.18`) pick this up on the next published release + dependency bump.
