### PR TITLE
feat(bulk-action): create reusable BulkActionToolbar component

### DIFF
--- a/src/__testing__/BulkActionToolbar.test.tsx
+++ b/src/__testing__/BulkActionToolbar.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}));
+
+jest.mock('remark-gfm', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+jest.mock('rehype-raw', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+import { BulkActionToolbar } from '../custom/BulkActionToolbar';
+import { SistentThemeProviderWithoutBaseLine } from '../theme';
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<SistentThemeProviderWithoutBaseLine>{ui}</SistentThemeProviderWithoutBaseLine>);
+}
+
+describe('BulkActionToolbar', () => {
+  it('renders null when selectedCount is 0', () => {
+    const { container } = renderWithTheme(<BulkActionToolbar selectedCount={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders selected count and children when selectedCount > 0', () => {
+    renderWithTheme(
+      <BulkActionToolbar selectedCount={3}>
+        <button data-testid="custom-action">Delete</button>
+      </BulkActionToolbar>
+    );
+
+    expect(screen.getByText('3 selected')).toBeTruthy();
+    expect(screen.getByTestId('custom-action')).toBeTruthy();
+  });
+
+  it('renders deselect button and handles callback', () => {
+    const onDeselectAll = jest.fn();
+    renderWithTheme(<BulkActionToolbar selectedCount={5} onDeselectAll={onDeselectAll} />);
+
+    const deselectButton = screen.getByTestId('deselect-all-button');
+    expect(deselectButton).toBeTruthy();
+
+    fireEvent.click(deselectButton);
+    expect(onDeselectAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__testing__/BulkActionToolbar.test.tsx
+++ b/src/__testing__/BulkActionToolbar.test.tsx
@@ -50,4 +50,17 @@ describe('BulkActionToolbar', () => {
     fireEvent.click(deselectButton);
     expect(onDeselectAll).toHaveBeenCalledTimes(1);
   });
+
+  it('renders custom labels when provided', () => {
+    renderWithTheme(
+      <BulkActionToolbar
+        selectedCount={3}
+        onDeselectAll={jest.fn()}
+        deselectAllLabel="Clear Selection"
+        selectedLabel="items chosen"
+      />
+    );
+
+    expect(screen.getByText('3 items chosen')).toBeTruthy();
+  });
 });

--- a/src/custom/BulkActionToolbar/BulkActionToolbar.tsx
+++ b/src/custom/BulkActionToolbar/BulkActionToolbar.tsx
@@ -25,6 +25,8 @@ export interface BulkActionToolbarProps {
   children?: React.ReactNode;
   style?: React.CSSProperties;
   'data-testid'?: string;
+  deselectAllLabel?: string;
+  selectedLabel?: string;
 }
 
 export const BulkActionToolbar: React.FC<BulkActionToolbarProps> = ({
@@ -32,7 +34,9 @@ export const BulkActionToolbar: React.FC<BulkActionToolbarProps> = ({
   onDeselectAll,
   children,
   style = {},
-  'data-testid': testId = 'bulk-action-toolbar'
+  'data-testid': testId = 'bulk-action-toolbar',
+  deselectAllLabel = 'Deselect ALL',
+  selectedLabel = 'selected'
 }) => {
   const theme = useTheme();
 
@@ -46,7 +50,7 @@ export const BulkActionToolbar: React.FC<BulkActionToolbarProps> = ({
     <StyledToolbar style={style} data-testid={testId}>
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         {onDeselectAll && (
-          <CustomTooltip title="Deselect ALL" arrow>
+          <CustomTooltip title={deselectAllLabel} arrow>
             <IconButton
               onClick={onDeselectAll}
               sx={{ marginRight: theme.spacing(2) }}
@@ -57,7 +61,7 @@ export const BulkActionToolbar: React.FC<BulkActionToolbarProps> = ({
           </CustomTooltip>
         )}
         <Typography variant="subtitle1" sx={{ fontWeight: 600, color: theme.palette.text.default }}>
-          {selectedCount} selected
+          {selectedCount} {selectedLabel}
         </Typography>
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: theme.spacing(1) }}>{children}</Box>

--- a/src/custom/BulkActionToolbar/BulkActionToolbar.tsx
+++ b/src/custom/BulkActionToolbar/BulkActionToolbar.tsx
@@ -1,0 +1,68 @@
+import { styled } from '@mui/material/styles';
+import React from 'react';
+import { Box, IconButton, Toolbar, Typography } from '../../base';
+import { IndeterminateCheckBoxIcon } from '../../icons';
+import { useTheme } from '../../theme';
+import { CustomTooltip } from '../CustomTooltip';
+
+const StyledToolbar = styled(Toolbar)(({ theme }) => ({
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? theme.palette.background.card
+      : theme.palette.background.secondary,
+  paddingLeft: theme.spacing(3),
+  paddingRight: theme.spacing(3),
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  minHeight: '64px'
+}));
+
+export interface BulkActionToolbarProps {
+  selectedCount: number;
+  onDeselectAll?: () => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  'data-testid'?: string;
+}
+
+export const BulkActionToolbar: React.FC<BulkActionToolbarProps> = ({
+  selectedCount,
+  onDeselectAll,
+  children,
+  style = {},
+  'data-testid': testId = 'bulk-action-toolbar'
+}) => {
+  const theme = useTheme();
+
+  if (selectedCount <= 0) {
+    return null;
+  }
+
+  const iconFill = theme.palette.icon.default;
+
+  return (
+    <StyledToolbar style={style} data-testid={testId}>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        {onDeselectAll && (
+          <CustomTooltip title="Deselect ALL" arrow>
+            <IconButton
+              onClick={onDeselectAll}
+              sx={{ marginRight: theme.spacing(2) }}
+              data-testid="deselect-all-button"
+            >
+              <IndeterminateCheckBoxIcon fill={iconFill} />
+            </IconButton>
+          </CustomTooltip>
+        )}
+        <Typography variant="subtitle1" sx={{ fontWeight: 600, color: theme.palette.text.default }}>
+          {selectedCount} selected
+        </Typography>
+      </Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: theme.spacing(1) }}>{children}</Box>
+    </StyledToolbar>
+  );
+};
+
+export default BulkActionToolbar;

--- a/src/custom/BulkActionToolbar/index.ts
+++ b/src/custom/BulkActionToolbar/index.ts
@@ -1,0 +1,2 @@
+export * from './BulkActionToolbar';
+export { default as BulkActionToolbar } from './BulkActionToolbar';

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -1,6 +1,7 @@
 import { ActionButton } from './ActionButton';
 import { BBChart } from './BBChart';
 import { BookmarkNotification } from './BookmarkNotification';
+import BulkActionToolbar, { BulkActionToolbarProps } from './BulkActionToolbar';
 import { Carousel } from './Carousel';
 import CatalogFilter, { CatalogFilterProps } from './CatalogFilter/CatalogFilter';
 import { ChapterCard } from './ChapterCard';
@@ -82,6 +83,7 @@ export {
   ActionButton,
   BBChart,
   BookmarkNotification,
+  BulkActionToolbar,
   Carousel,
   CatalogCardDesignLogo,
   CatalogFilter,
@@ -149,6 +151,7 @@ export { BasicMarkdown, RenderMarkdown };
 export { CustomizedStepper, useStepper } from './Stepper';
 
 export type {
+  BulkActionToolbarProps,
   CatalogFilterProps,
   ColView,
   CustomColumn,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,3 +23,5 @@ export { FeedbackButton, type FeedbackComponentProps } from './custom/Feedback';
 // `@sistent/mui-datatables` and would crash the dts build) precisely so this
 // explicit re-export can force them into the published declaration bundle.
 export { getCopyDeepLinkAction, type TableAction } from './custom/TableActions';
+
+export { BulkActionToolbar, type BulkActionToolbarProps } from './custom/BulkActionToolbar';


### PR DESCRIPTION
**Notes for Reviewers**

This PR implements a standardized, reusable `BulkActionToolbar` custom component in Sistent (resolving sub-issue #1665 under the #1661 umbrella).

This component is designed to replace the duplicate and custom `CustomToolbarSelect` headers implemented across `meshery-ui` and other Layer5 projects.

### Changes
* Created `src/custom/BulkActionToolbar/BulkActionToolbar.tsx` which implements the selection bar containing the selected count and an optional "Deselect ALL" checkbox action button.
* Reuses Sistent theme design tokens (`theme.palette.background.secondary`, `theme.palette.background.card`, `theme.palette.text.default`) for proper light/dark mode contrast.
* Returns `null` if `selectedCount <= 0` to hide itself automatically.
* Created unit tests in `src/__testing__/BulkActionToolbar.test.tsx` to verify component mounting, children rendering, and click events.
* Registered the component in custom and root barrel files to prevent rollup-plugin-dts nested declaration bugs.

### Integration and preview ->
When integrated with `mui-datatables` as a `customToolbarSelect` replacement, the `BulkActionToolbar` cleanly renders the deselect action `[-]`, selection count (`X selected`), and custom action buttons (like Delete/Compare) next to the table's default selection label:

<img width="2880" height="1800" alt="{2D4940A7-2A81-4FDD-A858-08C77056F932}" src="https://github.com/user-attachments/assets/0dfd1402-6ebc-43fa-8696-36017d7baa2b" />


This PR fixes #1665 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [✅ ] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
