### PR TITLE
fix(icon): forward fill prop to path elements in ExternalLink and Dow…

### DIFF
--- a/src/icons/Download/Download.tsx
+++ b/src/icons/Download/Download.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
-import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
+
 export const DownloadIcon: FC<IconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
-  fill = '#455a64',
+  fill = DEFAULT_FILL_NONE,
   style = {}
 }) => (
   <svg
@@ -12,10 +13,12 @@ export const DownloadIcon: FC<IconProps> = ({
     height={height}
     viewBox="0 -960 960 960"
     width={width}
-    fill={fill}
     style={style}
   >
-    <path d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z" />
+    <path
+      d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"
+      fill={fill}
+    />
   </svg>
 );
 

--- a/src/icons/Download/Download.tsx
+++ b/src/icons/Download/Download.tsx
@@ -6,14 +6,14 @@ export const DownloadIcon: FC<IconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   fill = DEFAULT_FILL_NONE,
-  style = {}
+  ...props
 }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     height={height}
     viewBox="0 -960 960 960"
     width={width}
-    style={style}
+    {...props}
   >
     <path
       d="M480-320 280-520l56-58 104 104v-326h80v326l104-104 56 58-200 200ZM240-160q-33 0-56.5-23.5T160-240v-120h80v120h480v-120h80v120q0 33-23.5 56.5T720-160H240Z"

--- a/src/icons/ExternalLink/Externallink.tsx
+++ b/src/icons/ExternalLink/Externallink.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
-import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
 
 export const ExternalLinkIcon: FC<IconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
+  fill = DEFAULT_FILL_NONE,
   ...props
 }) => {
   return (
@@ -15,7 +16,10 @@ export const ExternalLinkIcon: FC<IconProps> = ({
       viewBox="0 -960 960 960"
       {...props}
     >
-      <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z" />
+      <path
+        d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h560v-280h80v280q0 33-23.5 56.5T760-120H200Zm188-212-56-56 372-372H560v-80h280v280h-80v-144L388-332Z"
+        fill={fill}
+      />
     </svg>
   );
 };


### PR DESCRIPTION
**Notes for Reviewers**

This PR resolves an inconsistency in `ExternalLinkIcon` and `DownloadIcon` where they did not support or forward the `fill` prop correctly to their underlying `<path>` elements.
### Root Cause / Changes
Standard Sistent icons (like `AddIcon` and `FileUploadIcon`) destructure `fill = DEFAULT_FILL_NONE` (`"currentColor"`) and apply it to their `<path>` tags, enabling containers (like buttons) to dynamically color them. 
However:
1. **`ExternalLinkIcon` (`Externallink.tsx`):** Completely omitted `fill` from destructuring and did not pass it to `<path />`.
2. **`DownloadIcon` (`Download.tsx`):** Destructured a hardcoded default `fill = '#455a64'` and applied it to `<svg>` instead of `<path />`.
**Changes made in this PR:**
* Standardized both icons to destructure `fill = DEFAULT_FILL_NONE` from their props.
* Forwarded the `fill` attribute directly to the `<path>` elements of both icons.
* Verified code formatting via Prettier and ran eslint checks.
<img width="2640" height="1500" alt="{9FEE60FC-641A-4DAA-8328-5D4A1F51F879}" src="https://github.com/user-attachments/assets/9c6c610e-4b43-4280-956f-932493da6b69" />
<img width="1510" height="909" alt="{22157358-9DFA-4CC1-AC1C-96A62548DE9A}" src="https://github.com/user-attachments/assets/c21e8a0f-0300-412c-bab1-eb3eabc44e2b" />
<img width="1488" height="889" alt="{67F9CC2E-BA88-4E73-A1E2-A6978506ED3D}" src="https://github.com/user-attachments/assets/555e9d2a-1592-4397-af6a-d89d3413a25d" />
<img width="1533" height="938" alt="{FF368351-49A1-4C13-A2D3-31A7DFBAD36A}" src="https://github.com/user-attachments/assets/a0a6b73d-66f0-4a62-85dc-bc1ee4772271" />


This PR fixes #1669  and https://github.com/meshery/meshery/issues/20065

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [✅ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
