### PR TITLE
fix(UniversalFilter): use slotProps.paper instead of removed Drawer PaperProps

### DIFF
--- a/src/custom/UniversalFilter.tsx
+++ b/src/custom/UniversalFilter.tsx
@@ -214,10 +214,12 @@ function UniversalFilter({
             anchor="bottom"
             open={open}
             onClose={handleClose}
-            PaperProps={{
-              style: {
-                padding: '0 1rem 1rem 1rem',
-                backgroundColor: theme.palette.background.surfaces
+            slotProps={{
+              paper: {
+                style: {
+                  padding: '0 1rem 1rem 1rem',
+                  backgroundColor: theme.palette.background.surfaces
+                }
               }
             }}
           >


### PR DESCRIPTION
## Summary
- MUI v9's `DrawerProps` dropped the `PaperProps` prop in favor of the slots/slotProps pattern. `UniversalFilter`'s mobile `Drawer` variant still used `PaperProps`, which fails dts type-checking (`TS2322: Property 'PaperProps' does not exist on type 'IntrinsicAttributes & DrawerProps'`) and breaks `npm run build`.
- This is the reason the v0.21.29 release publish workflow failed right after PR #1680 merged (run 28616103448) — `npm publish` never ran because the build step errored, so v0.21.29 is a GitHub release that was never actually published to npm (registry still tops out at 0.21.28).
- Fix mirrors the `slotProps={{ paper: {...} }}` pattern already used elsewhere in this codebase (e.g. `HelperTextPopover.tsx`).

## Test plan
- [x] `npm run build` completes successfully (CJS/ESM/DTS all succeed, confirmed `UniversalFilter`/`UniversalFilterProps`/`FilterColumn` types land in `dist/index.d.ts`)
- [x] `npx jest` — 15 suites / 316 tests pass
- [x] `npm run lint` — clean