### PR TITLE
feat: add reusable TableToolbar component

### DIFF
--- a/src/__testing__/TableToolbar.test.tsx
+++ b/src/__testing__/TableToolbar.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { TableToolbar } from '../custom/TableToolbar/TableToolbar';
+import { SistentThemeProvider } from '../theme';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<SistentThemeProvider>{ui}</SistentThemeProvider>);
+
+describe('TableToolbar', () => {
+  it('renders composable leading, center, and end slots', () => {
+    renderWithTheme(
+      <TableToolbar
+        leadingContent={<button type="button">Create</button>}
+        centerContent={<div>Search and filters</div>}
+        endContent={<div>View controls</div>}
+      />
+    );
+
+    expect(screen.getByRole('toolbar', { name: 'Table toolbar' })).toBeTruthy();
+    expect(screen.getByText('Create')).toBeTruthy();
+    expect(screen.getByText('Search and filters')).toBeTruthy();
+    expect(screen.getByText('View controls')).toBeTruthy();
+  });
+
+  it('omits empty slot wrappers when content is not provided', () => {
+    renderWithTheme(<TableToolbar endContent={<div>Tools</div>} />);
+
+    expect(screen.queryByTestId('table-toolbar-leading')).toBeNull();
+    expect(screen.queryByTestId('table-toolbar-center')).toBeNull();
+    expect(screen.getByTestId('table-toolbar-end')).toBeTruthy();
+  });
+});

--- a/src/__testing__/TableToolbar.test.tsx
+++ b/src/__testing__/TableToolbar.test.tsx
@@ -29,4 +29,10 @@ describe('TableToolbar', () => {
     expect(screen.queryByTestId('table-toolbar-center')).toBeNull();
     expect(screen.getByTestId('table-toolbar-end')).toBeTruthy();
   });
+
+  it('supports a custom aria-label', () => {
+    renderWithTheme(<TableToolbar ariaLabel="Custom toolbar label" />);
+
+    expect(screen.getByRole('toolbar', { name: 'Custom toolbar label' })).toBeTruthy();
+  });
 });

--- a/src/custom/TableToolbar/TableToolbar.tsx
+++ b/src/custom/TableToolbar/TableToolbar.tsx
@@ -1,0 +1,75 @@
+import { styled } from '@mui/material';
+import React from 'react';
+
+interface TableToolbarProps {
+  leadingContent?: React.ReactNode;
+  centerContent?: React.ReactNode;
+  endContent?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  'data-testid'?: string;
+}
+
+const TableToolbarRoot = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(2),
+  width: '100%',
+  flexWrap: 'wrap'
+}));
+
+const ToolbarSlot = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  flexWrap: 'wrap',
+  minWidth: 0
+}));
+
+const ToolbarLeadingSlot = styled(ToolbarSlot)(() => ({
+  flex: '0 0 auto'
+}));
+
+const ToolbarCenterSlot = styled(ToolbarSlot)(() => ({
+  flex: '1 1 0',
+  justifyContent: 'center'
+}));
+
+const ToolbarEndSlot = styled(ToolbarSlot)(() => ({
+  flex: '0 0 auto',
+  marginLeft: 'auto',
+  justifyContent: 'flex-end'
+}));
+
+export function TableToolbar({
+  leadingContent,
+  centerContent,
+  endContent,
+  className,
+  style,
+  'data-testid': dataTestId = 'table-toolbar'
+}: TableToolbarProps): JSX.Element {
+  return (
+    <TableToolbarRoot
+      role="toolbar"
+      aria-label="Table toolbar"
+      className={className}
+      style={style}
+      data-testid={dataTestId}
+    >
+      {leadingContent ? (
+        <ToolbarLeadingSlot data-testid={`${dataTestId}-leading`}>
+          {leadingContent}
+        </ToolbarLeadingSlot>
+      ) : null}
+      {centerContent ? (
+        <ToolbarCenterSlot data-testid={`${dataTestId}-center`}>{centerContent}</ToolbarCenterSlot>
+      ) : null}
+      {endContent ? (
+        <ToolbarEndSlot data-testid={`${dataTestId}-end`}>{endContent}</ToolbarEndSlot>
+      ) : null}
+    </TableToolbarRoot>
+  );
+}
+
+export default TableToolbar;

--- a/src/custom/TableToolbar/TableToolbar.tsx
+++ b/src/custom/TableToolbar/TableToolbar.tsx
@@ -1,13 +1,14 @@
 import { styled } from '@mui/material';
 import React from 'react';
 
-interface TableToolbarProps {
+export interface TableToolbarProps {
   leadingContent?: React.ReactNode;
   centerContent?: React.ReactNode;
   endContent?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
   'data-testid'?: string;
+  ariaLabel?: string;
 }
 
 const TableToolbarRoot = styled('div')(({ theme }) => ({
@@ -47,12 +48,13 @@ export function TableToolbar({
   endContent,
   className,
   style,
-  'data-testid': dataTestId = 'table-toolbar'
+  'data-testid': dataTestId = 'table-toolbar',
+  ariaLabel = 'Table toolbar'
 }: TableToolbarProps): JSX.Element {
   return (
     <TableToolbarRoot
       role="toolbar"
-      aria-label="Table toolbar"
+      aria-label={ariaLabel}
       className={className}
       style={style}
       data-testid={dataTestId}

--- a/src/custom/index.tsx
+++ b/src/custom/index.tsx
@@ -45,6 +45,7 @@ import ResponsiveDataTable, {
 import SearchBar, { SearchBarProps } from './SearchBar';
 import { StyledCardProps } from './StyledCard/StyledCard';
 import { getCopyDeepLinkAction, TableAction } from './TableActions';
+import { TableToolbar } from './TableToolbar/TableToolbar';
 import { TeamTable, TeamTableConfiguration } from './TeamTable';
 import { TooltipIcon } from './TooltipIconButton';
 import { TransferList } from './TransferModal/TransferList';
@@ -116,6 +117,7 @@ export {
   StyledDialogActions,
   StyledDialogContent,
   StyledDialogTitle,
+  TableToolbar,
   TeamTable,
   TeamTableConfiguration,
   TooltipIcon,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,7 +23,7 @@ export { FeedbackButton, type FeedbackComponentProps } from './custom/Feedback';
 // `@sistent/mui-datatables` and would crash the dts build) precisely so this
 // explicit re-export can force them into the published declaration bundle.
 export { getCopyDeepLinkAction, type TableAction } from './custom/TableActions';
-export { TableToolbar } from './custom/TableToolbar/TableToolbar';
+export { TableToolbar, type TableToolbarProps } from './custom/TableToolbar/TableToolbar';
 // Same nested-barrel dts-drop quirk as FeedbackButton above: without this
 // explicit re-export the DangerConfirmationModal declarations (and its exported
 // props types) are dropped from the bundled d.ts, breaking

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export { FeedbackButton, type FeedbackComponentProps } from './custom/Feedback';
 // `@sistent/mui-datatables` and would crash the dts build) precisely so this
 // explicit re-export can force them into the published declaration bundle.
 export { getCopyDeepLinkAction, type TableAction } from './custom/TableActions';
+export { TableToolbar } from './custom/TableToolbar/TableToolbar';
 // Same nested-barrel dts-drop quirk as FeedbackButton above: without this
 // explicit re-export the DangerConfirmationModal declarations (and its exported
 // props types) are dropped from the bundled d.ts, breaking


### PR DESCRIPTION
## Summary
This PR introduces a reusable, composable `TableToolbar` component in Sistent to standardize data-table toolbars across Meshery UI and reduce duplication.

- Adds `TableToolbar` with three slots: `leadingContent`, `centerContent`, `endContent`
- Slots render conditionally, so empty wrappers are omitted
- Includes accessibility defaults: `role="toolbar"` and `aria-label="Table toolbar"`
- Exports from both the `custom` barrel and the root `index.tsx` via explicit re-export to preserve declaration types

## Related issue
Fixes #1667
Parent: #1661

## Test plan
- `npm test`
- `npm run lint`
- `npm run build`

## Notes for reviewers
This is a design system-level component intended to be composed by consumers in Meshery UI. Follow-up PRs can replace page-specific toolbar layouts with `TableToolbar` plus existing controls such as SearchBar, UniversalFilter, CustomColumnVisibilityControl, ViewSwitch, and action buttons.