### PR TITLE
Fix: Popper positioning for UniversalFilter

### DIFF
--- a/src/__testing__/UniversalFilter.test.tsx
+++ b/src/__testing__/UniversalFilter.test.tsx
@@ -36,10 +36,9 @@ jest.mock('../base/Paper', () => ({
 }));
 
 jest.mock('../base/Select', () => ({
-  Select: ({ children, value, onChange, MenuProps, 'data-testid': dataTestId }: any) => (
+  Select: ({ children, value, onChange, 'data-testid': dataTestId }: any) => (
     <select
       data-testid={dataTestId}
-      data-disable-portal={String(Boolean(MenuProps?.disablePortal))}
       value={value}
       onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
         onChange?.({ target: { value: event.target.value } })
@@ -106,7 +105,6 @@ describe('UniversalFilter', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
 
     const select = screen.getByTestId('universal-filter-select-status');
-    expect(select.getAttribute('data-disable-portal')).toBe('true');
 
     fireEvent.change(select, { target: { value: 'enabled' } });
 

--- a/src/__testing__/UniversalFilter.test.tsx
+++ b/src/__testing__/UniversalFilter.test.tsx
@@ -37,6 +37,8 @@ jest.mock('../base/Paper', () => ({
 
 jest.mock('../base/Select', () => ({
   Select: ({ children, value, onChange, 'data-testid': dataTestId }: any) => (
+    // No MenuProps — the Select menu should portal to document.body (default)
+    // so it positions correctly outside the Popper container.
     <select
       data-testid={dataTestId}
       value={value}

--- a/src/custom/UniversalFilter.tsx
+++ b/src/custom/UniversalFilter.tsx
@@ -188,7 +188,6 @@ function UniversalFilter({
                 width: '20rem',
                 marginBottom: '1rem'
               }}
-              MenuProps={{ disablePortal: true }}
               slotProps={{
                 input: {
                   'aria-label': 'Without label'


### PR DESCRIPTION


**Notes for Reviewers**

This PR fixes #

Before:

<img width="787" height="714" alt="Screenshot 2026-07-09 at 11 28 48 PM" src="https://github.com/user-attachments/assets/23a3d1f6-3cd7-4966-adc2-d0b8b5b65996" />


After:

<img width="1280" height="717" alt="Screenshot 2026-07-09 at 11 27 17 PM" src="https://github.com/user-attachments/assets/1d30065a-09d9-4c44-be0d-79900531ed13" />

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
