### PR TITLE
chore(release): bump package.json to v0.21.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.22.0",
+  "version": "0.21.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sistent/sistent",
-      "version": "0.22.0",
+      "version": "0.21.19",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.22.0",
+  "version": "0.21.19",
   "description": "Reusable React Components and SVG Icons library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` to `v0.21.19` to match the version just published to npm.

This is the version-bump-back that the `Publish Node.js Package` workflow normally opens automatically after a successful `npm publish`. For the `v0.21.19` release the automated step failed (`git exit 128`) because the workflow passed `base: refs/heads/master` (a full ref) instead of the short `master`, so `peter-evans/create-pull-request` refused to fetch into the checked-out branch. Opening it manually here.

Brings `master` (which had drifted ahead to `0.22.0` without a matching npm publish) back in line with the actually-published `0.21.19`.

The commit message carries `[skip ci]` so merging does not re-trigger workflows against the bump commit.