### PR TITLE
Fix Error 153 in Cloud Native Playground YouTube embed

### DIFF
--- a/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
@@ -30,7 +30,7 @@ export interface JourneyStep {
   content: React.ReactNode;
   image?: string;
   videoSrc?: string;
-  video?: boolean;
+  video?: string;
   embed?: boolean;
   previousButton?: boolean;
   isFullScreenModeAllowed?: boolean;

--- a/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/GetStartedModal.tsx
@@ -30,7 +30,7 @@ export interface JourneyStep {
   content: React.ReactNode;
   image?: string;
   videoSrc?: string;
-  video?: string;
+  video?: string | boolean;
   embed?: boolean;
   previousButton?: boolean;
   isFullScreenModeAllowed?: boolean;

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -39,8 +39,9 @@ export const ModalVideo = styled('video')(() => ({
   paddingBlock: '1rem'
 }));
 
-const FallbackLink: React.FC<{ video: string }> = ({ video }) => {
-  const watchLink = video.replace('/embed/', '/watch?v=');
+const FallbackLink: React.FC<{ video: string | boolean }> = ({ video }) => {
+  const videoUrl = typeof video === 'string' ? video : 'https://www.youtube.com/embed/Do7htKrRzDA?si=5iMQ5a1JUf3qpIiH';
+  const watchLink = videoUrl.replace('/embed/', '/watch?v=');
   return (
     <Box sx={{ textAlign: 'center', my: 2 }}>
       <Link
@@ -171,7 +172,7 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
                 aspectRatio: '16/9',
                 width: '100%'
               }}
-              src={data.video}
+              src={typeof data.video === 'string' ? data.video : 'https://www.youtube.com/embed/Do7htKrRzDA?si=5iMQ5a1JUf3qpIiH'}
               title="YouTube video player"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowFullScreen={true}

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -152,7 +152,7 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
               aspectRatio: '16/9',
               width: '100%'
             }}
-            src={data.video}
+            src={data.video ?? undefined}
             title="YouTube video player"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen={true}

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -152,10 +152,11 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
               aspectRatio: '16/9',
               width: '100%'
             }}
-            src="https://www.youtube.com/embed/Do7htKrRzDA?si=5iMQ5a1JUf3qpIiH"
+            src={data.video}
             title="YouTube video player"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen={true}
+            referrerPolicy="strict-origin-when-cross-origin"
           ></iframe>
         ) : (
           ''

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -152,7 +152,7 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
               aspectRatio: '16/9',
               width: '100%'
             }}
-            src={data.video ?? undefined}
+            src={data.video}
             title="YouTube video player"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen={true}

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -157,6 +157,7 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen={true}
             referrerPolicy="strict-origin-when-cross-origin"
+            loading="lazy"
           ></iframe>
         ) : (
           ''

--- a/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/JourneyModal.tsx
@@ -3,6 +3,7 @@
 import MesheryDesignEmbedUmd from '@layer5/meshery-design-embed';
 import _ from 'lodash';
 import { useEffect, useState } from 'react';
+import { Link, Box } from '@mui/material';
 import { styled } from '../../../theme';
 import { JourneyStep, ProfileData, StepData } from './GetStartedModal';
 import ReusableModal from './ReusableModal';
@@ -37,6 +38,23 @@ export const ModalVideo = styled('video')(() => ({
   aspectRatio: '16/9',
   paddingBlock: '1rem'
 }));
+
+const FallbackLink: React.FC<{ video: string }> = ({ video }) => {
+  const watchLink = video.replace('/embed/', '/watch?v=');
+  return (
+    <Box sx={{ textAlign: 'center', my: 2 }}>
+      <Link
+        href={watchLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        underline="hover"
+        sx={{ fontWeight: 'bold' }}
+      >
+        ▶ Having trouble viewing? Watch on YouTube
+      </Link>
+    </Box>
+  );
+};
 
 const JourneyModal: React.FC<JourneyModalProps> = ({
   open,
@@ -147,18 +165,21 @@ const JourneyModal: React.FC<JourneyModalProps> = ({
           ''
         )}
         {data.video !== undefined ? (
-          <iframe
-            style={{
-              aspectRatio: '16/9',
-              width: '100%'
-            }}
-            src={data.video}
-            title="YouTube video player"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen={true}
-            referrerPolicy="strict-origin-when-cross-origin"
-            loading="lazy"
-          ></iframe>
+          <div>
+            <iframe
+              style={{
+                aspectRatio: '16/9',
+                width: '100%'
+              }}
+              src={data.video}
+              title="YouTube video player"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen={true}
+              referrerPolicy="strict-origin-when-cross-origin"
+              loading="lazy"
+            ></iframe>
+            <FallbackLink video={data.video} />
+          </div>
         ) : (
           ''
         )}


### PR DESCRIPTION
**Notes for Reviewers**

## Description
This PR addresses the "Error 153" video player configuration issue that occurs in the Cloud Native Playground modal (`JourneyModal.tsx`) when viewed by users with strict privacy settings, browser shields (e.g., Brave), or ad-blockers.
**The Problem:**
When strict privacy configurations block the YouTube iframe embed, the player throws a configuration error (Error 153). 
**The Solution:**
To ensure a robust and graceful user experience, this PR introduces a permanent `FallbackLink` component rendered immediately beneath the iframe. 
- It automatically parses the `data.video` embed URL and transforms it into a direct YouTube `watch?v=` hyperlink.
- It provides a reliable fallback: ` Having trouble viewing? Watch on YouTube`
- The link is constructed using Material UI's `<Box>` and `<Link>` components, ensuring it natively inherits Sistent's global theme, colors, and hover states without relying on hardcoded CSS or hex colors.

<img width="2880" height="1720" alt="{003F2929-7C08-4A20-9606-1418C2225AEE}" src="https://github.com/user-attachments/assets/6f598278-eeec-4df9-9f36-c2a0b9126d10" />


This PR fixes #20118(meshery) -> https://github.com/meshery/meshery/issues/20118

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [ ✅] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
