### PR TITLE
chore(deps-dev): bump @meshery/schemas from 1.3.8 to 1.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "1.3.8",
+        "@meshery/schemas": "1.3.13",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3276,9 +3276,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.8.tgz",
-      "integrity": "sha512-DpMkpLPIP1P3bL/TBLnBOk+Yux1BpGGhCJBdxjZlvQAfmyXq0wq16v9g2z3RcjeihNp2ccMjV69g396l3AO14w==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.13.tgz",
+      "integrity": "sha512-VZw8yrKiBrxvJxFysOMQuuPJkDwGZ2DuW7ifPGJ6OxfBygAGIYuN4kofmPTglcW/WPhEYn656HM7/zahSmlcRg==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "1.3.8",
+    "@meshery/schemas": "1.3.13",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",


### PR DESCRIPTION
## Description

Bumps `@meshery/schemas` (devDependency) from **1.3.8** to **1.3.13**, the current
`latest` on npm.

`1.3.13` is the release that standardizes the Meshery ecosystem on
`github.com/gofrs/uuid`, reversing a brief `google/uuid` convergence that panicked
`gobuffalo/pop` (v4.13.1 hardcodes a gofrs `UUID` type assertion) on every DB write in
the pop-backed services. Keeping sistent on the same schemas release as
`meshery`, `meshkit`, and `meshery-cloud` keeps the design-system's generated types
aligned with the rest of the stack.

The substance of the release is Go-side. For TypeScript consumers a `format: uuid`
field maps to `string`, so sistent's type surface is unchanged - this is a routine
keep-current dependency bump.

## Test plan

- [x] `npm run build` (tsup) - CJS, ESM, **and DTS** all succeed. The DTS step runs the
      TypeScript compiler against schemas 1.3.13's `.d.ts`, so a green DTS build proves
      the new types are compatible with sistent's source (no breaking type changes
      across 1.3.8 -> 1.3.13).
- [x] `npm test` (jest) - **14 suites / 303 tests pass** (also re-run green by the
      pre-commit hook).
- [x] Lockfile updated consistently: `package.json` devDep, the lock manifest mirror,
      the installed `node_modules` entry, and `resolved`/`integrity` all point at
      `schemas-1.3.13.tgz`. Diff is schemas-only (2 files, 5/5 lines).

## Notes

- `@sistent/mui-datatables` (consumed by sistent) carries **no** `@meshery/schemas`
  dependency - direct or transitive - so it needs no schemas bump and is already at the
  latest published `8.0.0`.
