### PR TITLE
fix(modal): prevent fullscreen prop override

### DIFF
--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -159,8 +159,10 @@ export const Modal: React.FC<ModalProps> = ({
   const toggleFullScreen = () => {
     setFullScreen((prev) => !prev);
   };
+const { fullScreen: _ignoredFullScreen, fullWidth: _ignoredFullWidth, ...restProps } = props;
   return (
     <StyledDialog
+      {...restProps}
       maxWidth={maxWidth}
       open={open}
       onClose={closeModal}
@@ -168,7 +170,6 @@ export const Modal: React.FC<ModalProps> = ({
       aria-describedby="alert-dialog-slide-description"
       fullScreen={fullScreen}
       fullWidth={!fullScreen}
-      {...props}
     >
       {title && (
         <ModalStyledHeader className="modal-header" data-testid="modal-header">

--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -14,6 +14,7 @@ interface ModalProps extends DialogProps {
   headerIcon?: React.ReactNode;
   reactNode?: React.ReactNode;
   isFullScreenModeAllowed?: boolean;
+  openFullscreenOnStart?: boolean;
 }
 
 interface ModalFooterProps {
@@ -153,13 +154,19 @@ export const Modal: React.FC<ModalProps> = ({
   children,
   maxWidth = 'xs',
   isFullScreenModeAllowed,
+  openFullscreenOnStart = false,
   ...props
 }) => {
-  const [fullScreen, setFullScreen] = useState(false);
+  const [fullScreen, setFullScreen] = useState(openFullscreenOnStart);
   const toggleFullScreen = () => {
     setFullScreen((prev) => !prev);
   };
-const { fullScreen: _ignoredFullScreen, fullWidth: _ignoredFullWidth, ...restProps } = props;
+  
+  const {
+  fullScreen: _ignoredFullScreen,
+  fullWidth: _ignoredFullWidth,
+  ...restProps
+  } = props;
   return (
     <StyledDialog
       {...restProps}

--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -14,7 +14,6 @@ interface ModalProps extends DialogProps {
   headerIcon?: React.ReactNode;
   reactNode?: React.ReactNode;
   isFullScreenModeAllowed?: boolean;
-  openFullscreenOnStart?: boolean;
 }
 
 interface ModalFooterProps {
@@ -154,19 +153,25 @@ export const Modal: React.FC<ModalProps> = ({
   children,
   maxWidth = 'xs',
   isFullScreenModeAllowed,
-  openFullscreenOnStart = false,
   ...props
 }) => {
-  const [fullScreen, setFullScreen] = useState(openFullscreenOnStart);
+  /*
+   * Use the incoming fullScreen prop only as the initial state.
+   * After initialization, fullscreen is managed internally so, external
+   * fullScreen prop values do not override user-triggered fullscreen toggles.
+   */
+  const {
+    fullScreen: initialFullScreenState = false,
+    fullWidth: _ignoredFullWidth,
+    ...restProps
+  } = props;
+
+  const [fullScreen, setFullScreen] = useState(initialFullScreenState);
+
   const toggleFullScreen = () => {
     setFullScreen((prev) => !prev);
   };
-  
-  const {
-  fullScreen: _ignoredFullScreen,
-  fullWidth: _ignoredFullWidth,
-  ...restProps
-  } = props;
+
   return (
     <StyledDialog
       {...restProps}


### PR DESCRIPTION
**Notes for Reviewers**
### Description

This PR fixes an issue where the Modal component's internal fullscreen state could be overridden by external props.

### Previously:

allowed consumers passing fullScreen or fullWidth props to override the internal fullscreen toggle state managed by the component itself.

This caused fullscreen toggle behavior to fail in downstream consumers such as Meshery's Registry modal.

### Changes Made
Filtered conflicting fullScreen and fullWidth props from external props
Preserved external overrides for unrelated props
Kept internal fullscreen state authoritative

### Testing
Verified fullscreen toggle works correctly locally
Verified dialog now receives MuiDialog-paperFullScreen
Confirmed no unintended changes to unrelated props

[Signed commits](https://github.com/layer5io/sistent/compare/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)

This PR fixes #1617 


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
