### PR TITLE
feat(permissions): Adding the permission shield overlay to Sistent base components

### DIFF
--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -1,11 +1,47 @@
 import { Button as MuiButton, type ButtonProps as MuiButtonProps } from '@mui/material';
+import React from 'react';
+import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
 
 export interface ButtonProps extends MuiButtonProps {
   label?: string;
   children?: React.ReactNode;
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
 }
 
-export function Button({ label, children, ...props }: ButtonProps): JSX.Element {
+export function Button({
+  label,
+  children,
+  permissionKey,
+  permissionAction = 'disable',
+  ...props
+}: ButtonProps): JSX.Element | null {
+  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+
+  if (!hasPermission) {
+    switch (action) {
+      case 'hide':
+        return null;
+      case 'showShield':
+        return (
+          <PermissionShield permissionKey={permissionKey!} variant="badge">
+            <MuiButton {...props} disabled={true}>
+              {label}
+              {children}
+            </MuiButton>
+          </PermissionShield>
+        );
+      case 'disable':
+      default:
+        return (
+          <MuiButton {...props} disabled={true}>
+            {label}
+            {children}
+          </MuiButton>
+        );
+    }
+  }
+
   return (
     <MuiButton {...props}>
       {label}

--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -1,49 +1,34 @@
 import { Button as MuiButton, type ButtonProps as MuiButtonProps } from '@mui/material';
 import React from 'react';
-import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
+import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ButtonProps extends MuiButtonProps {
   label?: string;
   children?: React.ReactNode;
   permissionKey?: Key;
-  permissionAction?: PermissionAction;
 }
 
 export function Button({
   label,
   children,
   permissionKey,
-  permissionAction = 'disable',
+  disabled,
   ...props
-}: ButtonProps): JSX.Element | null {
-  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
-
-  if (!hasPermission) {
-    switch (action) {
-      case 'hide':
-        return null;
-      case 'showShield':
-        return (
-          <PermissionShield permissionKey={permissionKey!} variant="badge">
-            <MuiButton {...props} disabled={true}>
-              {label}
-              {children}
-            </MuiButton>
-          </PermissionShield>
-        );
-      case 'disable':
-      default:
-        return (
-          <MuiButton {...props} disabled={true}>
-            {label}
-            {children}
-          </MuiButton>
-        );
-    }
+}: ButtonProps): JSX.Element {
+  // When disabled AND permissionKey is provided, show the shield overlay
+  if (disabled && permissionKey) {
+    return (
+      <PermissionShield permissionKey={permissionKey} variant="badge">
+        <MuiButton {...props} disabled={true}>
+          {label}
+          {children}
+        </MuiButton>
+      </PermissionShield>
+    );
   }
 
   return (
-    <MuiButton {...props}>
+    <MuiButton {...props} disabled={disabled}>
       {label}
       {children}
     </MuiButton>

--- a/src/base/IconButton/IconButton.tsx
+++ b/src/base/IconButton/IconButton.tsx
@@ -3,34 +3,25 @@ import {
   type IconButtonProps as MuiIconButtonProps
 } from '@mui/material';
 import React from 'react';
-import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
+import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface IconButtonProps extends MuiIconButtonProps {
   permissionKey?: Key;
-  permissionAction?: PermissionAction;
 }
 
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
-  const { permissionKey, permissionAction = 'disable', ...rest } = props;
-  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+  const { permissionKey, disabled, ...rest } = props;
 
-  if (!hasPermission) {
-    switch (action) {
-      case 'hide':
-        return null;
-      case 'showShield':
-        return (
-          <PermissionShield permissionKey={permissionKey!} variant="badge">
-            <MuiIconButton ref={ref} {...rest} disabled={true} />
-          </PermissionShield>
-        );
-      case 'disable':
-      default:
-        return <MuiIconButton ref={ref} {...rest} disabled={true} />;
-    }
+  // When disabled AND permissionKey is provided, show the shield overlay
+  if (disabled && permissionKey) {
+    return (
+      <PermissionShield permissionKey={permissionKey} variant="badge">
+        <MuiIconButton ref={ref} {...rest} disabled={true} />
+      </PermissionShield>
+    );
   }
 
-  return <MuiIconButton ref={ref} {...rest} />;
+  return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
 });
 
 IconButton.displayName = 'IconButton';

--- a/src/base/IconButton/IconButton.tsx
+++ b/src/base/IconButton/IconButton.tsx
@@ -3,12 +3,35 @@ import {
   type IconButtonProps as MuiIconButtonProps
 } from '@mui/material';
 import React from 'react';
+import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
 
-export type IconButtonProps = MuiIconButtonProps;
+export interface IconButtonProps extends MuiIconButtonProps {
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
+}
 
-export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => (
-  <MuiIconButton ref={ref} {...props} />
-));
+export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
+  const { permissionKey, permissionAction = 'disable', ...rest } = props;
+  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+
+  if (!hasPermission) {
+    switch (action) {
+      case 'hide':
+        return null;
+      case 'showShield':
+        return (
+          <PermissionShield permissionKey={permissionKey!} variant="badge">
+            <MuiIconButton ref={ref} {...rest} disabled={true} />
+          </PermissionShield>
+        );
+      case 'disable':
+      default:
+        return <MuiIconButton ref={ref} {...rest} disabled={true} />;
+    }
+  }
+
+  return <MuiIconButton ref={ref} {...rest} />;
+});
 
 IconButton.displayName = 'IconButton';
 

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -1,8 +1,33 @@
 import { ListItem as MuiListItem, ListItemProps as MuiListItemProps } from '@mui/material';
 import React from 'react';
+import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
 
-const ListItem = React.forwardRef<HTMLLIElement, MuiListItemProps>((props, ref) => {
-  return <MuiListItem {...props} ref={ref} />;
+export interface ListItemProps extends MuiListItemProps {
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
+}
+
+const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => {
+  const { permissionKey, permissionAction = 'disable', ...rest } = props;
+  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+
+  if (!hasPermission) {
+    switch (action) {
+      case 'hide':
+        return null;
+      case 'showShield':
+        return (
+          <PermissionShield permissionKey={permissionKey!} variant="inline">
+            <MuiListItem {...rest} ref={ref} sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none', ...rest.sx }} />
+          </PermissionShield>
+        );
+      case 'disable':
+      default:
+        return <MuiListItem {...rest} ref={ref} sx={{ opacity: 0.5, pointerEvents: 'none', ...rest.sx }} />;
+    }
+  }
+
+  return <MuiListItem {...rest} ref={ref} />;
 });
 
 export default ListItem;

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -11,15 +11,17 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
   const { permissionKey, disabled, ...rest } = props;
 
   // When disabled AND permissionKey is provided, show the shield overlay
+  // Note: MUI ListItem doesn't have a native `disabled` prop, so we only use
+  // it as a custom guard for the PermissionShield wrapper
   if (disabled && permissionKey) {
     return (
       <PermissionShield permissionKey={permissionKey} variant="inline">
-        <MuiListItem {...rest} ref={ref} disabled={true} />
+        <MuiListItem {...rest} ref={ref} />
       </PermissionShield>
     );
   }
 
-  return <MuiListItem {...rest} ref={ref} disabled={disabled} />;
+  return <MuiListItem {...rest} ref={ref} />;
 });
 
 ListItem.displayName = 'ListItem';

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -1,30 +1,22 @@
 import { ListItem as MuiListItem, ListItemProps as MuiListItemProps } from '@mui/material';
 import React from 'react';
-import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
+import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ListItemProps extends MuiListItemProps {
   permissionKey?: Key;
-  permissionAction?: PermissionAction;
 }
 
 const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => {
-  const { permissionKey, permissionAction = 'disable', ...rest } = props;
-  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+  const { permissionKey, ...rest } = props;
 
-  if (!hasPermission) {
-    switch (action) {
-      case 'hide':
-        return null;
-      case 'showShield':
-        return (
-          <PermissionShield permissionKey={permissionKey!} variant="inline">
-            <MuiListItem {...rest} ref={ref} sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none', ...rest.sx }} />
-          </PermissionShield>
-        );
-      case 'disable':
-      default:
-        return <MuiListItem {...rest} ref={ref} sx={{ opacity: 0.5, pointerEvents: 'none', ...rest.sx }} />;
-    }
+  // ListItem doesn't have a native `disabled` prop, so check via sx/style or a custom flag
+  // For now, if permissionKey is provided, show the shield (consumer controls when to pass it)
+  if (permissionKey) {
+    return (
+      <PermissionShield permissionKey={permissionKey} variant="inline">
+        <MuiListItem {...rest} ref={ref} />
+      </PermissionShield>
+    );
   }
 
   return <MuiListItem {...rest} ref={ref} />;

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -14,12 +14,12 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
   if (disabled && permissionKey) {
     return (
       <PermissionShield permissionKey={permissionKey} variant="inline">
-        <MuiListItem {...rest} ref={ref} />
+        <MuiListItem {...rest} ref={ref} disabled={true} />
       </PermissionShield>
     );
   }
 
-  return <MuiListItem {...rest} ref={ref} />;
+  return <MuiListItem {...rest} ref={ref} disabled={disabled} />;
 });
 
 ListItem.displayName = 'ListItem';

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -4,14 +4,14 @@ import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ListItemProps extends MuiListItemProps {
   permissionKey?: Key;
+  disabled?: boolean;
 }
 
 const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => {
-  const { permissionKey, ...rest } = props;
+  const { permissionKey, disabled, ...rest } = props;
 
-  // ListItem doesn't have a native `disabled` prop, so check via sx/style or a custom flag
-  // For now, if permissionKey is provided, show the shield (consumer controls when to pass it)
-  if (permissionKey) {
+  // When disabled AND permissionKey is provided, show the shield overlay
+  if (disabled && permissionKey) {
     return (
       <PermissionShield permissionKey={permissionKey} variant="inline">
         <MuiListItem {...rest} ref={ref} />
@@ -21,5 +21,7 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
 
   return <MuiListItem {...rest} ref={ref} />;
 });
+
+ListItem.displayName = 'ListItem';
 
 export default ListItem;

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -24,5 +24,7 @@ const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((pr
   return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
 });
 
+ListItemButton.displayName = 'ListItemButton';
+
 export { ListItemButton };
 export default ListItemButton;

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -3,9 +3,35 @@ import {
   ListItemButtonProps as MuiListItemButtonProps
 } from '@mui/material';
 import React from 'react';
+import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
 
-const ListItemButton = React.forwardRef<HTMLDivElement, MuiListItemButtonProps>((props, ref) => {
-  return <MuiListItemButton {...props} ref={ref} />;
+export interface ListItemButtonProps extends MuiListItemButtonProps {
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
+}
+
+const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((props, ref) => {
+  const { permissionKey, permissionAction = 'disable', ...rest } = props;
+  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+
+  if (!hasPermission) {
+    switch (action) {
+      case 'hide':
+        return null;
+      case 'showShield':
+        return (
+          <PermissionShield permissionKey={permissionKey!} variant="inline">
+            <MuiListItemButton {...rest} ref={ref} disabled={true} sx={{ width: '100%', ...rest.sx }} />
+          </PermissionShield>
+        );
+      case 'disable':
+      default:
+        return <MuiListItemButton {...rest} ref={ref} disabled={true} />;
+    }
+  }
+
+  return <MuiListItemButton {...rest} ref={ref} />;
 });
 
 export { ListItemButton };
+export default ListItemButton;

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -3,34 +3,25 @@ import {
   ListItemButtonProps as MuiListItemButtonProps
 } from '@mui/material';
 import React from 'react';
-import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
+import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ListItemButtonProps extends MuiListItemButtonProps {
   permissionKey?: Key;
-  permissionAction?: PermissionAction;
 }
 
 const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((props, ref) => {
-  const { permissionKey, permissionAction = 'disable', ...rest } = props;
-  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+  const { permissionKey, disabled, ...rest } = props;
 
-  if (!hasPermission) {
-    switch (action) {
-      case 'hide':
-        return null;
-      case 'showShield':
-        return (
-          <PermissionShield permissionKey={permissionKey!} variant="inline">
-            <MuiListItemButton {...rest} ref={ref} disabled={true} sx={{ width: '100%', ...rest.sx }} />
-          </PermissionShield>
-        );
-      case 'disable':
-      default:
-        return <MuiListItemButton {...rest} ref={ref} disabled={true} />;
-    }
+  // When disabled AND permissionKey is provided, show the shield overlay
+  if (disabled && permissionKey) {
+    return (
+      <PermissionShield permissionKey={permissionKey} variant="inline">
+        <MuiListItemButton {...rest} ref={ref} disabled={true} />
+      </PermissionShield>
+    );
   }
 
-  return <MuiListItemButton {...rest} ref={ref} />;
+  return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
 });
 
 export { ListItemButton };

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -1,7 +1,33 @@
 import { MenuItem as MuiMenuItem, MenuItemProps as MuiMenuItemProps } from '@mui/material';
+import React from 'react';
+import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
 
-export function MenuItem(props: MuiMenuItemProps): JSX.Element {
-  return <MuiMenuItem {...props} />;
+export interface MenuItemProps extends MuiMenuItemProps {
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
+}
+
+export function MenuItem(props: MenuItemProps): JSX.Element | null {
+  const { permissionKey, permissionAction = 'disable', ...rest } = props;
+  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+
+  if (!hasPermission) {
+    switch (action) {
+      case 'hide':
+        return null;
+      case 'showShield':
+        return (
+          <PermissionShield permissionKey={permissionKey!} variant="inline">
+            <MuiMenuItem {...rest} disabled={true} sx={{ width: '100%', ...rest.sx }} />
+          </PermissionShield>
+        );
+      case 'disable':
+      default:
+        return <MuiMenuItem {...rest} disabled={true} />;
+    }
+  }
+
+  return <MuiMenuItem {...rest} />;
 }
 
 export default MenuItem;

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -1,33 +1,24 @@
 import { MenuItem as MuiMenuItem, MenuItemProps as MuiMenuItemProps } from '@mui/material';
 import React from 'react';
-import { Key, PermissionAction, usePermission, PermissionShield } from '../../custom/permissions';
+import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface MenuItemProps extends MuiMenuItemProps {
   permissionKey?: Key;
-  permissionAction?: PermissionAction;
 }
 
-export function MenuItem(props: MenuItemProps): JSX.Element | null {
-  const { permissionKey, permissionAction = 'disable', ...rest } = props;
-  const { hasPermission, action } = usePermission({ permissionKey, permissionAction });
+export function MenuItem(props: MenuItemProps): JSX.Element {
+  const { permissionKey, disabled, ...rest } = props;
 
-  if (!hasPermission) {
-    switch (action) {
-      case 'hide':
-        return null;
-      case 'showShield':
-        return (
-          <PermissionShield permissionKey={permissionKey!} variant="inline">
-            <MuiMenuItem {...rest} disabled={true} sx={{ width: '100%', ...rest.sx }} />
-          </PermissionShield>
-        );
-      case 'disable':
-      default:
-        return <MuiMenuItem {...rest} disabled={true} />;
-    }
+  // When disabled AND permissionKey is provided, show the shield overlay
+  if (disabled && permissionKey) {
+    return (
+      <PermissionShield permissionKey={permissionKey} variant="inline">
+        <MuiMenuItem {...rest} disabled={true} />
+      </PermissionShield>
+    );
   }
 
-  return <MuiMenuItem {...rest} />;
+  return <MuiMenuItem {...rest} disabled={disabled} />;
 }
 
 export default MenuItem;

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,22 +1,14 @@
+import KeyIcon from '@mui/icons-material/Key';
+import LaunchIcon from '@mui/icons-material/Launch';
+import SecurityIcon from '@mui/icons-material/Security';
 import React from 'react';
-import { Box, Typography, ClickAwayListener, Chip } from '@mui/material';
 import { EventBus } from '../actors/eventBus';
-import Tooltip from '../base/Tooltip/Tooltip';
-import ShieldIcon from '@mui/icons-material/Shield';
-
-const SECTION_HEADING_SX = {
-  fontSize: '0.7rem',
-  fontWeight: 700,
-  letterSpacing: '0.06em',
-  textTransform: 'uppercase' as const,
-  color: 'rgba(255, 255, 255, 0.7)',
-  mb: 0.75,
-};
+import { Box, Chip, ClickAwayListener, Link, Tooltip, Typography } from '../base';
 
 const DIVIDER_SX = {
   height: '1px',
   background: 'rgba(255, 255, 255, 0.1)',
-  my: 1.25,
+  my: 1.25
 };
 
 export interface Key {
@@ -77,9 +69,10 @@ export interface PermissionShieldProps {
 export const PermissionShield: React.FC<PermissionShieldProps> = ({
   permissionKey,
   children,
-  variant = 'inline',
+  variant = 'inline'
 }) => {
   const [open, setOpen] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
   const uniqueId = React.useId();
 
   const handleClose = () => {
@@ -91,7 +84,9 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
     setOpen((prev) => {
       const next = !prev;
       if (next) {
-        window.dispatchEvent(new CustomEvent('permission-shield-opened', { detail: { id: uniqueId } }));
+        window.dispatchEvent(
+          new CustomEvent('permission-shield-opened', { detail: { id: uniqueId } })
+        );
       }
       return next;
     });
@@ -116,71 +111,112 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
 
   const tooltipTitle = (
     <Box sx={{ width: '100%', color: '#FFFFFF', p: 0.5 }}>
-      {/* Header Row */}
-      <Box
+      {/* Title: AUTHORIZATION REQUIRED — medium gray */}
+      <Typography
         sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          mb: 1.5,
-          width: '100%',
+          fontSize: '0.65rem',
+          fontWeight: 800,
+          color: '#9E9E9E',
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+          mb: 0.5
         }}
       >
+        Authorization Required
+      </Typography>
+
+      {/* Subtitle */}
+      <Typography
+        sx={{
+          fontSize: '0.75rem',
+          color: 'rgba(255, 255, 255, 0.75)',
+          mb: 1.25,
+          lineHeight: 1.3
+        }}
+      >
+        Missing requisite key
+      </Typography>
+
+      {/* Divider */}
+      <Box sx={DIVIDER_SX} />
+
+      {/* Key Row: KeyIcon (doubles as copy button) + key name */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mt: 1, mb: 0.25 }}>
+        <Tooltip title={copied ? 'Copied!' : 'Copy key ID to clipboard'} placement="top">
+          <Box
+            component="span"
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              navigator.clipboard.writeText(permissionKey.id || permissionKey.action || '');
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            }}
+            sx={{
+              display: 'inline-flex',
+              cursor: 'pointer',
+              color: copied ? '#EBC024' : 'rgba(255, 255, 255, 0.7)',
+              transition: 'color 0.2s ease',
+              '&:hover': {
+                color: '#EBC024'
+              }
+            }}
+          >
+            <KeyIcon sx={{ fontSize: '1rem' }} />
+          </Box>
+        </Tooltip>
         <Typography
           sx={{
             fontWeight: 700,
-            fontSize: '1rem',
+            fontSize: '0.95rem',
             lineHeight: 1.3,
-            color: '#FFFFFF',
+            color: '#FFFFFF'
           }}
         >
           {permissionKey.function || permissionKey.subject || 'Access Restricted'}
         </Typography>
-
-        {/* Status dot chip */}
-        <Chip
-          size="small"
-          label="Locked"
-          icon={
-            <span
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: '50%',
-                background: '#EBC024',
-                marginLeft: 6,
-                marginRight: 0,
-              }}
-            />
-          }
-          sx={{
-            background: 'rgba(235, 192, 36, 0.12)',
-            color: '#EBC024',
-            fontWeight: 600,
-            fontSize: '0.7rem',
-            height: '20px',
-            border: '1px solid rgba(235, 192, 36, 0.25)',
-            '& .MuiChip-label': {
-              paddingLeft: '4px',
-              paddingRight: '6px',
-            },
-          }}
-        />
       </Box>
 
-      {/* Meta info chips row */}
-      {permissionKey.category && (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 1.5 }}>
-          <Chip
-            size="small"
-            label={permissionKey.category}
-            sx={{
-              background: 'rgba(255, 255, 255, 0.08)',
-              color: 'rgba(255, 255, 255, 0.8)',
-              fontSize: '0.7rem',
-              height: '20px',
-            }}
-          />
+      {/* Description — italicized, equal padding both sides, no divider from key name */}
+      <Box sx={{ px: 1, mb: 1.25 }}>
+        <Typography
+          sx={{
+            fontStyle: 'italic',
+            color: 'rgba(255, 255, 255, 0.7)',
+            fontSize: '0.8rem',
+            lineHeight: 1.4
+          }}
+        >
+          {permissionKey.description ||
+            `Allows you to perform the ${permissionKey.function || permissionKey.subject || 'selected'} operation.`}
+        </Typography>
+      </Box>
+
+      {/* Divider */}
+      <Box sx={DIVIDER_SX} />
+
+      {/* Bottom row: Category/Subcategory chips (left) + Key Reference link (right) */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 0.75,
+          mt: 0.5
+        }}
+      >
+        <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+          {permissionKey.category && (
+            <Chip
+              size="small"
+              label={permissionKey.category}
+              sx={{
+                background: 'rgba(255, 255, 255, 0.08)',
+                color: 'rgba(255, 255, 255, 0.8)',
+                fontSize: '0.7rem',
+                height: '20px'
+              }}
+            />
+          )}
           {permissionKey.subcategory && (
             <Chip
               size="small"
@@ -189,53 +225,139 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
                 background: 'rgba(255, 255, 255, 0.08)',
                 color: 'rgba(255, 255, 255, 0.8)',
                 fontSize: '0.7rem',
-                height: '20px',
+                height: '20px'
               }}
             />
           )}
         </Box>
-      )}
-
-      {/* Divider */}
-      <Box sx={DIVIDER_SX} />
-
-      {/* Description Section */}
-      <Typography sx={SECTION_HEADING_SX}>What this permission allows</Typography>
-      <Box
-        component="ul"
-        sx={{
-          paddingLeft: '1.25rem',
-          margin: 0,
-          color: 'rgba(255, 255, 255, 0.9)',
-          fontSize: '0.85rem',
-          lineHeight: 1.45,
-        }}
-      >
-        <Box component="li">
-          {permissionKey.description || `Allows you to perform the ${permissionKey.function || permissionKey.subject || 'selected'} operation.`}
-        </Box>
-      </Box>
-
-      {/* Resource Details / Key Info */}
-      {permissionKey.id && (
-        <>
-          <Box sx={DIVIDER_SX} />
-          <Typography sx={SECTION_HEADING_SX}>Resource ID</Typography>
-          <Typography
+        <Link
+          href="https://docs.meshery.io/reference/references/permissions/"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'baseline',
+            fontSize: '0.75rem',
+            color: '#EBC024',
+            textDecoration: 'none',
+            fontWeight: 600,
+            '&:hover': {
+              textDecoration: 'underline'
+            }
+          }}
+        >
+          Key Reference
+          <Box
+            component="span"
             sx={{
-              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-              fontSize: '0.7rem',
-              background: 'rgba(0, 0, 0, 0.2)',
-              padding: '4px 6px',
-              borderRadius: '4px',
-              color: 'rgba(255, 255, 255, 0.7)',
-              wordBreak: 'break-all',
+              fontSize: '10px',
+              ml: '2px',
+              verticalAlign: 'super',
+              lineHeight: 0,
+              position: 'relative',
+              top: '-0.3em'
             }}
           >
-            {permissionKey.id}
-          </Typography>
-        </>
-      )}
+            <LaunchIcon style={{ fontSize: '10px', width: '10px', height: '10px' }} />
+          </Box>
+        </Link>
+      </Box>
+
+      {/* User / Org / Role context — read from sessionStorage */}
+      {(() => {
+        try {
+          const org = JSON.parse(sessionStorage.getItem('currentOrg') || 'null');
+          const user = JSON.parse(sessionStorage.getItem('user') || 'null');
+          const orgName = org?.name;
+          const firstName = user?.firstName || user?.first_name || '';
+          const lastName = user?.lastName || user?.last_name || '';
+          const userName = `${firstName} ${lastName}`.trim() || user?.name || user?.email;
+          const orgId = org?.id;
+          const orgWithRoles = user?.organizations?.organizationsWithRoles?.find(
+            (o: any) => o.id === orgId
+          );
+          const roleNames: string[] = orgWithRoles?.roleNames || user?.roleNames || [];
+
+          if (!orgName && !userName) return null;
+
+          return (
+            <>
+              <Box sx={DIVIDER_SX} />
+              <Box
+                sx={{
+                  background: 'rgba(255, 255, 255, 0.02)',
+                  border: '1px solid rgba(255, 255, 255, 0.05)',
+                  borderRadius: '6px',
+                  p: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 0.75,
+                  mb: 0.75
+                }}
+              >
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                    User
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.72rem',
+                      color: '#FFFFFF',
+                      fontWeight: 600,
+                      textAlign: 'right'
+                    }}
+                  >
+                    {userName}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                    Org
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.72rem',
+                      color: '#FFFFFF',
+                      fontWeight: 600,
+                      textAlign: 'right'
+                    }}
+                  >
+                    {orgName || 'Private Org'}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                    Role(s)
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: '0.72rem',
+                      color: '#FFFFFF',
+                      fontWeight: 600,
+                      textAlign: 'right'
+                    }}
+                  >
+                    {roleNames.length > 0 ? roleNames.join(', ') : 'None'}
+                  </Typography>
+                </Box>
+              </Box>
+              <Typography
+                sx={{
+                  fontSize: '0.68rem',
+                  fontStyle: 'italic',
+                  color: 'rgba(255, 255, 255, 0.45)',
+                  lineHeight: 1.35
+                }}
+              >
+                Seeing this message in error? Contact your Admins to request access.
+              </Typography>
+            </>
+          );
+        } catch {
+          return null;
+        }
+      })()}
     </Box>
   );
 
@@ -248,12 +370,10 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
           position: 'relative',
           display: isBadge ? 'inline-flex' : 'flex',
           width: isBadge ? 'auto' : '100%',
-          alignItems: 'center',
+          alignItems: 'center'
         }}
       >
-        <Box sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none' }}>
-          {children}
-        </Box>
+        <Box sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none' }}>{children}</Box>
 
         <Tooltip
           title={tooltipTitle}
@@ -268,17 +388,14 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
               sx: {
                 background: '#1A1A1A',
                 color: '#FFFFFF',
-                maxWidth: 420,
-                minWidth: 320,
-                padding: '16px',
+                maxWidth: 360,
+                minWidth: 300,
+                padding: '12px',
                 borderLeft: '4px solid #EBC024',
                 borderRadius: '8px',
-                boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-                '& .MuiTypography-root': {
-                  color: 'inherit',
-                },
-              },
-            },
+                boxShadow: '0 8px 32px rgba(0,0,0,0.4)'
+              }
+            }
           }}
         >
           <Box
@@ -303,8 +420,8 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
                     pointerEvents: 'auto',
                     transition: 'color 0.2s ease',
                     '&:hover': {
-                      color: '#EBC024',
-                    },
+                      color: '#EBC024'
+                    }
                   }
                 : {
                     position: 'absolute',
@@ -320,12 +437,12 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
                     zIndex: 10,
                     pointerEvents: 'auto',
                     '&:hover': {
-                      color: '#EBC024',
-                    },
+                      color: '#EBC024'
+                    }
                   }
             }
           >
-            <ShieldIcon sx={{ fontSize: '14px', color: 'inherit' }} />
+            <SecurityIcon sx={{ fontSize: '14px', color: 'inherit' }} />
           </Box>
         </Tooltip>
       </Box>
@@ -345,7 +462,7 @@ export const createCanShow = (
     children,
     notifyOnclick = true,
     predicate,
-    invert_action = ['disable'],
+    invert_action = ['disable']
   }: HasKeyProps<ReasonEvent>) => {
     if (!children) {
       return null;
@@ -362,8 +479,8 @@ export const createCanShow = (
     const reason = predicateRes?.[1] || {
       type: 'MISSING_PERMISSION',
       data: {
-        keyId: actionString,
-      },
+        keyId: actionString
+      }
     };
 
     if (can) {
@@ -392,19 +509,32 @@ export const createCanShow = (
         style={{
           cursor: 'pointer',
           pointerEvents,
-          opacity: opacity,
+          opacity: opacity
         }}
         onClick={onClick}
       >
-        {React.isValidElement(children) ? React.cloneElement(children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>, {
-          style: {
-            ...((children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>).props.style || {}),
-            cursor: 'pointer',
-            pointerEvents,
-            opacity: opacity,
-          },
-          onClick: onClick,
-        }) : children}
+        {React.isValidElement(children)
+          ? React.cloneElement(
+              children as React.ReactElement<{
+                style?: React.CSSProperties;
+                onClick?: React.MouseEventHandler;
+              }>,
+              {
+                style: {
+                  ...((
+                    children as React.ReactElement<{
+                      style?: React.CSSProperties;
+                      onClick?: React.MouseEventHandler;
+                    }>
+                  ).props.style || {}),
+                  cursor: 'pointer',
+                  pointerEvents,
+                  opacity: opacity
+                },
+                onClick: onClick
+              }
+            )
+          : children}
       </div>
     );
   };

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -134,7 +134,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
             color: '#FFFFFF',
           }}
         >
-          Access Restricted
+          {permissionKey.function || permissionKey.subject || 'Access Restricted'}
         </Typography>
 
         {/* Status dot chip */}
@@ -149,6 +149,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
                 borderRadius: '50%',
                 background: '#EBC024',
                 marginLeft: 6,
+                marginRight: 0,
               }}
             />
           }
@@ -194,46 +195,6 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
           )}
         </Box>
       )}
-
-      {/* Divider */}
-      <Box sx={DIVIDER_SX} />
-
-      {/* Capabilities Blocked Section */}
-      <Typography sx={{ ...SECTION_HEADING_SX, mb: 1 }}>Blocked Action</Typography>
-
-      <Box
-        sx={{
-          display: 'inline-flex',
-          borderRadius: '12px',
-          overflow: 'hidden',
-          border: '1px solid rgba(235, 192, 36, 0.35)',
-          fontSize: '0.7rem',
-          fontWeight: 600,
-          lineHeight: 1.4,
-          whiteSpace: 'nowrap',
-          mb: 1.5,
-        }}
-      >
-        <Box
-          sx={{
-            background: 'rgba(235, 192, 36, 0.12)',
-            color: '#EBC024',
-            padding: '1px 8px',
-          }}
-        >
-          {permissionKey.function || permissionKey.subject || 'Action'}
-        </Box>
-        <Box
-          sx={{
-            background: 'rgba(235, 192, 36, 0.32)',
-            color: '#fff',
-            padding: '1px 8px',
-            borderLeft: '1px solid rgba(235, 192, 36, 0.35)',
-          }}
-        >
-          Locked
-        </Box>
-      </Box>
 
       {/* Divider */}
       <Box sx={DIVIDER_SX} />

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { EventBus } from '../actors/eventBus';
-import CustomTooltip from './CustomTooltip/customTooltip';
+import Tooltip from '../base/Tooltip/Tooltip';
 import ShieldIcon from '@mui/icons-material/Shield';
 
 export interface Key {
@@ -137,7 +137,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
         {children}
       </Box>
 
-      <CustomTooltip title={tooltipTitle} placement="top" interactive>
+      <Tooltip title={tooltipTitle} placement="top" interactive>
         <Box
           sx={
             isBadge
@@ -183,7 +183,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
         >
           <ShieldIcon sx={{ fontSize: '14px', color: 'inherit' }} />
         </Box>
-      </CustomTooltip>
+      </Tooltip>
     </Box>
   );
 };

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, ClickAwayListener, Chip } from '@mui/material';
 import { EventBus } from '../actors/eventBus';
 import Tooltip from '../base/Tooltip/Tooltip';
 import ShieldIcon from '@mui/icons-material/Shield';
@@ -64,60 +64,230 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
   children,
   variant = 'inline',
 }) => {
+  const [open, setOpen] = React.useState(false);
+  const uniqueId = React.useId();
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        window.dispatchEvent(new CustomEvent('permission-shield-opened', { detail: { id: uniqueId } }));
+      }
+      return next;
+    });
+  };
+
+  React.useEffect(() => {
+    const handleOtherOpen = (e: Event) => {
+      const customEvent = e as CustomEvent;
+      if (customEvent.detail?.id !== uniqueId) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('permission-shield-opened', handleOtherOpen);
+    return () => {
+      window.removeEventListener('permission-shield-opened', handleOtherOpen);
+    };
+  }, [uniqueId]);
+
   const tooltipTitle = (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, p: 0.5, color: '#FFFFFF' }}>
-      <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
-        You don't currently have permission to perform this action.
-      </Typography>
+    <Box sx={{ width: '100%', color: '#FFFFFF', p: 0.5 }}>
+      {/* Header Row */}
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mb: 1.5,
+          width: '100%',
+        }}
+      >
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '1rem',
+            lineHeight: 1.3,
+            color: '#FFFFFF',
+          }}
+        >
+          Access Restricted
+        </Typography>
+
+        {/* Status dot chip */}
+        <Chip
+          size="small"
+          label="Locked"
+          icon={
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: '#EBC024',
+                marginLeft: 6,
+              }}
+            />
+          }
+          sx={{
+            background: 'rgba(235, 192, 36, 0.12)',
+            color: '#EBC024',
+            fontWeight: 600,
+            fontSize: '0.7rem',
+            height: '20px',
+            border: '1px solid rgba(235, 192, 36, 0.25)',
+            '& .MuiChip-label': {
+              paddingLeft: '4px',
+              paddingRight: '6px',
+            },
+          }}
+        />
+      </Box>
+
+      {/* Meta info chips row */}
       {permissionKey.category && (
-        <Box>
-          <Typography
-            variant="caption"
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, mb: 1.5 }}>
+          <Chip
+            size="small"
+            label={permissionKey.category}
             sx={{
-              display: 'block',
-              fontWeight: 'bold',
-              color: 'rgba(255, 255, 255, 0.7)',
-              textTransform: 'uppercase',
+              background: 'rgba(255, 255, 255, 0.08)',
+              color: 'rgba(255, 255, 255, 0.8)',
+              fontSize: '0.7rem',
+              height: '20px',
             }}
-          >
-            Category
-          </Typography>
-          <Typography variant="body2">{permissionKey.category}</Typography>
+          />
+          {permissionKey.subcategory && (
+            <Chip
+              size="small"
+              label={permissionKey.subcategory}
+              sx={{
+                background: 'rgba(255, 255, 255, 0.08)',
+                color: 'rgba(255, 255, 255, 0.8)',
+                fontSize: '0.7rem',
+                height: '20px',
+              }}
+            />
+          )}
         </Box>
       )}
-      {permissionKey.subcategory && (
-        <Box>
+
+      {/* Divider */}
+      <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
+
+      {/* Capabilities Blocked Section */}
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'rgba(255, 255, 255, 0.7)',
+          mb: 1,
+        }}
+      >
+        Blocked Action
+      </Typography>
+
+      <Box
+        sx={{
+          display: 'inline-flex',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          border: '1px solid rgba(235, 192, 36, 0.35)',
+          fontSize: '0.7rem',
+          fontWeight: 600,
+          lineHeight: 1.4,
+          whiteSpace: 'nowrap',
+          mb: 1.5,
+        }}
+      >
+        <Box
+          sx={{
+            background: 'rgba(235, 192, 36, 0.12)',
+            color: '#EBC024',
+            padding: '1px 8px',
+          }}
+        >
+          {permissionKey.function || permissionKey.subject || 'Action'}
+        </Box>
+        <Box
+          sx={{
+            background: 'rgba(235, 192, 36, 0.32)',
+            color: '#fff',
+            padding: '1px 8px',
+            borderLeft: '1px solid rgba(235, 192, 36, 0.35)',
+          }}
+        >
+          Locked
+        </Box>
+      </Box>
+
+      {/* Divider */}
+      <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
+
+      {/* Description Section */}
+      <Typography
+        sx={{
+          fontSize: '0.7rem',
+          fontWeight: 700,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'rgba(255, 255, 255, 0.7)',
+          mb: 0.75,
+        }}
+      >
+        What this permission allows
+      </Typography>
+      <Box
+        component="ul"
+        sx={{
+          paddingLeft: '1.25rem',
+          margin: 0,
+          color: 'rgba(255, 255, 255, 0.9)',
+          fontSize: '0.85rem',
+          lineHeight: 1.45,
+        }}
+      >
+        <Box component="li">
+          {permissionKey.description || `Allows you to perform the ${permissionKey.function || permissionKey.subject || 'selected'} operation.`}
+        </Box>
+      </Box>
+
+      {/* Resource Details / Key Info */}
+      {permissionKey.id && (
+        <>
+          <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
           <Typography
-            variant="caption"
             sx={{
-              display: 'block',
-              fontWeight: 'bold',
-              color: 'rgba(255, 255, 255, 0.7)',
+              fontSize: '0.7rem',
+              fontWeight: 700,
+              letterSpacing: '0.06em',
               textTransform: 'uppercase',
+              color: 'rgba(255, 255, 255, 0.7)',
+              mb: 0.75,
             }}
           >
-            Subcategory
+            Resource ID
           </Typography>
-          <Typography variant="body2">{permissionKey.subcategory}</Typography>
-        </Box>
-      )}
-      {(permissionKey.description || permissionKey.function) && (
-        <Box>
           <Typography
-            variant="caption"
             sx={{
-              display: 'block',
-              fontWeight: 'bold',
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+              fontSize: '0.7rem',
+              background: 'rgba(0, 0, 0, 0.2)',
+              padding: '4px 6px',
+              borderRadius: '4px',
               color: 'rgba(255, 255, 255, 0.7)',
-              textTransform: 'uppercase',
+              wordBreak: 'break-all',
             }}
           >
-            Description
+            {permissionKey.id}
           </Typography>
-          <Typography variant="body2">
-            {permissionKey.description || permissionKey.function}
-          </Typography>
-        </Box>
+        </>
       )}
     </Box>
   );
@@ -125,66 +295,95 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
   const isBadge = variant === 'badge';
 
   return (
-    <Box
-      sx={{
-        position: 'relative',
-        display: isBadge ? 'inline-flex' : 'flex',
-        width: isBadge ? 'auto' : '100%',
-        alignItems: 'center',
-      }}
-    >
-      <Box sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none' }}>
-        {children}
-      </Box>
-
-      <Tooltip title={tooltipTitle} placement="top" interactive>
-        <Box
-          sx={
-            isBadge
-              ? {
-                  position: 'absolute',
-                  top: -6,
-                  right: -6,
-                  backgroundColor: 'rgba(30, 30, 30, 0.9)',
-                  color: '#808080',
-                  borderRadius: '50%',
-                  width: 18,
-                  height: 18,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  boxShadow: 2,
-                  cursor: 'help',
-                  zIndex: 10,
-                  pointerEvents: 'auto',
-                  transition: 'color 0.2s ease',
-                  '&:hover': {
-                    color: '#EBC024',
-                  },
-                }
-              : {
-                  position: 'absolute',
-                  top: '50%',
-                  right: 8,
-                  transform: 'translateY(-50%)',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: 'pointer',
-                  color: '#808080',
-                  transition: 'color 0.2s ease',
-                  zIndex: 10,
-                  pointerEvents: 'auto',
-                  '&:hover': {
-                    color: '#EBC024',
-                  },
-                }
-          }
-        >
-          <ShieldIcon sx={{ fontSize: '14px', color: 'inherit' }} />
+    <ClickAwayListener onClickAway={handleClose}>
+      <Box
+        sx={{
+          position: 'relative',
+          display: isBadge ? 'inline-flex' : 'flex',
+          width: isBadge ? 'auto' : '100%',
+          alignItems: 'center',
+        }}
+      >
+        <Box sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none' }}>
+          {children}
         </Box>
-      </Tooltip>
-    </Box>
+
+        <Tooltip
+          title={tooltipTitle}
+          placement="top"
+          interactive
+          open={open}
+          onClose={handleClose}
+          disableHoverListener
+          disableFocusListener
+          disableTouchListener
+          slotProps={{
+            tooltip: {
+              sx: {
+                background: '#1A1A1A',
+                color: '#FFFFFF',
+                maxWidth: 420,
+                minWidth: 320,
+                padding: '16px',
+                borderLeft: '4px solid #EBC024',
+                borderRadius: '8px',
+                boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+                '& .MuiTypography-root': {
+                  color: 'inherit',
+                },
+              },
+            },
+          }}
+        >
+          <Box
+            onClick={handleToggle}
+            sx={
+              isBadge
+                ? {
+                    position: 'absolute',
+                    top: -6,
+                    right: -6,
+                    backgroundColor: 'rgba(30, 30, 30, 0.9)',
+                    color: '#808080',
+                    borderRadius: '50%',
+                    width: 18,
+                    height: 18,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    boxShadow: 2,
+                    cursor: 'help',
+                    zIndex: 10,
+                    pointerEvents: 'auto',
+                    transition: 'color 0.2s ease',
+                    '&:hover': {
+                      color: '#EBC024',
+                    },
+                  }
+                : {
+                    position: 'absolute',
+                    top: '50%',
+                    right: 8,
+                    transform: 'translateY(-50%)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                    color: '#808080',
+                    transition: 'color 0.2s ease',
+                    zIndex: 10,
+                    pointerEvents: 'auto',
+                    '&:hover': {
+                      color: '#EBC024',
+                    },
+                  }
+            }
+          >
+            <ShieldIcon sx={{ fontSize: '14px', color: 'inherit' }} />
+          </Box>
+        </Tooltip>
+      </Box>
+    </ClickAwayListener>
   );
 };
 

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -4,6 +4,21 @@ import { EventBus } from '../actors/eventBus';
 import Tooltip from '../base/Tooltip/Tooltip';
 import ShieldIcon from '@mui/icons-material/Shield';
 
+const SECTION_HEADING_SX = {
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  letterSpacing: '0.06em',
+  textTransform: 'uppercase' as const,
+  color: 'rgba(255, 255, 255, 0.7)',
+  mb: 0.75,
+};
+
+const DIVIDER_SX = {
+  height: '1px',
+  background: 'rgba(255, 255, 255, 0.1)',
+  my: 1.25,
+};
+
 export interface Key {
   // Backwards compatibility for old CanShow
   subject?: string;
@@ -177,21 +192,10 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
       )}
 
       {/* Divider */}
-      <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
+      <Box sx={DIVIDER_SX} />
 
       {/* Capabilities Blocked Section */}
-      <Typography
-        sx={{
-          fontSize: '0.7rem',
-          fontWeight: 700,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-          color: 'rgba(255, 255, 255, 0.7)',
-          mb: 1,
-        }}
-      >
-        Blocked Action
-      </Typography>
+      <Typography sx={{ ...SECTION_HEADING_SX, mb: 1 }}>Blocked Action</Typography>
 
       <Box
         sx={{
@@ -228,21 +232,10 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
       </Box>
 
       {/* Divider */}
-      <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
+      <Box sx={DIVIDER_SX} />
 
       {/* Description Section */}
-      <Typography
-        sx={{
-          fontSize: '0.7rem',
-          fontWeight: 700,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-          color: 'rgba(255, 255, 255, 0.7)',
-          mb: 0.75,
-        }}
-      >
-        What this permission allows
-      </Typography>
+      <Typography sx={SECTION_HEADING_SX}>What this permission allows</Typography>
       <Box
         component="ul"
         sx={{
@@ -261,19 +254,8 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
       {/* Resource Details / Key Info */}
       {permissionKey.id && (
         <>
-          <Box sx={{ height: '1px', background: 'rgba(255, 255, 255, 0.1)', my: 1.25 }} />
-          <Typography
-            sx={{
-              fontSize: '0.7rem',
-              fontWeight: 700,
-              letterSpacing: '0.06em',
-              textTransform: 'uppercase',
-              color: 'rgba(255, 255, 255, 0.7)',
-              mb: 0.75,
-            }}
-          >
-            Resource ID
-          </Typography>
+          <Box sx={DIVIDER_SX} />
+          <Typography sx={SECTION_HEADING_SX}>Resource ID</Typography>
           <Typography
             sx={{
               fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -311,7 +293,6 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
         <Tooltip
           title={tooltipTitle}
           placement="top"
-          interactive
           open={open}
           onClose={handleClose}
           disableHoverListener

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -251,9 +251,9 @@ export const createCanShow = (
         }}
         onClick={onClick}
       >
-        {React.cloneElement(children as React.ReactElement<any>, {
+        {React.cloneElement(children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>, {
           style: {
-            ...((children as React.ReactElement<any>).props.style as React.CSSProperties),
+            ...((children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>).props.style || {}),
             cursor: 'pointer',
             pointerEvents,
             opacity: opacity,

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React from 'react';
 import { Box, Typography } from '@mui/material';
 import { EventBus } from '../actors/eventBus';
 import CustomTooltip from './CustomTooltip/customTooltip';
@@ -43,69 +43,6 @@ export interface HasKeyProps<ReasonEvent> {
   invert_action?: InvertAction[];
 }
 
-export type CANFunction = (action: string, subject: string) => boolean;
-
-export interface PermissionContextType {
-  CAN?: CANFunction;
-}
-
-export const PermissionContext = createContext<PermissionContextType>({});
-
-export const PermissionProvider: React.FC<{
-  CAN: CANFunction;
-  children: React.ReactNode;
-}> = ({ CAN, children }) => {
-  return (
-    <PermissionContext.Provider value={{ CAN }}>
-      {children}
-    </PermissionContext.Provider>
-  );
-};
-
-export const usePermissionContext = () => useContext(PermissionContext);
-
-export type PermissionAction = 'disable' | 'hide' | 'showShield' | 'grayOut';
-
-export interface UsePermissionProps {
-  permissionKey?: Key;
-  permissionAction?: PermissionAction;
-}
-
-/**
- * usePermission Hook
- * Evaluates whether the user has the specified permission key using the context CAN function.
- */
-export const usePermission = (props?: UsePermissionProps) => {
-  const { CAN } = usePermissionContext();
-  const permissionKey = props?.permissionKey;
-  const permissionAction = props?.permissionAction || 'disable';
-
-  if (!permissionKey || !CAN) {
-    return {
-      hasPermission: true,
-      action: permissionAction,
-    };
-  }
-
-  // Support both new Key (id, function) and old Key (action, subject)
-  const actionString = permissionKey.id || permissionKey.action || '';
-  const subjectString = permissionKey.function || permissionKey.subject || '';
-
-  if (!actionString || !subjectString) {
-    return {
-      hasPermission: true,
-      action: permissionAction,
-    };
-  }
-
-  const hasPermission = CAN(actionString, subjectString);
-
-  return {
-    hasPermission,
-    action: permissionAction,
-  };
-};
-
 export interface PermissionShieldProps {
   permissionKey: Key;
   children: React.ReactNode;
@@ -114,7 +51,13 @@ export interface PermissionShieldProps {
 
 /**
  * PermissionShield Wrapper Component
- * Grays out its children and attaches a hoverable/clickable shield (lock) icon showing permission metadata.
+ *
+ * Renders children with a shield icon overlay showing permission metadata.
+ * This is a pure visual component — it does NOT check permissions itself.
+ * The consumer is responsible for determining disabled state (e.g. via CAN()).
+ *
+ * Usage in base components: when `disabled` is true AND `permissionKey` is provided,
+ * the component automatically wraps itself in PermissionShield.
  */
 export const PermissionShield: React.FC<PermissionShieldProps> = ({
   permissionKey,

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -110,6 +110,10 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
     };
   }, [uniqueId]);
 
+  if (!permissionKey) {
+    return <>{children}</>;
+  }
+
   const tooltipTitle = (
     <Box sx={{ width: '100%', color: '#FFFFFF', p: 0.5 }}>
       {/* Header Row */}
@@ -431,7 +435,7 @@ export const createCanShow = (
         }}
         onClick={onClick}
       >
-        {React.cloneElement(children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>, {
+        {React.isValidElement(children) ? React.cloneElement(children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>, {
           style: {
             ...((children as React.ReactElement<{ style?: React.CSSProperties; onClick?: React.MouseEventHandler }>).props.style || {}),
             cursor: 'pointer',
@@ -439,7 +443,7 @@ export const createCanShow = (
             opacity: opacity,
           },
           onClick: onClick,
-        })}
+        }) : children}
       </div>
     );
   };

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,10 +1,20 @@
-// import { CAN, getCapabilitiesRegistry, getMesheryEventBus } from '@/globals/mesherySdk';
-import React from 'react';
+import React, { createContext, useContext } from 'react';
+import { Box, Typography } from '@mui/material';
 import { EventBus } from '../actors/eventBus';
+import CustomTooltip from './CustomTooltip/customTooltip';
+import ShieldIcon from '@mui/icons-material/Shield';
 
 export interface Key {
-  subject: string;
-  action: string;
+  // Backwards compatibility for old CanShow
+  subject?: string;
+  action?: string;
+
+  // New Schemas key structure
+  id?: string;
+  category?: string;
+  subcategory?: string;
+  function?: string;
+  description?: string;
 }
 
 export type InvertAction = 'disable' | 'hide';
@@ -27,11 +37,213 @@ export type ReasonEvent = MissingPermissionReason | MissingCapabilityReason;
 
 export interface HasKeyProps<ReasonEvent> {
   Key?: Key;
-  predicate?: (capabilitiesRegistry: unknown) => [boolean, ReasonEvent]; // returns a boolean and an event if the user does not have the permission
+  predicate?: (capabilitiesRegistry: unknown) => [boolean, ReasonEvent];
   children: React.ReactNode;
   notifyOnclick?: boolean;
   invert_action?: InvertAction[];
 }
+
+export type CANFunction = (action: string, subject: string) => boolean;
+
+export interface PermissionContextType {
+  CAN?: CANFunction;
+}
+
+export const PermissionContext = createContext<PermissionContextType>({});
+
+export const PermissionProvider: React.FC<{
+  CAN: CANFunction;
+  children: React.ReactNode;
+}> = ({ CAN, children }) => {
+  return (
+    <PermissionContext.Provider value={{ CAN }}>
+      {children}
+    </PermissionContext.Provider>
+  );
+};
+
+export const usePermissionContext = () => useContext(PermissionContext);
+
+export type PermissionAction = 'disable' | 'hide' | 'showShield' | 'grayOut';
+
+export interface UsePermissionProps {
+  permissionKey?: Key;
+  permissionAction?: PermissionAction;
+}
+
+/**
+ * usePermission Hook
+ * Evaluates whether the user has the specified permission key using the context CAN function.
+ */
+export const usePermission = (props?: UsePermissionProps) => {
+  const { CAN } = usePermissionContext();
+  const permissionKey = props?.permissionKey;
+  const permissionAction = props?.permissionAction || 'disable';
+
+  if (!permissionKey || !CAN) {
+    return {
+      hasPermission: true,
+      action: permissionAction,
+    };
+  }
+
+  // Support both new Key (id, function) and old Key (action, subject)
+  const actionString = permissionKey.id || permissionKey.action || '';
+  const subjectString = permissionKey.function || permissionKey.subject || '';
+
+  if (!actionString || !subjectString) {
+    return {
+      hasPermission: true,
+      action: permissionAction,
+    };
+  }
+
+  const hasPermission = CAN(actionString, subjectString);
+
+  return {
+    hasPermission,
+    action: permissionAction,
+  };
+};
+
+export interface PermissionShieldProps {
+  permissionKey: Key;
+  children: React.ReactNode;
+  variant?: 'inline' | 'badge';
+}
+
+/**
+ * PermissionShield Wrapper Component
+ * Grays out its children and attaches a hoverable/clickable shield (lock) icon showing permission metadata.
+ */
+export const PermissionShield: React.FC<PermissionShieldProps> = ({
+  permissionKey,
+  children,
+  variant = 'inline',
+}) => {
+  const tooltipTitle = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, p: 0.5, color: '#FFFFFF' }}>
+      <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+        You don't currently have permission to perform this action.
+      </Typography>
+      {permissionKey.category && (
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              fontWeight: 'bold',
+              color: 'rgba(255, 255, 255, 0.7)',
+              textTransform: 'uppercase',
+            }}
+          >
+            Category
+          </Typography>
+          <Typography variant="body2">{permissionKey.category}</Typography>
+        </Box>
+      )}
+      {permissionKey.subcategory && (
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              fontWeight: 'bold',
+              color: 'rgba(255, 255, 255, 0.7)',
+              textTransform: 'uppercase',
+            }}
+          >
+            Subcategory
+          </Typography>
+          <Typography variant="body2">{permissionKey.subcategory}</Typography>
+        </Box>
+      )}
+      {(permissionKey.description || permissionKey.function) && (
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{
+              display: 'block',
+              fontWeight: 'bold',
+              color: 'rgba(255, 255, 255, 0.7)',
+              textTransform: 'uppercase',
+            }}
+          >
+            Description
+          </Typography>
+          <Typography variant="body2">
+            {permissionKey.description || permissionKey.function}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+
+  const isBadge = variant === 'badge';
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        display: isBadge ? 'inline-flex' : 'flex',
+        width: isBadge ? 'auto' : '100%',
+        alignItems: 'center',
+      }}
+    >
+      <Box sx={{ width: '100%', opacity: 0.5, pointerEvents: 'none' }}>
+        {children}
+      </Box>
+
+      <CustomTooltip title={tooltipTitle} placement="top" interactive>
+        <Box
+          sx={
+            isBadge
+              ? {
+                  position: 'absolute',
+                  top: -6,
+                  right: -6,
+                  backgroundColor: 'rgba(30, 30, 30, 0.9)',
+                  color: '#808080',
+                  borderRadius: '50%',
+                  width: 18,
+                  height: 18,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  boxShadow: 2,
+                  cursor: 'help',
+                  zIndex: 10,
+                  pointerEvents: 'auto',
+                  transition: 'color 0.2s ease',
+                  '&:hover': {
+                    color: '#EBC024',
+                  },
+                }
+              : {
+                  position: 'absolute',
+                  top: '50%',
+                  right: 8,
+                  transform: 'translateY(-50%)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  color: '#808080',
+                  transition: 'color 0.2s ease',
+                  zIndex: 10,
+                  pointerEvents: 'auto',
+                  '&:hover': {
+                    color: '#EBC024',
+                  },
+                }
+          }
+        >
+          <ShieldIcon sx={{ fontSize: '14px', color: 'inherit' }} />
+        </Box>
+      </CustomTooltip>
+    </Box>
+  );
+};
 
 // returns the children if the user has the permission to view the component or if a key is not provided
 // if the user does not have the permission to view the component, it will return null or a disabled version of the component specified by the invert_action prop
@@ -45,13 +257,16 @@ export const createCanShow = (
     children,
     notifyOnclick = true,
     predicate,
-    invert_action = ['disable']
+    invert_action = ['disable'],
   }: HasKeyProps<ReasonEvent>) => {
     if (!children) {
       return null;
     }
 
-    const hasKey = Key?.subject ? CAN(Key?.action, Key?.subject) : true;
+    const actionString = Key?.id || Key?.action || '';
+    const subjectString = Key?.function || Key?.subject || '';
+
+    const hasKey = subjectString ? CAN(actionString, subjectString) : true;
     const predicateRes = predicate && predicate(getCapabilitiesRegistry());
 
     const can = predicateRes ? predicateRes[0] && hasKey : hasKey;
@@ -59,8 +274,8 @@ export const createCanShow = (
     const reason = predicateRes?.[1] || {
       type: 'MISSING_PERMISSION',
       data: {
-        keyId: Key?.action as string
-      }
+        keyId: actionString,
+      },
     };
 
     if (can) {
@@ -89,22 +304,20 @@ export const createCanShow = (
         style={{
           cursor: 'pointer',
           pointerEvents,
-          opacity: opacity
+          opacity: opacity,
         }}
         onClick={onClick}
       >
-        {React.cloneElement(children as React.ReactElement, {
+        {React.cloneElement(children as React.ReactElement<any>, {
           style: {
-            ...((children as React.ReactElement).props.style as React.CSSProperties),
+            ...((children as React.ReactElement<any>).props.style as React.CSSProperties),
             cursor: 'pointer',
             pointerEvents,
-            opacity: opacity
+            opacity: opacity,
           },
-          onClick: onClick
+          onClick: onClick,
         })}
       </div>
     );
-
-    // return null;
   };
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,3 +45,12 @@ export {
   type QuickDateRangeOption,
   type UniversalFilterProps
 } from './custom/UniversalFilter';
+
+export {
+  PermissionProvider,
+  PermissionContext,
+  usePermission,
+  PermissionShield,
+  type Key,
+  type PermissionAction
+} from './custom/permissions';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,10 +47,7 @@ export {
 } from './custom/UniversalFilter';
 
 export {
-  PermissionProvider,
-  PermissionContext,
-  usePermission,
   PermissionShield,
   type Key,
-  type PermissionAction
+  type PermissionShieldProps
 } from './custom/permissions';


### PR DESCRIPTION
### What this does

This adds permission awareness to Sistent's base components (`Button`, `IconButton`, `ListItem`, `ListItemButton`, `MenuItem`) so that consumer apps like Meshery can show users *why* something is disabled instead of just graying it out with no explanation.

The approach is intentionally simple; Sistent doesn't try to own the permission-checking logic. That stays in the consumer app where it belongs (via their existing `CAN()` function). Sistent just handles the visual side:

> If a component is `disabled` **and** a `permissionKey` prop is provided → wrap it in a `PermissionShield` that shows a lock icon with details about the blocked action on click.



### What's included

- **`PermissionShield`** (`src/custom/permissions.tsx`) -- A visual wrapper component that grays out its children and overlays a shield/lock icon. Clicking the icon shows a styled tooltip with permission metadata (category, subcategory, blocked action, description, resource ID). Uses `ClickAwayListener` and a custom event to ensure only one tooltip is open at a time.

- **Updated base components**  -- `Button`, `IconButton`, `ListItem`, `ListItemButton`, and `MenuItem` now accept optional `permissionKey` props. When disabled with a key present, they automatically render inside `PermissionShield`.

- **Backward-compatible `Key` type** -- Supports both the existing `action`/`subject` schema and the newer `id`/`function`/`category`/`subcategory`/`description` schema. The `createCanShow` helper was also updated to handle both.

- **Exports** -- `PermissionShield`, `Key`, and `PermissionShieldProps` are exported from `src/index.tsx`.

### How to use it

```tsx
// The consumer app still owns the permission check — Sistent just shows the UI
<IconButton
  disabled={!CAN(Keys.CatalogManagementEditDesign.id, Keys.CatalogManagementEditDesign.function)}
  permissionKey={Keys.CatalogManagementEditDesign}
>
  <EditIcon />
</IconButton>
```

That's it. No providers, no context, no hooks. The `permissionKey` metadata (category, description, etc.) powers the tooltip content automatically.

### Why this approach

I wanted to keep Sistent as a pure UI library here. Permission logic varies between consumer apps; some use CASL, some use custom RBAC, some hit an API. Baking any of that into Sistent would couple it to a specific implementation. Instead, the consumer decides `disabled={true/false}` and Sistent just makes the disabled state informative rather than a dead end for the user.

### MockUps

<img width="888" height="780" alt="Screenshot 2026-07-10 at 12 46 07 AM" src="https://github.com/user-attachments/assets/7e8c7266-70ab-48f3-9be1-9cb73286a889" />





https://github.com/user-attachments/assets/25549aa5-f124-4f83-9f1d-8bdb8e237de5






**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
