### PR TITLE
fix(exports): explicitly re-export UniversalFilter so its types ship

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,3 +32,14 @@ export {
   type DangerConfirmationCheckbox,
   type DangerConfirmationModalProps
 } from './custom/DangerConfirmationModal';
+// Same nested-barrel dts-drop quirk as FeedbackButton above: UniversalFilter
+// (and its FilterColumn / UniversalFilterProps types) reaches the entry only
+// through `export * from './custom'`, so rollup-plugin-dts drops it from the
+// bundled d.ts and `import { UniversalFilter } from "@sistent/sistent"` fails
+// type-checking despite the runtime export. The explicit re-export forces the
+// declaration into the published bundle.
+export {
+  default as UniversalFilter,
+  type FilterColumn,
+  type UniversalFilterProps
+} from './custom/UniversalFilter';


### PR DESCRIPTION
UniversalFilter reaches the package entry only through `export * from
'./custom'`, so rollup-plugin-dts drops its declaration from the bundled
d.ts and `import { UniversalFilter } from "@sistent/sistent"` fails
type-checking even though the runtime export exists. Add an explicit
re-export (mirroring FeedbackButton, TableAction and DangerConfirmationModal)
to force UniversalFilter, FilterColumn and UniversalFilterProps into the
published declaration bundle, so consumers can drop their local d.ts
augmentations.
