### PR TITLE
docs: add npm pack method as alternative to npm link for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,52 @@ ls -l node_modules/@sistent/sistent
 # node_modules/@sistent/sistent -> ../../../../../sistent
 ```
 
-To revert back to the official package, first unlink the package, then install the official package using the following commands:
+To revert back to the official package, first uninstall the package, then install the official package using the following commands:
 
 ```
-npm unlink @sistent/sistent
+npm uninstall @sistent/sistent
+npm install @sistent/sistent
+```
+
+#### Method 3: Using `npm pack`
+
+This method creates a tarball of your local Sistent build and installs it like a regular npm package. It avoids the peer dependency issues that `npm link` sometimes causes.
+
+1. Build your local Sistent fork
+
+```
+cd <path-to-sistent-on-local-machine>
+
+make build
+```
+
+2. Create a tarball
+
+```
+npm pack
+```
+
+This creates a `.tgz` file (e.g., `sistent-sistent-<version>.tgz`) in the Sistent directory.
+
+3. Install the tarball in your project
+
+```
+cd <path-to-your-project>
+
+npm install <path-to-sistent-on-local-machine>/sistent-sistent-<version>.tgz
+```
+
+4. Run the build command in your project
+
+```
+# example, Meshery UI
+make ui-build
+```
+
+To revert back to the official package:
+
+```
+npm uninstall @sistent/sistent
 npm install @sistent/sistent
 ```
 


### PR DESCRIPTION
Adds a **Method 3: Using `npm pack`** to the README installation section, placed between Method 2 (npm link) and the Note section.

The `npm link` approach often fails with "Module not found" errors in Meshery UI. The `npm pack` method works more reliably by creating a tarball and installing it as a regular npm package, avoiding peer dependency issues.

New section covers:
1. Building the local Sistent fork
2. Creating a tarball via `npm pack`
3. Installing the tarball in the target project
4. Building the target project
5. Reverting to the official package

**Commit:** `169d2a7c`
**Branch:** `feat/readme-npm-pack` (from fork @Uday9909)
