### PR TITLE
feat(ViewSwitch): add reusable ViewSwitch component

### DIFF
--- a/src/custom/ViewSwitch/ViewSwitch.tsx
+++ b/src/custom/ViewSwitch/ViewSwitch.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { IconButton } from '../../base/IconButton';
+import { GridOnIcon } from '../../icons/GridOn';
+import { TableChartIcon } from '../../icons/TableChart';
+import { useTheme } from '../../theme';
+import { CustomTooltip } from '../CustomTooltip';
+
+export type ViewMode = 'grid' | 'table';
+
+export interface ViewSwitchProps {
+  // The current active view mode.
+  view: ViewMode;
+  // Callback invoked with the next view mode when the user clicks the toggle.
+  changeView: (nextView: ViewMode) => void;
+  // Optional additional styles for the icon button.
+  style?: React.CSSProperties;
+  // If true, the switch is disabled.
+  disabled?: boolean;
+  // Optional custom aria-label for the button.
+  ariaLabel?: string;
+  // Optional custom tooltip for the grid view icon (shown when in table view).
+  gridViewTooltip?: string;
+  // Optional custom tooltip for the table view icon (shown when in grid view).
+  tableViewTooltip?: string;
+}
+
+function ViewSwitch({
+  view,
+  changeView,
+  style,
+  disabled = false,
+  ariaLabel = 'Switch View',
+  gridViewTooltip = 'Grid View',
+  tableViewTooltip = 'Table View'
+}: ViewSwitchProps): JSX.Element {
+  const theme = useTheme();
+  const isGrid = view === 'grid';
+  const tooltipTitle = isGrid ? tableViewTooltip : gridViewTooltip;
+
+  return (
+    <CustomTooltip title={tooltipTitle}>
+      <span>
+        <IconButton
+          size="small"
+          disabled={disabled}
+          onClick={() => {
+            changeView(isGrid ? 'table' : 'grid');
+          }}
+          aria-label={ariaLabel}
+          sx={{ ...style }}
+        >
+          {isGrid ? (
+            <TableChartIcon style={{ color: theme.palette.icon.default }} />
+          ) : (
+            <GridOnIcon style={{ color: theme.palette.icon.default }} />
+          )}
+        </IconButton>
+      </span>
+    </CustomTooltip>
+  );
+}
+
+export default ViewSwitch;
+

--- a/src/custom/ViewSwitch/index.ts
+++ b/src/custom/ViewSwitch/index.ts
@@ -1,0 +1,4 @@
+import ViewSwitch from './ViewSwitch';
+
+export { ViewSwitch };
+export type { ViewMode, ViewSwitchProps } from './ViewSwitch';

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -52,6 +52,7 @@ import { TransferListProps } from './TransferModal/TransferList/TransferList';
 import UniversalFilter, { UniversalFilterProps } from './UniversalFilter';
 import { UsersTable, UserTableAvatarInfo } from './UsersTable';
 import { VisibilityChipMenu } from './VisibilityChipMenu';
+import { ViewSwitch, ViewSwitchProps, ViewMode } from './ViewSwitch';
 export { CatalogCard } from './CatalogCard';
 export { CatalogFilterSidebar } from './CatalogFilterSection';
 export type { FilterListType } from './CatalogFilterSection';
@@ -121,6 +122,7 @@ export {
   UsersTable,
   UserTableAvatarInfo,
   useWindowDimensions,
+  ViewSwitch,
   VisibilityChipMenu,
   withErrorBoundary,
   withSuppressedErrorBoundary
@@ -161,7 +163,9 @@ export type {
   StyledCardProps,
   TableAction,
   TransferListProps,
-  UniversalFilterProps
+  UniversalFilterProps,
+  ViewMode,
+  ViewSwitchProps
 };
 
 export * from './CatalogDesignTable';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1663

### Description
Add a reusable `ViewSwitch` component to Sistent


**Changes:**
- Created `src/custom/ViewSwitch/ViewSwitch.tsx` - the component with `ViewMode` type and `ViewSwitchProps` interface
- Created `src/custom/ViewSwitch/index.ts` - barrel export
- Updated `src/custom/index.tsx` - registered `ViewSwitch`, `ViewSwitchProps`, and `ViewMode` exports

### Screenshot & Demo


https://github.com/user-attachments/assets/f68e85e2-e6b8-418b-965f-224249305db9



```bash
 PASS  src/__testing__/useWindowDimensions.test.tsx
 PASS  src/__testing__/hideRootObjectTitle.test.tsx
 PASS  src/__testing__/RJSFFormWrapper.test.tsx
 PASS  src/__testing__/Icons.test.tsx

Test Suites: 14 passed, 14 total
Tests:       303 passed, 303 total
Snapshots:   0 total
Time:        2.664 s, estimated 3 s
Ran all test suites.
```

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
