### PR TITLE
suppress unused var lint error in hideRootObjectTitle test

### DIFF
--- a/src/__testing__/hideRootObjectTitle.test.tsx
+++ b/src/__testing__/hideRootObjectTitle.test.tsx
@@ -84,6 +84,7 @@ describe('hideRootObjectTitle — RJSF root title/description derivation', () =>
       return importDesignUiSchema;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { label: _label, ...otherOptions } = existingOptions;
     return {
       ...importDesignUiSchema,


### PR DESCRIPTION
**Notes for Reviewers**

Adds an eslint-disable comment for the `_label` destructure in hideRootObjectTitle.test.tsx to fix the CI lint failure.

Fixes: `@typescript-eslint/no-unused-vars` error on line 91.

<img width="779" height="380" alt="image" src="https://github.com/user-attachments/assets/b3e45039-4e9b-4a0a-bf70-229705fb9762" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
