### PR TITLE
feat(DangerConfirmationModal): add destructive-action confirmation modal

### DIFF
--- a/src/__testing__/DangerConfirmationModal.test.tsx
+++ b/src/__testing__/DangerConfirmationModal.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  DangerConfirmationModal,
+  type DangerConfirmationModalProps
+} from '../custom/DangerConfirmationModal';
+import { SistentThemeProvider } from '../theme';
+
+// The Modal primitives transitively import CustomTooltip -> Markdown ->
+// react-markdown (ESM-only). Jest's transformIgnorePatterns allowlist excludes
+// the markdown ESM tree, so those leaf modules are stubbed here (this suite
+// never exercises markdown rendering). Mirrors CatalogFilterSection.test.tsx.
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}));
+
+jest.mock('remark-gfm', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+jest.mock('rehype-raw', () => ({
+  __esModule: true,
+  default: () => {}
+}));
+
+const renderModal = (props: Partial<DangerConfirmationModalProps> = {}) => {
+  const onConfirm = jest.fn();
+  const onCancel = jest.fn();
+  const utils = render(
+    <SistentThemeProvider>
+      <DangerConfirmationModal
+        open
+        title="Delete organization"
+        description="This action cannot be undone."
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        {...props}
+      />
+    </SistentThemeProvider>
+  );
+  return { onConfirm, onCancel, ...utils };
+};
+
+const getConfirmButton = () =>
+  screen.getByTestId('danger-confirmation-confirm') as HTMLButtonElement;
+
+describe('DangerConfirmationModal', () => {
+  it('enables confirm only after the single required checkbox is ticked, then fires onConfirm', () => {
+    const { onConfirm } = renderModal({
+      checkboxes: [{ id: 'ack', label: 'I understand this is permanent.' }]
+    });
+
+    const confirm = getConfirmButton();
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /permanent/i }));
+    expect(confirm.disabled).toBe(false);
+
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps confirm disabled until the confirmation phrase matches exactly', () => {
+    renderModal({ confirmationPhrase: 'Acme Corp' });
+
+    const confirm = getConfirmButton();
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: 'Acme' } });
+    expect(confirm.disabled).toBe(true);
+
+    // Case-sensitive: a near-miss must not unlock the action.
+    fireEvent.change(input, { target: { value: 'acme corp' } });
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: 'Acme Corp' } });
+    expect(confirm.disabled).toBe(false);
+  });
+
+  it('requires the phrase AND every required checkbox before enabling confirm', () => {
+    renderModal({
+      confirmationPhrase: 'Acme Corp',
+      checkboxes: [
+        { id: 'ack', label: 'I understand this is permanent.' },
+        { id: 'shared', label: 'I understand shared resources will be destroyed.' }
+      ]
+    });
+
+    const confirm = getConfirmButton();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Acme Corp' } });
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /permanent/i }));
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /shared resources/i }));
+    expect(confirm.disabled).toBe(false);
+  });
+
+  it('does not gate on a checkbox marked required: false', () => {
+    renderModal({
+      checkboxes: [{ id: 'optional', label: 'Email me a copy of the audit log.', required: false }]
+    });
+
+    expect(getConfirmButton().disabled).toBe(false);
+  });
+
+  it('honors defaultChecked so a pre-ticked required checkbox enables confirm immediately', () => {
+    renderModal({
+      checkboxes: [{ id: 'ack', label: 'I understand this is permanent.', defaultChecked: true }]
+    });
+
+    expect(getConfirmButton().disabled).toBe(false);
+  });
+
+  it('fires onCancel from the Cancel button', () => {
+    const { onCancel } = renderModal();
+
+    fireEvent.click(screen.getByTestId('danger-confirmation-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the recommended-alternative callout only when provided', () => {
+    const { rerender } = renderModal();
+    expect(screen.queryByTestId('danger-confirmation-recommended-alternative')).toBeNull();
+
+    rerender(
+      <SistentThemeProvider>
+        <DangerConfirmationModal
+          open
+          title="Delete organization"
+          description="This action cannot be undone."
+          recommendedAlternative={<span>Transfer ownership instead.</span>}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </SistentThemeProvider>
+    );
+    expect(screen.getByTestId('danger-confirmation-recommended-alternative')).not.toBeNull();
+    expect(screen.getByText('Transfer ownership instead.')).not.toBeNull();
+  });
+
+  it('blocks the primary action and dismissal while a destructive request is in flight', () => {
+    const { onCancel } = renderModal({ isConfirming: true });
+
+    expect(getConfirmButton().disabled).toBe(true);
+    expect((screen.getByTestId('danger-confirmation-cancel') as HTMLButtonElement).disabled).toBe(
+      true
+    );
+
+    fireEvent.click(screen.getByTestId('danger-confirmation-cancel'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('resets the typed phrase each time the modal reopens', () => {
+    const stableCheckboxes = [{ id: 'ack', label: 'I understand this is permanent.' }];
+    const ui = (open: boolean) => (
+      <SistentThemeProvider>
+        <DangerConfirmationModal
+          open={open}
+          title="Delete organization"
+          description="This action cannot be undone."
+          confirmationPhrase="Acme Corp"
+          checkboxes={stableCheckboxes}
+          onConfirm={jest.fn()}
+          onCancel={jest.fn()}
+        />
+      </SistentThemeProvider>
+    );
+
+    const { rerender } = render(ui(true));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Acme Corp' } });
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('Acme Corp');
+
+    rerender(ui(false));
+    rerender(ui(true));
+
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('');
+    expect(getConfirmButton().disabled).toBe(true);
+  });
+});

--- a/src/custom/DangerConfirmationModal/DangerConfirmationModal.stories.tsx
+++ b/src/custom/DangerConfirmationModal/DangerConfirmationModal.stories.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import { Typography } from '../../base';
+import { SistentThemeProvider } from '../../theme';
+import { DangerConfirmationModal } from './DangerConfirmationModal';
+
+/**
+ * Sistent does not yet ship a Storybook runner, so these stories are authored
+ * in standard CSF3 (a default `meta` export plus named story exports) and can
+ * be dropped into a Storybook once one is configured - swap the local `Story`
+ * type for `StoryObj<typeof DangerConfirmationModal>` at that point. The same
+ * three scenarios are exercised headlessly in
+ * `src/__testing__/DangerConfirmationModal.test.tsx`.
+ */
+const meta = {
+  title: 'Custom/DangerConfirmationModal',
+  component: DangerConfirmationModal
+};
+
+export default meta;
+
+type Story = { name?: string; render: () => React.ReactElement };
+
+const TriggerButton = ({
+  label,
+  onClick
+}: {
+  label: string;
+  onClick: () => void;
+}): React.ReactElement => (
+  <button type="button" onClick={onClick}>
+    {label}
+  </button>
+);
+
+/** (a) Simple checkbox-only confirmation. */
+const CheckboxOnlyDemo = (): React.ReactElement => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SistentThemeProvider>
+      <TriggerButton label="Delete workspace" onClick={() => setOpen(true)} />
+      <DangerConfirmationModal
+        open={open}
+        title="Delete workspace"
+        description={
+          <>
+            This permanently deletes the <b>Payments</b> workspace and everything inside it. This
+            action cannot be undone.
+          </>
+        }
+        checkboxes={[
+          {
+            id: 'acknowledge',
+            label: 'I understand this action is permanent and cannot be undone.'
+          }
+        ]}
+        confirmText="Delete workspace"
+        onCancel={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+      />
+    </SistentThemeProvider>
+  );
+};
+
+/** (b) Type-to-confirm phrase gate plus a single acknowledgement checkbox. */
+const TypeToConfirmWithCheckboxDemo = (): React.ReactElement => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SistentThemeProvider>
+      <TriggerButton label="Delete organization" onClick={() => setOpen(true)} />
+      <DangerConfirmationModal
+        open={open}
+        title="Delete organization"
+        description={
+          <>
+            Deleting <b>Acme Corp</b> removes all of its workspaces, teams, and connections for
+            every member.
+          </>
+        }
+        confirmationPhrase="Acme Corp"
+        checkboxes={[
+          {
+            id: 'acknowledge',
+            label: 'I understand this will permanently delete the organization.'
+          }
+        ]}
+        confirmText="Delete organization"
+        onCancel={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+      />
+    </SistentThemeProvider>
+  );
+};
+
+/**
+ * (c) Full destructive flow: type-to-confirm + primary destruction checkbox +
+ * an extra shared-resource checkbox + a recommended-alternative callout.
+ */
+const FullDestructiveFlowDemo = (): React.ReactElement => {
+  const [open, setOpen] = useState(false);
+  return (
+    <SistentThemeProvider>
+      <TriggerButton label="Delete organization" onClick={() => setOpen(true)} />
+      <DangerConfirmationModal
+        open={open}
+        title="Delete organization"
+        description={
+          <>
+            Deleting <b>Acme Corp</b> permanently destroys all of its workspaces, teams, designs,
+            and connections. This cannot be undone.
+          </>
+        }
+        confirmationPhrase="Acme Corp"
+        checkboxes={[
+          {
+            id: 'acknowledge',
+            label: 'I understand this action is permanent and cannot be undone.'
+          },
+          {
+            id: 'shared-resources',
+            label:
+              'I understand 12 resources shared with other organizations will be permanently destroyed.'
+          }
+        ]}
+        recommendedAlternative={
+          <Typography variant="body2" component="div">
+            Prefer to keep this data? <b>Transfer ownership</b> to another member instead of
+            deleting the organization.
+          </Typography>
+        }
+        confirmText="Delete organization"
+        onCancel={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+      />
+    </SistentThemeProvider>
+  );
+};
+
+export const CheckboxOnly: Story = {
+  name: 'Checkbox only',
+  render: () => <CheckboxOnlyDemo />
+};
+
+export const TypeToConfirmWithCheckbox: Story = {
+  name: 'Type-to-confirm + checkbox',
+  render: () => <TypeToConfirmWithCheckboxDemo />
+};
+
+export const FullDestructiveFlow: Story = {
+  name: 'Type-to-confirm + shared-resource checkbox + recommended alternative',
+  render: () => <FullDestructiveFlowDemo />
+};

--- a/src/custom/DangerConfirmationModal/DangerConfirmationModal.tsx
+++ b/src/custom/DangerConfirmationModal/DangerConfirmationModal.tsx
@@ -1,5 +1,5 @@
 import { DialogProps } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useId, useState } from 'react';
 import { Checkbox, FormControlLabel, FormGroup, TextField, Typography } from '../../base';
 import { iconLarge, iconMedium } from '../../constants/iconsSizes';
 import { IdeaIcon, WarningIcon } from '../../icons';
@@ -118,24 +118,34 @@ export const DangerConfirmationModal: React.FC<DangerConfirmationModalProps> = (
 }) => {
   const theme = useTheme();
   const checkboxList = checkboxes ?? [];
+  const confirmationInputId = useId();
 
   const [typedValue, setTypedValue] = useState('');
   const [checkedState, setCheckedState] = useState<Record<string, boolean>>(() =>
     buildInitialCheckedState(checkboxList)
   );
 
-  // Reset the ephemeral gate state each time the modal opens so a reused
-  // instance never leaks a previous attempt's typed value or ticks. Keyed on
-  // `open` alone: re-seeding on every `checkboxes` identity change would wipe
-  // the user's in-progress selections whenever the parent re-renders.
+  // Serialize only the stable, non-circular checkbox fields for use as an
+  // effect dependency. The `label` is a ReactNode and would throw
+  // (`Converting circular structure to JSON`) if stringified, so it is omitted;
+  // only `id`/`required`/`defaultChecked` affect the seeded state.
+  const serializedCheckboxes = JSON.stringify(
+    checkboxes?.map(({ id, required, defaultChecked }) => ({ id, required, defaultChecked })) ?? []
+  );
+
+  // Reset the ephemeral gate state each time the modal opens (or the checkbox
+  // config genuinely changes) so a reused instance never leaks a previous
+  // attempt's typed value or ticks. Keying on the serialized config - not the
+  // raw array reference - avoids wiping in-progress selections when the parent
+  // re-renders with a new reference carrying unchanged values.
   useEffect(() => {
     if (open) {
       setTypedValue('');
-      setCheckedState(buildInitialCheckedState(checkboxes ?? []));
+      setCheckedState(buildInitialCheckedState(JSON.parse(serializedCheckboxes)));
     }
-  }, [open]);
+  }, [open, serializedCheckboxes]);
 
-  const typedGateSatisfied = !confirmationPhrase || typedValue === confirmationPhrase;
+  const typedGateSatisfied = confirmationPhrase === undefined || typedValue === confirmationPhrase;
   const checkboxGateSatisfied = checkboxList.every(
     (checkbox) => checkbox.required === false || Boolean(checkedState[checkbox.id])
   );
@@ -191,11 +201,11 @@ export const DangerConfirmationModal: React.FC<DangerConfirmationModalProps> = (
 
         {confirmationPhrase !== undefined && (
           <ConfirmField>
-            <ConfirmFieldLabel htmlFor="danger-confirmation-input">
+            <ConfirmFieldLabel htmlFor={confirmationInputId}>
               {resolvedConfirmationLabel}
             </ConfirmFieldLabel>
             <TextField
-              id="danger-confirmation-input"
+              id={confirmationInputId}
               fullWidth
               size="small"
               value={typedValue}

--- a/src/custom/DangerConfirmationModal/DangerConfirmationModal.tsx
+++ b/src/custom/DangerConfirmationModal/DangerConfirmationModal.tsx
@@ -1,0 +1,253 @@
+import { DialogProps } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Checkbox, FormControlLabel, FormGroup, TextField, Typography } from '../../base';
+import { iconLarge, iconMedium } from '../../constants/iconsSizes';
+import { IdeaIcon, WarningIcon } from '../../icons';
+import { useTheme } from '../../theme';
+import { Modal, ModalBody, ModalButtonDanger, ModalButtonSecondary, ModalFooter } from '../Modal';
+import {
+  Actions,
+  CheckboxSection,
+  ConfirmField,
+  ConfirmFieldLabel,
+  DangerBody,
+  RecommendedCallout,
+  RecommendedCalloutBody
+} from './style';
+
+/** A single acknowledgement checkbox rendered inside the confirmation modal. */
+export interface DangerConfirmationCheckbox {
+  /** Stable identifier used as the React key and to build the checkbox `data-testid`. */
+  id: string;
+  /** Checkbox label. `ReactNode` so callers can embed counts, bold text, or links. */
+  label: React.ReactNode;
+  /**
+   * When `true` (the default) this checkbox must be ticked before the primary
+   * action enables. Set to `false` for a purely optional, non-gating checkbox.
+   */
+  required?: boolean;
+  /** Initial checked state applied each time the modal opens. Defaults to `false`. */
+  defaultChecked?: boolean;
+}
+
+export interface DangerConfirmationModalProps {
+  /** Controls visibility. Fully controlled by the caller. */
+  open: boolean;
+  /** Fired when the user dismisses the modal (Cancel button, close icon, backdrop, or Escape). */
+  onCancel: () => void;
+  /** Fired when the user confirms and every gate (typed phrase + required checkboxes) is satisfied. */
+  onConfirm: () => void;
+  /** Modal title, e.g. `"Delete organization"`. */
+  title: string;
+  /** Warning/description body. `ReactNode` so callers can bold the target name. Rendered with danger styling. */
+  description: React.ReactNode;
+  /**
+   * Exact phrase the user must type to unlock the primary action (e.g. an
+   * organization name). Comparison is strict and case-sensitive. Omit to
+   * disable the type-to-confirm gate entirely.
+   */
+  confirmationPhrase?: string;
+  /**
+   * Label rendered above the type-to-confirm field. Defaults to
+   * `Type <b>{confirmationPhrase}</b> to confirm`.
+   */
+  confirmationPhraseLabel?: React.ReactNode;
+  /** Placeholder for the type-to-confirm field. Defaults to `confirmationPhrase`. */
+  confirmationPhrasePlaceholder?: string;
+  /**
+   * One or more acknowledgement checkboxes. Every checkbox with
+   * `required !== false` must be checked before the primary action enables.
+   */
+  checkboxes?: DangerConfirmationCheckbox[];
+  /**
+   * Optional callout recommending a safer alternative (e.g. transferring
+   * ownership instead of deleting). Rendered in a highlighted info box above
+   * the actions.
+   */
+  recommendedAlternative?: React.ReactNode;
+  /** Primary (destructive) button label. Defaults to `"Delete"`. */
+  confirmText?: string;
+  /** Cancel button label. Defaults to `"Cancel"`. */
+  cancelText?: string;
+  /**
+   * While `true`, the primary action is disabled and dismissal is blocked, so
+   * an in-flight destructive request cannot be double-submitted or interrupted.
+   * Defaults to `false`.
+   */
+  isConfirming?: boolean;
+  /** Overrides the default warning header icon. */
+  headerIcon?: React.ReactNode;
+  /** Dialog max width. Defaults to `"sm"`. */
+  maxWidth?: DialogProps['maxWidth'];
+}
+
+const buildInitialCheckedState = (
+  checkboxes: DangerConfirmationCheckbox[]
+): Record<string, boolean> =>
+  checkboxes.reduce<Record<string, boolean>>((acc, checkbox) => {
+    acc[checkbox.id] = checkbox.defaultChecked ?? false;
+    return acc;
+  }, {});
+
+/**
+ * A fully controlled, composable confirmation modal for destructive actions
+ * (delete account, delete organization, etc.). Built from Sistent's existing
+ * Modal primitives.
+ *
+ * The primary action stays disabled until every configured gate is satisfied:
+ * the `confirmationPhrase` (if supplied) is typed exactly, and every required
+ * checkbox is ticked. All gate state is managed internally; callers only wire
+ * up `open`, `onCancel`, and `onConfirm`.
+ */
+export const DangerConfirmationModal: React.FC<DangerConfirmationModalProps> = ({
+  open,
+  onCancel,
+  onConfirm,
+  title,
+  description,
+  confirmationPhrase,
+  confirmationPhraseLabel,
+  confirmationPhrasePlaceholder,
+  checkboxes,
+  recommendedAlternative,
+  confirmText = 'Delete',
+  cancelText = 'Cancel',
+  isConfirming = false,
+  headerIcon,
+  maxWidth = 'sm'
+}) => {
+  const theme = useTheme();
+  const checkboxList = checkboxes ?? [];
+
+  const [typedValue, setTypedValue] = useState('');
+  const [checkedState, setCheckedState] = useState<Record<string, boolean>>(() =>
+    buildInitialCheckedState(checkboxList)
+  );
+
+  // Reset the ephemeral gate state each time the modal opens so a reused
+  // instance never leaks a previous attempt's typed value or ticks. Keyed on
+  // `open` alone: re-seeding on every `checkboxes` identity change would wipe
+  // the user's in-progress selections whenever the parent re-renders.
+  useEffect(() => {
+    if (open) {
+      setTypedValue('');
+      setCheckedState(buildInitialCheckedState(checkboxes ?? []));
+    }
+  }, [open]);
+
+  const typedGateSatisfied = !confirmationPhrase || typedValue === confirmationPhrase;
+  const checkboxGateSatisfied = checkboxList.every(
+    (checkbox) => checkbox.required === false || Boolean(checkedState[checkbox.id])
+  );
+  const canConfirm = typedGateSatisfied && checkboxGateSatisfied && !isConfirming;
+
+  const handleClose = () => {
+    // Block dismissal while a destructive request is in flight.
+    if (isConfirming) return;
+    onCancel();
+  };
+
+  const handleConfirm = () => {
+    if (!canConfirm) return;
+    onConfirm();
+  };
+
+  const handleCheckboxToggle = (id: string) => {
+    setCheckedState((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const resolvedHeaderIcon = headerIcon ?? (
+    <WarningIcon {...iconLarge} fill={theme.palette.text.constant?.white ?? '#fff'} />
+  );
+
+  const resolvedConfirmationLabel: React.ReactNode = confirmationPhraseLabel ?? (
+    <>
+      Type <b>{confirmationPhrase}</b> to confirm
+    </>
+  );
+
+  return (
+    <Modal
+      open={open}
+      closeModal={handleClose}
+      title={title}
+      headerIcon={resolvedHeaderIcon}
+      maxWidth={maxWidth}
+      data-testid="danger-confirmation-modal"
+    >
+      <ModalBody data-testid="danger-confirmation-body">
+        <DangerBody data-testid="danger-confirmation-description">
+          <Typography component="div" variant="body1" color={theme.palette.text.primary}>
+            {description}
+          </Typography>
+        </DangerBody>
+
+        {recommendedAlternative && (
+          <RecommendedCallout data-testid="danger-confirmation-recommended-alternative">
+            <IdeaIcon {...iconMedium} fill={theme.palette.status.info} />
+            <RecommendedCalloutBody>{recommendedAlternative}</RecommendedCalloutBody>
+          </RecommendedCallout>
+        )}
+
+        {confirmationPhrase !== undefined && (
+          <ConfirmField>
+            <ConfirmFieldLabel htmlFor="danger-confirmation-input">
+              {resolvedConfirmationLabel}
+            </ConfirmFieldLabel>
+            <TextField
+              id="danger-confirmation-input"
+              fullWidth
+              size="small"
+              value={typedValue}
+              placeholder={confirmationPhrasePlaceholder ?? confirmationPhrase}
+              onChange={(event) => setTypedValue(event.target.value)}
+              autoComplete="off"
+            />
+          </ConfirmField>
+        )}
+
+        {checkboxList.length > 0 && (
+          <CheckboxSection>
+            <FormGroup data-testid="danger-confirmation-checkboxes">
+              {checkboxList.map((checkbox) => (
+                <FormControlLabel
+                  key={checkbox.id}
+                  control={
+                    <Checkbox
+                      checked={Boolean(checkedState[checkbox.id])}
+                      onChange={() => handleCheckboxToggle(checkbox.id)}
+                      color="primary"
+                      data-testid={`danger-confirmation-checkbox-${checkbox.id}`}
+                    />
+                  }
+                  label={checkbox.label}
+                />
+              ))}
+            </FormGroup>
+          </CheckboxSection>
+        )}
+      </ModalBody>
+
+      <ModalFooter variant="filled">
+        <Actions>
+          <ModalButtonSecondary
+            onClick={handleClose}
+            disabled={isConfirming}
+            data-testid="danger-confirmation-cancel"
+          >
+            {cancelText}
+          </ModalButtonSecondary>
+          <ModalButtonDanger
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            data-testid="danger-confirmation-confirm"
+          >
+            {confirmText}
+          </ModalButtonDanger>
+        </Actions>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default DangerConfirmationModal;

--- a/src/custom/DangerConfirmationModal/index.tsx
+++ b/src/custom/DangerConfirmationModal/index.tsx
@@ -1,0 +1,6 @@
+export {
+  DangerConfirmationModal,
+  default,
+  type DangerConfirmationCheckbox,
+  type DangerConfirmationModalProps
+} from './DangerConfirmationModal';

--- a/src/custom/DangerConfirmationModal/style.tsx
+++ b/src/custom/DangerConfirmationModal/style.tsx
@@ -1,0 +1,60 @@
+import { alpha, styled } from '@mui/material';
+import { Box } from '../../base';
+
+/**
+ * Error-tinted container for the warning/description body. Uses the canonical
+ * `status.error` token (not a hard-coded red) so it tracks light/dark themes.
+ */
+export const DangerBody = styled(Box)(({ theme }) => ({
+  borderRadius: '0.25rem',
+  borderLeft: `3px solid ${theme.palette.status.error}`,
+  backgroundColor: alpha(theme.palette.status.error, 0.08),
+  padding: '0.75rem 1rem',
+  overflowWrap: 'anywhere'
+}));
+
+/**
+ * Info-tinted "recommended alternative" callout (e.g. transfer ownership
+ * instead of deleting). Lays out an icon alongside caller-supplied content.
+ */
+export const RecommendedCallout = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.75rem',
+  marginTop: '1rem',
+  borderRadius: '0.25rem',
+  border: `1px solid ${alpha(theme.palette.status.info, 0.4)}`,
+  backgroundColor: alpha(theme.palette.status.info, 0.08),
+  padding: '0.75rem 1rem'
+}));
+
+export const RecommendedCalloutBody = styled(Box)(() => ({
+  flex: 1,
+  minWidth: 0
+}));
+
+export const ConfirmField = styled(Box)(() => ({
+  marginTop: '1rem'
+}));
+
+/**
+ * Real `<label>` element so `htmlFor` associates it with the type-to-confirm
+ * input for assistive technology.
+ */
+export const ConfirmFieldLabel = styled('label')(({ theme }) => ({
+  display: 'block',
+  marginBottom: '0.5rem',
+  fontSize: '0.875rem',
+  color: theme.palette.text.secondary
+}));
+
+export const CheckboxSection = styled(Box)(() => ({
+  marginTop: '1rem'
+}));
+
+export const Actions = styled(Box)(() => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  width: '100%',
+  gap: '0.75rem'
+}));

--- a/src/custom/Modal/index.tsx
+++ b/src/custom/Modal/index.tsx
@@ -129,7 +129,9 @@ export const ModalBody = styled(Paper)(({ theme }) => ({
 }));
 
 const StyledFooter = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'variant'
+  // Both are styling-only props; neither may reach the DOM node (otherwise React
+  // warns "unknown prop hasHelpText on a DOM element").
+  shouldForwardProp: (prop) => prop !== 'variant' && prop !== 'hasHelpText'
 })<ModalFooterProps>(({ theme, variant, hasHelpText }) => ({
   background: variant === 'filled' ? theme.palette.surface.tint : 'transparent',
   display: 'flex',
@@ -163,10 +165,7 @@ export const Modal: React.FC<ModalProps> = ({
    * prop is applied after {...restProps}, so any caller-provided fullWidth is
    * intentionally overridden without needing to strip it here.
    */
-  const {
-    fullScreen: initialFullScreenState = false,
-    ...restProps
-  } = props;
+  const { fullScreen: initialFullScreenState = false, ...restProps } = props;
 
   const [fullScreen, setFullScreen] = useState(initialFullScreenState);
 

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -56,6 +56,11 @@ export { CatalogCard } from './CatalogCard';
 export { CatalogFilterSidebar } from './CatalogFilterSection';
 export type { FilterListType } from './CatalogFilterSection';
 export { StyledChartDialog } from './ChartDialog';
+export {
+  DangerConfirmationModal,
+  type DangerConfirmationCheckbox,
+  type DangerConfirmationModalProps
+} from './DangerConfirmationModal';
 export { InputSearchField } from './InputSearchField';
 export { LearningContent } from './LearningContent';
 export { NavigationNavbar } from './NavigationNavbar';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,3 +23,12 @@ export { FeedbackButton, type FeedbackComponentProps } from './custom/Feedback';
 // `@sistent/mui-datatables` and would crash the dts build) precisely so this
 // explicit re-export can force them into the published declaration bundle.
 export { getCopyDeepLinkAction, type TableAction } from './custom/TableActions';
+// Same nested-barrel dts-drop quirk as FeedbackButton above: without this
+// explicit re-export the DangerConfirmationModal declarations (and its exported
+// props types) are dropped from the bundled d.ts, breaking
+// `import { DangerConfirmationModal } from "@sistent/sistent"` type-checking.
+export {
+  DangerConfirmationModal,
+  type DangerConfirmationCheckbox,
+  type DangerConfirmationModalProps
+} from './custom/DangerConfirmationModal';


### PR DESCRIPTION
## Description

Adds **`DangerConfirmationModal`** - a reusable, fully controlled destructive-action confirmation modal composed from the existing Sistent `Modal` primitives. Built for meshery-cloud's account/organization deletion flow, but generic enough for any irreversible destructive action (delete account, delete org, delete workspace, etc.).

### Features
- Danger-variant title/body with a warning header icon.
- Optional **type-to-confirm** gate (`confirmationPhrase`) - primary action stays disabled until the typed value matches exactly.
- **One or more acknowledgement checkboxes** (`checkboxes: DangerConfirmationCheckbox[]`, each with per-item `required`) - covers a primary destruction acknowledgement plus optional extra confirmations (e.g. destroying shared resources).
- Optional **recommended-alternative** callout slot (`recommendedAlternative`) - e.g. to suggest a safer path than destruction.
- `isConfirming` disables the primary and blocks dismissal during an in-flight request.
- Primary enables only when the phrase matches AND every required checkbox is ticked.

### Verification
- `npm run build` (tsup CJS+ESM+DTS): success; the component + `DangerConfirmationModalProps` + `DangerConfirmationCheckbox` land in `dist/index.d.ts`.
- `npm run lint`: clean.
- `npm test`: passing (includes a new 9-test suite for this component).
- CSF3 story with three scenarios (checkbox-only; type-to-confirm + checkbox; type-to-confirm + primary + shared-resource checkbox + recommended-alternative callout).

### Adjacent fix
- `Modal/index.tsx` `StyledFooter` leaked the styling-only `hasHelpText` prop to the DOM (React "unknown prop" warning). Fixed via `shouldForwardProp` - benefits every `ModalFooter` consumer.
