### PR TITLE
fix: reduce CustomTooltip delays to eliminate sluggishness

### DIFF
--- a/src/custom/CustomTooltip/customTooltip.tsx
+++ b/src/custom/CustomTooltip/customTooltip.tsx
@@ -27,15 +27,16 @@ function CustomTooltip({
   variant = 'standard',
   bgColor = '#141414',
   slotProps = {},
+  enterDelay = 100,
+  leaveDelay = 0,
   ...props
 }: CustomTooltipProps): JSX.Element {
   const theme = useTheme();
 
   return (
     <Tooltip
-      enterDelay={150}
-      enterNextDelay={400}
-      leaveDelay={700}
+      enterDelay={enterDelay}
+      leaveDelay={leaveDelay}
       slotProps={_.merge(
         {
           tooltip: {


### PR DESCRIPTION
**Description**
Reduces the hardcoded enter/leave delays in `CustomTooltip` that cause sluggish tooltip behavior.

**Changes**
- `enterDelay`: `150` → `100` (configurable via props, default `100`)
- `leaveDelay`: `700` → `0` (configurable via props, default `0`) — this was the main cause of sluggishness
- Removed `enterNextDelay={400}` (unnecessary with `leaveDelay=0`)
- All delay values are now overridable by callers via props

**Related**
Companion PR in meshery/meshery: adds theme-level `MuiTooltip.defaultProps` for direct `Tooltip` usages not using `CustomTooltip`.