### PR TITLE
fix(theme): use default checkbox icon components

### DIFF
--- a/src/icons/Checkbox/CheckboxCheckedIcon.tsx
+++ b/src/icons/Checkbox/CheckboxCheckedIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const CheckboxCheckedIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  ...props
+}: IconProps): JSX.Element => (
+  <svg
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+    fill="currentColor"
+  >
+    <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+  </svg>
+);
+
+export default CheckboxCheckedIcon;

--- a/src/icons/Checkbox/CheckboxCheckedIcon.tsx
+++ b/src/icons/Checkbox/CheckboxCheckedIcon.tsx
@@ -5,6 +5,7 @@ import { IconProps } from '../types';
 export const CheckboxCheckedIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
+  fill = 'currentColor',
   ...props
 }: IconProps): JSX.Element => (
   <svg
@@ -12,8 +13,8 @@ export const CheckboxCheckedIcon = ({
     height={height}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
+    fill={fill}
     {...props}
-    fill="currentColor"
   >
     <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
   </svg>

--- a/src/icons/Checkbox/CheckboxIcon.tsx
+++ b/src/icons/Checkbox/CheckboxIcon.tsx
@@ -5,6 +5,7 @@ import { IconProps } from '../types';
 export const CheckboxIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
+  stroke = 'currentColor',
   ...props
 }: IconProps): JSX.Element => (
   <svg
@@ -12,8 +13,8 @@ export const CheckboxIcon = ({
     height={height}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
-    {...props}
     fill="none"
+    {...props}
   >
     <rect
       x="3"
@@ -21,7 +22,7 @@ export const CheckboxIcon = ({
       width="18"
       height="18"
       rx="2"
-      stroke="currentColor"
+      stroke={stroke}
       strokeWidth="1.5"
     />
   </svg>

--- a/src/icons/Checkbox/CheckboxIcon.tsx
+++ b/src/icons/Checkbox/CheckboxIcon.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
 
+type CheckboxIconProps = IconProps & {
+  innerRectStroke?: string;
+};
+
 export const CheckboxIcon = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
-  stroke = 'currentColor',
+  innerRectStroke = 'currentColor',
   ...props
-}: IconProps): JSX.Element => (
+}: CheckboxIconProps): JSX.Element => (
   <svg
     width={width}
     height={height}
@@ -22,7 +26,7 @@ export const CheckboxIcon = ({
       width="18"
       height="18"
       rx="2"
-      stroke={stroke}
+      stroke={innerRectStroke}
       strokeWidth="1.5"
     />
   </svg>

--- a/src/icons/Checkbox/CheckboxIcon.tsx
+++ b/src/icons/Checkbox/CheckboxIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { IconProps } from '../types';
+
+export const CheckboxIcon = ({
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  ...props
+}: IconProps): JSX.Element => (
+  <svg
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+    fill="none"
+  >
+    <rect
+      x="3"
+      y="3"
+      width="18"
+      height="18"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+export default CheckboxIcon;

--- a/src/icons/Checkbox/index.ts
+++ b/src/icons/Checkbox/index.ts
@@ -1,0 +1,2 @@
+export * from './CheckboxIcon';
+export * from './CheckboxCheckedIcon';

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -206,3 +206,4 @@ export * from './Warning';
 export * from './Wasm';
 export * from './Workspace';
 export * from './Zoom';
+export * from './Checkbox';

--- a/src/theme/components/checkbox.modifier.ts
+++ b/src/theme/components/checkbox.modifier.ts
@@ -15,7 +15,6 @@ export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
       const inverseBackground = ownerState.inverseBackground || false;
 
       return {
-        color: 'transparent',
         '&.Mui-checked': {
           color: defaultText,
           '& .MuiSvgIcon-root': {
@@ -26,6 +25,9 @@ export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
             fill: inverseBackground ? inverseColor : defaultText,
             padding: '0px'
           }
+        },
+        '&:not(.Mui-checked):not(.Mui-indeterminate) .MuiSvgIcon-root': {
+          color: 'transparent'
         },
         '& .MuiSvgIcon-root': {
           width: '1.25rem',

--- a/src/theme/components/checkbox.modifier.ts
+++ b/src/theme/components/checkbox.modifier.ts
@@ -1,13 +1,19 @@
 import { Components, Theme } from '@mui/material';
+import React from 'react';
+import { CheckboxIcon } from '../../icons/Checkbox/CheckboxIcon';
+import { CheckboxCheckedIcon } from '../../icons/Checkbox/CheckboxCheckedIcon';
 
 export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
+  defaultProps: {
+    icon: React.createElement(CheckboxIcon),
+    checkedIcon: React.createElement(CheckboxCheckedIcon),
+  },
   styleOverrides: {
     root: ({ theme, ownerState }) => {
       const {
         palette: {
           text: { default: defaultText },
           icon: { inverse: inverseColor },
-          background: { brand },
           border: { strong }
         }
       } = theme;
@@ -15,25 +21,13 @@ export const MuiCheckbox: Components<Theme>['MuiCheckbox'] = {
       const inverseBackground = ownerState.inverseBackground || false;
 
       return {
+        color: inverseBackground ? inverseColor : strong,
         '&.Mui-checked': {
           color: defaultText,
-          '& .MuiSvgIcon-root': {
-            width: '1.25rem',
-            height: '1.25rem',
-            borderColor: brand?.default,
-            marginLeft: '0px',
-            fill: inverseBackground ? inverseColor : defaultText,
-            padding: '0px'
-          }
-        },
-        '&:not(.Mui-checked):not(.Mui-indeterminate) .MuiSvgIcon-root': {
-          color: 'transparent'
         },
         '& .MuiSvgIcon-root': {
           width: '1.25rem',
           height: '1.25rem',
-          border: `.75px solid ${inverseBackground ? inverseColor : strong}`,
-          borderRadius: '2px',
           padding: '0px'
         },
         '&:hover': {


### PR DESCRIPTION


**Notes for Reviewers**
This PR resolves the checkbox color bleeding bug by adding custom default SVG icons. It ensures that custom child icons (like `FilterAllIcon` in Meshery UI) are fully visible and inherit the correct colors, while standard checkboxes preserve Sistent's exact border design.

This PR fixes #1621 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
