### PR TITLE
Fix invalid hex color typo in CrossCircleIcon

### DIFF
--- a/src/icons/CrossCircle/index.tsx
+++ b/src/icons/CrossCircle/index.tsx
@@ -25,7 +25,7 @@ function CrossCircleIcon({
       </g>
       <defs>
         <clipPath id="a">
-          <path d="M0 0h24v24H0z" fill={props.stroke || '#FFFFF'} />
+          <path d="M0 0h24v24H0z" fill={props.stroke || '#FFFFFF'} />
         </clipPath>
       </defs>
     </svg>


### PR DESCRIPTION
**Notes for Reviewers**

## Description
This PR fixes a small typo in the `CrossCircleIcon` component where an invalid 5-character hex color code (`#FFFFF`) was used as the fallback fill color in the clip path.
## Changes Made
- Updated the fallback fill color in `src/icons/CrossCircle/index.tsx` from `#FFFFF` to `#FFFFFF` (valid 6-character hex code for white).


This PR fixes #1688 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [✅] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
