### PR TITLE
fix: handle React key prop correctly

### DIFF
--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -201,8 +201,10 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             }}
           />
         )}
-        renderOption={(props, option: User) => (
-          <li {...props} id={option.userId}>
+        renderOption={(props, option: User) => {
+          const { key, ...restProps } = props;
+          return (
+            <li key={key} {...restProps} id={option.userId}>
             <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
               {' '}
               <Grid2 container sx={{ alignItems: 'center' }}>
@@ -232,7 +234,8 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
               </Grid2>
             </Box>
           </li>
-        )}
+          );
+        }}
       />
       {showNotifyCheckbox && !isCreate && handleNotifyPref && (
         <FormGroup row={true}>

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -201,10 +201,8 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             }}
           />
         )}
-        renderOption={(props, option: User) => {
-          const { key, ...restProps } = props;
-          return (
-            <li key={key} {...restProps} id={option.userId}>
+        renderOption={({ key, ...restProps }: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key }, option: User) => (
+          <li key={key} {...restProps} id={option.userId}>
             <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
               {' '}
               <Grid2 container sx={{ alignItems: 'center' }}>
@@ -234,8 +232,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
               </Grid2>
             </Box>
           </li>
-          );
-        }}
+        )}
       />
       {showNotifyCheckbox && !isCreate && handleNotifyPref && (
         <FormGroup row={true}>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1644
It removes the React warning caused by spreading the key prop into JSX and passes the key prop correctly.
**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ] Yes, I signed my commits.
