### PR TITLE
feat: integrate PermissionProvider and permission hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "1.3.13",
+        "@meshery/schemas": "^1.3.25",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3355,9 +3355,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.13.tgz",
-      "integrity": "sha512-VZw8yrKiBrxvJxFysOMQuuPJkDwGZ2DuW7ifPGJ6OxfBygAGIYuN4kofmPTglcW/WPhEYn656HM7/zahSmlcRg==",
+      "version": "1.3.25",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.25.tgz",
+      "integrity": "sha512-wsFu2nkIKUtVBLekbDyZ0lesEMOaxEBlyYeqRSa0Y02oMAZ+ubfpnTDPiDEOUvPYxCBQfWx1vYUsbqRaU5odWA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "1.3.13",
+    "@meshery/schemas": "^1.3.25",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",

--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -12,7 +12,6 @@ export interface ButtonProps extends MuiButtonProps {
    *
    * - `'showShield'` (default) — disables the button and shows a shield icon
    *   with a permission-metadata tooltip.
-   * - `'disable'` — disables the button without a shield.
    * - `'hide'` — renders nothing.
    *
    * Ignored when `permissionKey` is not provided.
@@ -30,18 +29,8 @@ export function Button({
 }: ButtonProps): JSX.Element {
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey → normal behavior (backward compatible)
-  if (!permissionKey) {
-    return (
-      <MuiButton {...props} disabled={disabled}>
-        {label}
-        {children}
-      </MuiButton>
-    );
-  }
-
-  // User HAS permission → render normally
-  if (hasPermission) {
+  // No permissionKey or user has permission → render normally
+  if (!permissionKey || hasPermission) {
     return (
       <MuiButton {...props} disabled={disabled}>
         {label}
@@ -51,27 +40,18 @@ export function Button({
   }
 
   // User LACKS permission → apply the permissionAction
-  switch (permissionAction) {
-    case 'hide':
-      return <></>;
-    case 'disable':
-      return (
-        <MuiButton {...props} disabled={true}>
-          {label}
-          {children}
-        </MuiButton>
-      );
-    case 'showShield':
-    default:
-      return (
-        <PermissionShield permissionKey={permissionKey} variant="badge">
-          <MuiButton {...props} disabled={true}>
-            {label}
-            {children}
-          </MuiButton>
-        </PermissionShield>
-      );
+  if (permissionAction === 'hide') {
+    return <></>;
   }
+
+  return (
+    <PermissionShield permissionKey={permissionKey} variant="badge">
+      <MuiButton {...props} disabled={true}>
+        {label}
+        {children}
+      </MuiButton>
+    </PermissionShield>
+  );
 }
 
 export const ContainedButton = (props: ButtonProps): JSX.Element => (

--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -1,38 +1,77 @@
 import { Button as MuiButton, type ButtonProps as MuiButtonProps } from '@mui/material';
 import React from 'react';
+import { useHasPermission, type PermissionAction } from '../../custom/PermissionProvider';
 import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ButtonProps extends MuiButtonProps {
   label?: string;
   children?: React.ReactNode;
   permissionKey?: Key;
+  /**
+   * Determines behavior when the user lacks the required permission.
+   *
+   * - `'showShield'` (default) — disables the button and shows a shield icon
+   *   with a permission-metadata tooltip.
+   * - `'disable'` — disables the button without a shield.
+   * - `'hide'` — renders nothing.
+   *
+   * Ignored when `permissionKey` is not provided.
+   */
+  permissionAction?: PermissionAction;
 }
 
 export function Button({
   label,
   children,
   permissionKey,
+  permissionAction = 'showShield',
   disabled,
   ...props
 }: ButtonProps): JSX.Element {
-  // When disabled AND permissionKey is provided, show the shield overlay
-  if (disabled && permissionKey) {
+  const hasPermission = useHasPermission(permissionKey);
+
+  // No permissionKey → normal behavior (backward compatible)
+  if (!permissionKey) {
     return (
-      <PermissionShield permissionKey={permissionKey} variant="badge">
+      <MuiButton {...props} disabled={disabled}>
+        {label}
+        {children}
+      </MuiButton>
+    );
+  }
+
+  // User HAS permission → render normally
+  if (hasPermission) {
+    return (
+      <MuiButton {...props} disabled={disabled}>
+        {label}
+        {children}
+      </MuiButton>
+    );
+  }
+
+  // User LACKS permission → apply the permissionAction
+  switch (permissionAction) {
+    case 'hide':
+      return null as unknown as JSX.Element;
+    case 'disable':
+      return (
         <MuiButton {...props} disabled={true}>
           {label}
           {children}
         </MuiButton>
-      </PermissionShield>
-    );
+      );
+    case 'showShield':
+    default:
+      return (
+        <PermissionShield permissionKey={permissionKey} variant="badge">
+          <MuiButton {...props} disabled={true}>
+            {label}
+            {children}
+          </MuiButton>
+        </PermissionShield>
+      );
   }
-
-  return (
-    <MuiButton {...props} disabled={disabled}>
-      {label}
-      {children}
-    </MuiButton>
-  );
 }
 
 export const ContainedButton = (props: ButtonProps): JSX.Element => (

--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -53,7 +53,7 @@ export function Button({
   // User LACKS permission → apply the permissionAction
   switch (permissionAction) {
     case 'hide':
-      return null as unknown as JSX.Element;
+      return <></>;
     case 'disable':
       return (
         <MuiButton {...props} disabled={true}>

--- a/src/base/Button/Button.tsx
+++ b/src/base/Button/Button.tsx
@@ -29,8 +29,8 @@ export function Button({
 }: ButtonProps): JSX.Element {
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey or user has permission → render normally
-  if (!permissionKey || hasPermission) {
+  // useHasPermission returns true when no permissionKey is provided (backward compatible)
+  if (hasPermission) {
     return (
       <MuiButton {...props} disabled={disabled}>
         {label}
@@ -45,7 +45,7 @@ export function Button({
   }
 
   return (
-    <PermissionShield permissionKey={permissionKey} variant="badge">
+    <PermissionShield permissionKey={permissionKey!} variant="badge">
       <MuiButton {...props} disabled={true}>
         {label}
         {children}

--- a/src/base/IconButton/IconButton.tsx
+++ b/src/base/IconButton/IconButton.tsx
@@ -24,8 +24,8 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey or user has permission → render normally
-  if (!permissionKey || hasPermission) {
+  // useHasPermission returns true when no permissionKey is provided (backward compatible)
+  if (hasPermission) {
     return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
   }
 
@@ -35,7 +35,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((
   }
 
   return (
-    <PermissionShield permissionKey={permissionKey} variant="badge">
+    <PermissionShield permissionKey={permissionKey!} variant="badge">
       <MuiIconButton ref={ref} {...rest} disabled={true} />
     </PermissionShield>
   );

--- a/src/base/IconButton/IconButton.tsx
+++ b/src/base/IconButton/IconButton.tsx
@@ -3,25 +3,52 @@ import {
   type IconButtonProps as MuiIconButtonProps
 } from '@mui/material';
 import React from 'react';
+import { useHasPermission, type PermissionAction } from '../../custom/PermissionProvider';
 import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface IconButtonProps extends MuiIconButtonProps {
   permissionKey?: Key;
+  /**
+   * Determines behavior when the user lacks the required permission.
+   *
+   * - `'showShield'` (default) — disables the button and shows a shield icon
+   *   with a permission-metadata tooltip.
+   * - `'disable'` — disables the button without a shield.
+   * - `'hide'` — renders nothing.
+   *
+   * Ignored when `permissionKey` is not provided.
+   */
+  permissionAction?: PermissionAction;
 }
 
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
-  const { permissionKey, disabled, ...rest } = props;
+  const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
+  const hasPermission = useHasPermission(permissionKey);
 
-  // When disabled AND permissionKey is provided, show the shield overlay
-  if (disabled && permissionKey) {
-    return (
-      <PermissionShield permissionKey={permissionKey} variant="badge">
-        <MuiIconButton ref={ref} {...rest} disabled={true} />
-      </PermissionShield>
-    );
+  // No permissionKey → normal behavior (backward compatible)
+  if (!permissionKey) {
+    return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
   }
 
-  return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
+  // User HAS permission → render normally
+  if (hasPermission) {
+    return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
+  }
+
+  // User LACKS permission → apply the permissionAction
+  switch (permissionAction) {
+    case 'hide':
+      return null;
+    case 'disable':
+      return <MuiIconButton ref={ref} {...rest} disabled={true} />;
+    case 'showShield':
+    default:
+      return (
+        <PermissionShield permissionKey={permissionKey} variant="badge">
+          <MuiIconButton ref={ref} {...rest} disabled={true} />
+        </PermissionShield>
+      );
+  }
 });
 
 IconButton.displayName = 'IconButton';

--- a/src/base/IconButton/IconButton.tsx
+++ b/src/base/IconButton/IconButton.tsx
@@ -13,7 +13,6 @@ export interface IconButtonProps extends MuiIconButtonProps {
    *
    * - `'showShield'` (default) — disables the button and shows a shield icon
    *   with a permission-metadata tooltip.
-   * - `'disable'` — disables the button without a shield.
    * - `'hide'` — renders nothing.
    *
    * Ignored when `permissionKey` is not provided.
@@ -25,30 +24,21 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>((
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey → normal behavior (backward compatible)
-  if (!permissionKey) {
-    return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
-  }
-
-  // User HAS permission → render normally
-  if (hasPermission) {
+  // No permissionKey or user has permission → render normally
+  if (!permissionKey || hasPermission) {
     return <MuiIconButton ref={ref} {...rest} disabled={disabled} />;
   }
 
   // User LACKS permission → apply the permissionAction
-  switch (permissionAction) {
-    case 'hide':
-      return null;
-    case 'disable':
-      return <MuiIconButton ref={ref} {...rest} disabled={true} />;
-    case 'showShield':
-    default:
-      return (
-        <PermissionShield permissionKey={permissionKey} variant="badge">
-          <MuiIconButton ref={ref} {...rest} disabled={true} />
-        </PermissionShield>
-      );
+  if (permissionAction === 'hide') {
+    return null;
   }
+
+  return (
+    <PermissionShield permissionKey={permissionKey} variant="badge">
+      <MuiIconButton ref={ref} {...rest} disabled={true} />
+    </PermissionShield>
+  );
 });
 
 IconButton.displayName = 'IconButton';

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -1,27 +1,55 @@
 import { ListItem as MuiListItem, ListItemProps as MuiListItemProps } from '@mui/material';
 import React from 'react';
+import { useHasPermission, type PermissionAction } from '../../custom/PermissionProvider';
 import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ListItemProps extends MuiListItemProps {
   permissionKey?: Key;
   disabled?: boolean;
+  /**
+   * Determines behavior when the user lacks the required permission.
+   *
+   * - `'showShield'` (default) — disables the item and shows a shield icon
+   *   with a permission-metadata tooltip.
+   * - `'disable'` — disables the item without a shield.
+   * - `'hide'` — renders nothing.
+   *
+   * Ignored when `permissionKey` is not provided.
+   */
+  permissionAction?: PermissionAction;
 }
 
 const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => {
-  const { permissionKey, disabled, ...rest } = props;
+  const { permissionKey, permissionAction = 'showShield', ...rest } = props;
+  delete (rest as Record<string, unknown>).disabled;
+  const hasPermission = useHasPermission(permissionKey);
 
-  // When disabled AND permissionKey is provided, show the shield overlay
+  // No permissionKey → normal behavior (backward compatible)
   // Note: MUI ListItem doesn't have a native `disabled` prop, so we only use
   // it as a custom guard for the PermissionShield wrapper
-  if (disabled && permissionKey) {
-    return (
-      <PermissionShield permissionKey={permissionKey} variant="inline">
-        <MuiListItem {...rest} ref={ref} />
-      </PermissionShield>
-    );
+  if (!permissionKey) {
+    return <MuiListItem {...rest} ref={ref} />;
   }
 
-  return <MuiListItem {...rest} ref={ref} />;
+  // User HAS permission → render normally
+  if (hasPermission) {
+    return <MuiListItem {...rest} ref={ref} />;
+  }
+
+  // User LACKS permission → apply the permissionAction
+  switch (permissionAction) {
+    case 'hide':
+      return null;
+    case 'disable':
+      return <MuiListItem {...rest} ref={ref} />;
+    case 'showShield':
+    default:
+      return (
+        <PermissionShield permissionKey={permissionKey} variant="inline">
+          <MuiListItem {...rest} ref={ref} />
+        </PermissionShield>
+      );
+  }
 });
 
 ListItem.displayName = 'ListItem';

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -23,8 +23,8 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
   delete (rest as Record<string, unknown>).disabled;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey or user has permission → render normally
-  if (!permissionKey || hasPermission) {
+  // useHasPermission returns true when no permissionKey is provided (backward compatible)
+  if (hasPermission) {
     return <MuiListItem {...rest} ref={ref} />;
   }
 
@@ -34,7 +34,7 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
   }
 
   return (
-    <PermissionShield permissionKey={permissionKey} variant="inline">
+    <PermissionShield permissionKey={permissionKey!} variant="inline">
       <MuiListItem {...rest} ref={ref} />
     </PermissionShield>
   );

--- a/src/base/ListItem/ListItem.tsx
+++ b/src/base/ListItem/ListItem.tsx
@@ -11,7 +11,6 @@ export interface ListItemProps extends MuiListItemProps {
    *
    * - `'showShield'` (default) — disables the item and shows a shield icon
    *   with a permission-metadata tooltip.
-   * - `'disable'` — disables the item without a shield.
    * - `'hide'` — renders nothing.
    *
    * Ignored when `permissionKey` is not provided.
@@ -24,32 +23,21 @@ const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>((props, ref) => 
   delete (rest as Record<string, unknown>).disabled;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey → normal behavior (backward compatible)
-  // Note: MUI ListItem doesn't have a native `disabled` prop, so we only use
-  // it as a custom guard for the PermissionShield wrapper
-  if (!permissionKey) {
-    return <MuiListItem {...rest} ref={ref} />;
-  }
-
-  // User HAS permission → render normally
-  if (hasPermission) {
+  // No permissionKey or user has permission → render normally
+  if (!permissionKey || hasPermission) {
     return <MuiListItem {...rest} ref={ref} />;
   }
 
   // User LACKS permission → apply the permissionAction
-  switch (permissionAction) {
-    case 'hide':
-      return null;
-    case 'disable':
-      return <MuiListItem {...rest} ref={ref} />;
-    case 'showShield':
-    default:
-      return (
-        <PermissionShield permissionKey={permissionKey} variant="inline">
-          <MuiListItem {...rest} ref={ref} />
-        </PermissionShield>
-      );
+  if (permissionAction === 'hide') {
+    return null;
   }
+
+  return (
+    <PermissionShield permissionKey={permissionKey} variant="inline">
+      <MuiListItem {...rest} ref={ref} />
+    </PermissionShield>
+  );
 });
 
 ListItem.displayName = 'ListItem';

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -24,8 +24,8 @@ const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((pr
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey or user has permission → render normally
-  if (!permissionKey || hasPermission) {
+  // useHasPermission returns true when no permissionKey is provided (backward compatible)
+  if (hasPermission) {
     return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
   }
 
@@ -35,7 +35,7 @@ const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((pr
   }
 
   return (
-    <PermissionShield permissionKey={permissionKey} variant="inline">
+    <PermissionShield permissionKey={permissionKey!} variant="inline">
       <MuiListItemButton {...rest} ref={ref} disabled={true} />
     </PermissionShield>
   );

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -13,7 +13,6 @@ export interface ListItemButtonProps extends MuiListItemButtonProps {
    *
    * - `'showShield'` (default) — disables the button and shows a shield icon
    *   with a permission-metadata tooltip.
-   * - `'disable'` — disables the button without a shield.
    * - `'hide'` — renders nothing.
    *
    * Ignored when `permissionKey` is not provided.
@@ -25,30 +24,21 @@ const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((pr
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey → normal behavior (backward compatible)
-  if (!permissionKey) {
-    return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
-  }
-
-  // User HAS permission → render normally
-  if (hasPermission) {
+  // No permissionKey or user has permission → render normally
+  if (!permissionKey || hasPermission) {
     return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
   }
 
   // User LACKS permission → apply the permissionAction
-  switch (permissionAction) {
-    case 'hide':
-      return null;
-    case 'disable':
-      return <MuiListItemButton {...rest} ref={ref} disabled={true} />;
-    case 'showShield':
-    default:
-      return (
-        <PermissionShield permissionKey={permissionKey} variant="inline">
-          <MuiListItemButton {...rest} ref={ref} disabled={true} />
-        </PermissionShield>
-      );
+  if (permissionAction === 'hide') {
+    return null;
   }
+
+  return (
+    <PermissionShield permissionKey={permissionKey} variant="inline">
+      <MuiListItemButton {...rest} ref={ref} disabled={true} />
+    </PermissionShield>
+  );
 });
 
 ListItemButton.displayName = 'ListItemButton';

--- a/src/base/ListItemButton/ListItemButton.tsx
+++ b/src/base/ListItemButton/ListItemButton.tsx
@@ -3,25 +3,52 @@ import {
   ListItemButtonProps as MuiListItemButtonProps
 } from '@mui/material';
 import React from 'react';
+import { useHasPermission, type PermissionAction } from '../../custom/PermissionProvider';
 import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface ListItemButtonProps extends MuiListItemButtonProps {
   permissionKey?: Key;
+  /**
+   * Determines behavior when the user lacks the required permission.
+   *
+   * - `'showShield'` (default) — disables the button and shows a shield icon
+   *   with a permission-metadata tooltip.
+   * - `'disable'` — disables the button without a shield.
+   * - `'hide'` — renders nothing.
+   *
+   * Ignored when `permissionKey` is not provided.
+   */
+  permissionAction?: PermissionAction;
 }
 
 const ListItemButton = React.forwardRef<HTMLDivElement, ListItemButtonProps>((props, ref) => {
-  const { permissionKey, disabled, ...rest } = props;
+  const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
+  const hasPermission = useHasPermission(permissionKey);
 
-  // When disabled AND permissionKey is provided, show the shield overlay
-  if (disabled && permissionKey) {
-    return (
-      <PermissionShield permissionKey={permissionKey} variant="inline">
-        <MuiListItemButton {...rest} ref={ref} disabled={true} />
-      </PermissionShield>
-    );
+  // No permissionKey → normal behavior (backward compatible)
+  if (!permissionKey) {
+    return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
   }
 
-  return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
+  // User HAS permission → render normally
+  if (hasPermission) {
+    return <MuiListItemButton {...rest} ref={ref} disabled={disabled} />;
+  }
+
+  // User LACKS permission → apply the permissionAction
+  switch (permissionAction) {
+    case 'hide':
+      return null;
+    case 'disable':
+      return <MuiListItemButton {...rest} ref={ref} disabled={true} />;
+    case 'showShield':
+    default:
+      return (
+        <PermissionShield permissionKey={permissionKey} variant="inline">
+          <MuiListItemButton {...rest} ref={ref} disabled={true} />
+        </PermissionShield>
+      );
+  }
 });
 
 ListItemButton.displayName = 'ListItemButton';

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -10,7 +10,6 @@ export interface MenuItemProps extends MuiMenuItemProps {
    *
    * - `'showShield'` (default) — disables the item and shows a shield icon
    *   with a permission-metadata tooltip.
-   * - `'disable'` — disables the item without a shield.
    * - `'hide'` — renders nothing.
    *
    * Ignored when `permissionKey` is not provided.
@@ -22,30 +21,21 @@ export function MenuItem(props: MenuItemProps): JSX.Element {
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey → normal behavior (backward compatible)
-  if (!permissionKey) {
-    return <MuiMenuItem {...rest} disabled={disabled} />;
-  }
-
-  // User HAS permission → render normally
-  if (hasPermission) {
+  // No permissionKey or user has permission → render normally
+  if (!permissionKey || hasPermission) {
     return <MuiMenuItem {...rest} disabled={disabled} />;
   }
 
   // User LACKS permission → apply the permissionAction
-  switch (permissionAction) {
-    case 'hide':
-      return <></>;
-    case 'disable':
-      return <MuiMenuItem {...rest} disabled={true} />;
-    case 'showShield':
-    default:
-      return (
-        <PermissionShield permissionKey={permissionKey} variant="inline">
-          <MuiMenuItem {...rest} disabled={true} />
-        </PermissionShield>
-      );
+  if (permissionAction === 'hide') {
+    return <></>;
   }
+
+  return (
+    <PermissionShield permissionKey={permissionKey} variant="inline">
+      <MuiMenuItem {...rest} disabled={true} />
+    </PermissionShield>
+  );
 }
 
 export default MenuItem;

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -1,24 +1,51 @@
 import { MenuItem as MuiMenuItem, MenuItemProps as MuiMenuItemProps } from '@mui/material';
 import React from 'react';
+import { useHasPermission, type PermissionAction } from '../../custom/PermissionProvider';
 import { Key, PermissionShield } from '../../custom/permissions';
 
 export interface MenuItemProps extends MuiMenuItemProps {
   permissionKey?: Key;
+  /**
+   * Determines behavior when the user lacks the required permission.
+   *
+   * - `'showShield'` (default) — disables the item and shows a shield icon
+   *   with a permission-metadata tooltip.
+   * - `'disable'` — disables the item without a shield.
+   * - `'hide'` — renders nothing.
+   *
+   * Ignored when `permissionKey` is not provided.
+   */
+  permissionAction?: PermissionAction;
 }
 
 export function MenuItem(props: MenuItemProps): JSX.Element {
-  const { permissionKey, disabled, ...rest } = props;
+  const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
+  const hasPermission = useHasPermission(permissionKey);
 
-  // When disabled AND permissionKey is provided, show the shield overlay
-  if (disabled && permissionKey) {
-    return (
-      <PermissionShield permissionKey={permissionKey} variant="inline">
-        <MuiMenuItem {...rest} disabled={true} />
-      </PermissionShield>
-    );
+  // No permissionKey → normal behavior (backward compatible)
+  if (!permissionKey) {
+    return <MuiMenuItem {...rest} disabled={disabled} />;
   }
 
-  return <MuiMenuItem {...rest} disabled={disabled} />;
+  // User HAS permission → render normally
+  if (hasPermission) {
+    return <MuiMenuItem {...rest} disabled={disabled} />;
+  }
+
+  // User LACKS permission → apply the permissionAction
+  switch (permissionAction) {
+    case 'hide':
+      return null as unknown as JSX.Element;
+    case 'disable':
+      return <MuiMenuItem {...rest} disabled={true} />;
+    case 'showShield':
+    default:
+      return (
+        <PermissionShield permissionKey={permissionKey} variant="inline">
+          <MuiMenuItem {...rest} disabled={true} />
+        </PermissionShield>
+      );
+  }
 }
 
 export default MenuItem;

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -21,8 +21,8 @@ export function MenuItem(props: MenuItemProps): JSX.Element {
   const { permissionKey, permissionAction = 'showShield', disabled, ...rest } = props;
   const hasPermission = useHasPermission(permissionKey);
 
-  // No permissionKey or user has permission → render normally
-  if (!permissionKey || hasPermission) {
+  // useHasPermission returns true when no permissionKey is provided (backward compatible)
+  if (hasPermission) {
     return <MuiMenuItem {...rest} disabled={disabled} />;
   }
 
@@ -32,7 +32,7 @@ export function MenuItem(props: MenuItemProps): JSX.Element {
   }
 
   return (
-    <PermissionShield permissionKey={permissionKey} variant="inline">
+    <PermissionShield permissionKey={permissionKey!} variant="inline">
       <MuiMenuItem {...rest} disabled={true} />
     </PermissionShield>
   );

--- a/src/base/MenuItem/MenuItem.tsx
+++ b/src/base/MenuItem/MenuItem.tsx
@@ -35,7 +35,7 @@ export function MenuItem(props: MenuItemProps): JSX.Element {
   // User LACKS permission → apply the permissionAction
   switch (permissionAction) {
     case 'hide':
-      return null as unknown as JSX.Element;
+      return <></>;
     case 'disable':
       return <MuiMenuItem {...rest} disabled={true} />;
     case 'showShield':

--- a/src/custom/PermissionProvider.tsx
+++ b/src/custom/PermissionProvider.tsx
@@ -1,0 +1,144 @@
+import React, { createContext, useContext } from 'react';
+
+
+/**
+ * Determines how a component responds when the user lacks the required permission.
+ *
+ * - `'disable'`    — renders the component in a disabled state (no shield icon).
+ * - `'hide'`       — renders nothing (`null`).
+ * - `'showShield'` — disables the component, overlays a shield/lock icon, and
+ *                     displays permission metadata in a tooltip.
+ */
+export type PermissionAction = 'disable' | 'hide' | 'showShield';
+
+/**
+ * User context displayed inside the PermissionShield tooltip.
+ *
+ * Passed through the provider so that `PermissionShield` never reads from
+ * `sessionStorage` or any other host-specific storage mechanism.
+ */
+export interface PermissionUserContext {
+  userName?: string;
+  orgName?: string;
+  roleNames?: string[];
+}
+
+/**
+ * The `Key` interface mirrors the structure defined in `@meshery/schemas`.
+ *
+ * Re-declared here so that `PermissionProvider` can reference it without
+ * importing from the permissions barrel (which would create a circular dep).
+ */
+export interface PermissionKey {
+  id?: string;
+  category?: string;
+  subcategory?: string;
+  function?: string;
+  description?: string;
+  // Backwards compatibility for old CanShow
+  subject?: string;
+  action?: string;
+}
+
+/**
+ * Value exposed by `PermissionContext`.
+ */
+export interface PermissionProviderValue {
+  /**
+   * Generic permission evaluator supplied by the host application.
+   *
+   * Sistent never knows *how* permissions are checked (CASL, server lookup,
+   * JWT claim, etc.) — it only calls this function.
+   */
+  userHasPermission: (key: PermissionKey) => boolean;
+
+  /** Optional user context rendered inside the shield tooltip. */
+  userContext?: PermissionUserContext;
+}
+
+
+const PermissionContext = createContext<PermissionProviderValue | null>(null);
+
+// Provider
+
+export interface PermissionProviderProps {
+  /**
+   * A function that returns `true` when the current user holds the given
+   * permission key.  The host application is responsible for implementing
+   * this — it may delegate to CASL, a server-side API, a JWT claim, etc.
+   */
+  userHasPermission: (key: PermissionKey) => boolean;
+
+  /**
+   * Optional user/org/role context displayed inside the `PermissionShield`
+   * tooltip.  When omitted the tooltip's user-context section is hidden.
+   */
+  userContext?: PermissionUserContext;
+
+  children: React.ReactNode;
+}
+
+/**
+ * `PermissionProvider` — the single integration point between Sistent's
+ * permission-aware components and the host application's authorization system.
+ *
+ * Mount this near the root of the React tree (alongside your theme provider).
+ * If no `PermissionProvider` is present, all permission checks default to
+ * "permitted" — ensuring full backward compatibility.
+ *
+ * @example
+ * ```tsx
+ * // In _app.tsx — CASL adapter (the ONLY place CASL is referenced)
+ * import { PermissionProvider } from '@sistent/sistent';
+ * import { ability } from '@/utils/can';
+ *
+ * const userHasPermission = (key) => ability.can(key.id, key.function?.toLowerCase());
+ *
+ * <PermissionProvider userHasPermission={userHasPermission} userContext={{ userName, orgName, roleNames }}>
+ *   {children}
+ * </PermissionProvider>
+ * ```
+ */
+export const PermissionProvider: React.FC<PermissionProviderProps> = ({
+  userHasPermission,
+  userContext,
+  children
+}) => (
+  <PermissionContext.Provider value={{ userHasPermission, userContext }}>
+    {children}
+  </PermissionContext.Provider>
+);
+
+PermissionProvider.displayName = 'PermissionProvider';
+
+// Hooks
+
+/**
+ * Access the full `PermissionProviderValue`.
+ * Returns `null` when no `PermissionProvider` is mounted.
+ */
+export const usePermission = (): PermissionProviderValue | null => useContext(PermissionContext);
+
+/**
+ * Check whether the current user has a given permission key.
+ *
+ * Returns `true` when:
+ * - No `PermissionProvider` is mounted (backward-compatible default), OR
+ * - No `key` is supplied, OR
+ * - `userHasPermission(key)` returns `true`.
+ */
+export const useHasPermission = (key?: PermissionKey): boolean => {
+  const ctx = usePermission();
+  if (!key || !ctx) return true;
+  return ctx.userHasPermission(key);
+};
+
+/**
+ * Retrieve the user context supplied to `PermissionProvider`.
+ * Used internally by `PermissionShield` to display user/org/role info
+ * without reading from `sessionStorage`.
+ */
+export const usePermissionUserContext = (): PermissionUserContext | undefined => {
+  const ctx = usePermission();
+  return ctx?.userContext;
+};

--- a/src/custom/PermissionProvider.tsx
+++ b/src/custom/PermissionProvider.tsx
@@ -5,12 +5,11 @@ import React, { createContext, useContext } from 'react';
 /**
  * Determines how a component responds when the user lacks the required permission.
  *
- * - `'disable'`    — renders the component in a disabled state (no shield icon).
  * - `'hide'`       — renders nothing (`null`).
  * - `'showShield'` — disables the component, overlays a shield/lock icon, and
  *                     displays permission metadata in a tooltip.
  */
-export type PermissionAction = 'disable' | 'hide' | 'showShield';
+export type PermissionAction = 'hide' | 'showShield';
 
 /**
  * User context displayed inside the PermissionShield tooltip.

--- a/src/custom/PermissionProvider.tsx
+++ b/src/custom/PermissionProvider.tsx
@@ -1,3 +1,4 @@
+import { Key } from '@meshery/schemas/permissions';
 import React, { createContext, useContext } from 'react';
 
 
@@ -24,23 +25,6 @@ export interface PermissionUserContext {
 }
 
 /**
- * The `Key` interface mirrors the structure defined in `@meshery/schemas`.
- *
- * Re-declared here so that `PermissionProvider` can reference it without
- * importing from the permissions barrel (which would create a circular dep).
- */
-export interface PermissionKey {
-  id?: string;
-  category?: string;
-  subcategory?: string;
-  function?: string;
-  description?: string;
-  // Backwards compatibility for old CanShow
-  subject?: string;
-  action?: string;
-}
-
-/**
  * Value exposed by `PermissionContext`.
  */
 export interface PermissionProviderValue {
@@ -50,7 +34,7 @@ export interface PermissionProviderValue {
    * Sistent never knows *how* permissions are checked (CASL, server lookup,
    * JWT claim, etc.) — it only calls this function.
    */
-  userHasPermission: (key: PermissionKey) => boolean;
+  userHasPermission: (key: Key) => boolean;
 
   /** Optional user context rendered inside the shield tooltip. */
   userContext?: PermissionUserContext;
@@ -67,7 +51,7 @@ export interface PermissionProviderProps {
    * permission key.  The host application is responsible for implementing
    * this — it may delegate to CASL, a server-side API, a JWT claim, etc.
    */
-  userHasPermission: (key: PermissionKey) => boolean;
+  userHasPermission: (key: Key) => boolean;
 
   /**
    * Optional user/org/role context displayed inside the `PermissionShield`
@@ -127,7 +111,7 @@ export const usePermission = (): PermissionProviderValue | null => useContext(Pe
  * - No `key` is supplied, OR
  * - `userHasPermission(key)` returns `true`.
  */
-export const useHasPermission = (key?: PermissionKey): boolean => {
+export const useHasPermission = (key?: Key): boolean => {
   const ctx = usePermission();
   if (!key || !ctx) return true;
   return ctx.userHasPermission(key);

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -4,6 +4,7 @@ import SecurityIcon from '@mui/icons-material/Security';
 import React from 'react';
 import { EventBus } from '../actors/eventBus';
 import { Box, Chip, ClickAwayListener, Link, Tooltip, Typography } from '../base';
+import { usePermissionUserContext } from './PermissionProvider';
 
 const DIVIDER_SX = {
   height: '1px',
@@ -74,6 +75,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
   const [open, setOpen] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
   const uniqueId = React.useId();
+  const userContext = usePermissionUserContext();
 
   const handleClose = () => {
     setOpen(false);
@@ -264,100 +266,82 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
         </Link>
       </Box>
 
-      {/* User / Org / Role context — read from sessionStorage */}
-      {(() => {
-        try {
-          const org = JSON.parse(sessionStorage.getItem('currentOrg') || 'null');
-          const user = JSON.parse(sessionStorage.getItem('user') || 'null');
-          const orgName = org?.name;
-          const firstName = user?.firstName || user?.first_name || '';
-          const lastName = user?.lastName || user?.last_name || '';
-          const userName = `${firstName} ${lastName}`.trim() || user?.name || user?.email;
-          const orgId = org?.id;
-          const orgWithRoles = user?.organizations?.organizationsWithRoles?.find(
-            (o: { id?: string; roleNames?: string[] }) => o.id === orgId
-          );
-          const roleNames: string[] = orgWithRoles?.roleNames || user?.roleNames || [];
-
-          if (!orgName && !userName) return null;
-
-          return (
-            <>
-              <Box sx={DIVIDER_SX} />
-              <Box
-                sx={{
-                  background: 'rgba(255, 255, 255, 0.02)',
-                  border: '1px solid rgba(255, 255, 255, 0.05)',
-                  borderRadius: '6px',
-                  p: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 0.75,
-                  mb: 0.75
-                }}
-              >
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
-                    User
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: '0.72rem',
-                      color: '#FFFFFF',
-                      fontWeight: 600,
-                      textAlign: 'right'
-                    }}
-                  >
-                    {userName}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
-                    Org
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: '0.72rem',
-                      color: '#FFFFFF',
-                      fontWeight: 600,
-                      textAlign: 'right'
-                    }}
-                  >
-                    {orgName || 'Private Org'}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-                  <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
-                    Role(s)
-                  </Typography>
-                  <Typography
-                    sx={{
-                      fontSize: '0.72rem',
-                      color: '#FFFFFF',
-                      fontWeight: 600,
-                      textAlign: 'right'
-                    }}
-                  >
-                    {roleNames.length > 0 ? roleNames.join(', ') : 'None'}
-                  </Typography>
-                </Box>
-              </Box>
+      {/* User / Org / Role context — provided via PermissionProvider */}
+      {userContext && (userContext.userName || userContext.orgName) && (
+        <>
+          <Box sx={DIVIDER_SX} />
+          <Box
+            sx={{
+              background: 'rgba(255, 255, 255, 0.02)',
+              border: '1px solid rgba(255, 255, 255, 0.05)',
+              borderRadius: '6px',
+              p: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 0.75,
+              mb: 0.75
+            }}
+          >
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+              <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                User
+              </Typography>
               <Typography
                 sx={{
-                  fontSize: '0.68rem',
-                  fontStyle: 'italic',
-                  color: 'rgba(255, 255, 255, 0.45)',
-                  lineHeight: 1.35
+                  fontSize: '0.72rem',
+                  color: '#FFFFFF',
+                  fontWeight: 600,
+                  textAlign: 'right'
                 }}
               >
-                Seeing this message in error? Contact your Admins to request access.
+                {userContext.userName}
               </Typography>
-            </>
-          );
-        } catch {
-          return null;
-        }
-      })()}
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+              <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                Org
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.72rem',
+                  color: '#FFFFFF',
+                  fontWeight: 600,
+                  textAlign: 'right'
+                }}
+              >
+                {userContext.orgName || 'Private Org'}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+              <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                Role(s)
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: '0.72rem',
+                  color: '#FFFFFF',
+                  fontWeight: 600,
+                  textAlign: 'right'
+                }}
+              >
+                {userContext.roleNames && userContext.roleNames.length > 0
+                  ? userContext.roleNames.join(', ')
+                  : 'None'}
+              </Typography>
+            </Box>
+          </Box>
+          <Typography
+            sx={{
+              fontSize: '0.68rem',
+              fontStyle: 'italic',
+              color: 'rgba(255, 255, 255, 0.45)',
+              lineHeight: 1.35
+            }}
+          >
+            Seeing this message in error? Contact your Admins to request access.
+          </Typography>
+        </>
+      )}
     </Box>
   );
 
@@ -539,3 +523,18 @@ export const createCanShow = (
     );
   };
 };
+
+// Re-export PermissionProvider types and hooks
+export {
+  PermissionProvider,
+  usePermission,
+  useHasPermission,
+  usePermissionUserContext
+} from './PermissionProvider';
+export type {
+  PermissionAction,
+  PermissionProviderValue,
+  PermissionUserContext,
+  PermissionProviderProps,
+  PermissionKey
+} from './PermissionProvider';

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,3 +1,5 @@
+import { Key } from '@meshery/schemas/permissions';
+export type { Key };
 import KeyIcon from '@mui/icons-material/Key';
 import LaunchIcon from '@mui/icons-material/Launch';
 import SecurityIcon from '@mui/icons-material/Security';
@@ -11,19 +13,6 @@ const DIVIDER_SX = {
   background: 'rgba(255, 255, 255, 0.1)',
   my: 1.25
 };
-
-export interface Key {
-  // Backwards compatibility for old CanShow
-  subject?: string;
-  action?: string;
-
-  // New Schemas key structure
-  id?: string;
-  category?: string;
-  subcategory?: string;
-  function?: string;
-  description?: string;
-}
 
 export type InvertAction = 'disable' | 'hide';
 
@@ -44,7 +33,7 @@ export type MissingCapabilityReason = {
 export type ReasonEvent = MissingPermissionReason | MissingCapabilityReason;
 
 export interface HasKeyProps<ReasonEvent> {
-  Key?: Key;
+  Key?: Key & { action?: string; subject?: string };
   predicate?: (capabilitiesRegistry: unknown) => [boolean, ReasonEvent];
   children: React.ReactNode;
   notifyOnclick?: boolean;
@@ -149,7 +138,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
             component="span"
             onClick={(e: React.MouseEvent) => {
               e.stopPropagation();
-              navigator.clipboard.writeText(permissionKey.id || permissionKey.action || '');
+              navigator.clipboard.writeText(permissionKey.id || '');
               setCopied(true);
               setTimeout(() => setCopied(false), 1500);
             }}
@@ -174,7 +163,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
             color: '#FFFFFF'
           }}
         >
-          {permissionKey.function || permissionKey.subject || 'Access Restricted'}
+          {permissionKey.function || 'Access Restricted'}
         </Typography>
       </Box>
 
@@ -189,7 +178,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
           }}
         >
           {permissionKey.description ||
-            `Allows you to perform the ${permissionKey.function || permissionKey.subject || 'selected'} operation.`}
+            `Allows you to perform the ${permissionKey.function || 'selected'} operation.`}
         </Typography>
       </Box>
 
@@ -282,21 +271,23 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
               mb: 0.75
             }}
           >
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
-              <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
-                User
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: '0.72rem',
-                  color: '#FFFFFF',
-                  fontWeight: 600,
-                  textAlign: 'right'
-                }}
-              >
-                {userContext.userName}
-              </Typography>
-            </Box>
+            {userContext.userName && (
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
+                  User
+                </Typography>
+                <Typography
+                  sx={{
+                    fontSize: '0.72rem',
+                    color: '#FFFFFF',
+                    fontWeight: 600,
+                    textAlign: 'right'
+                  }}
+                >
+                  {userContext.userName}
+                </Typography>
+              </Box>
+            )}
             <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
               <Typography sx={{ fontSize: '0.68rem', color: '#9E9E9E', fontWeight: 500 }}>
                 Org
@@ -535,6 +526,5 @@ export type {
   PermissionAction,
   PermissionProviderValue,
   PermissionUserContext,
-  PermissionProviderProps,
-  PermissionKey
+  PermissionProviderProps
 } from './PermissionProvider';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,7 +54,6 @@ export {
   usePermissionUserContext,
   type Key,
   type PermissionAction,
-  type PermissionKey,
   type PermissionProviderProps,
   type PermissionProviderValue,
   type PermissionShieldProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,7 +47,16 @@ export {
 } from './custom/UniversalFilter';
 
 export {
+  PermissionProvider,
   PermissionShield,
+  usePermission,
+  useHasPermission,
+  usePermissionUserContext,
   type Key,
-  type PermissionShieldProps
+  type PermissionAction,
+  type PermissionKey,
+  type PermissionProviderProps,
+  type PermissionProviderValue,
+  type PermissionShieldProps,
+  type PermissionUserContext
 } from './custom/permissions';


### PR DESCRIPTION
#### **Summary**
This PR implements a generic, CASL-agnostic `PermissionProvider` in Sistent and integrates it into Meshery UI. By moving permission checks into Sistent's base components and checking them declaratively via props, we decouple Sistent from direct CASL dependency and eliminate hardcoded `sessionStorage` lookups from within Sistent.

---

#### **Changes Made**

##### **Sistent Library (`/sistent`)**
1. **`PermissionProvider` (`src/custom/PermissionProvider.tsx`)**
   - Added a new CASL-agnostic context/hook wrapper. It accepts a generic `userHasPermission: (key: Key) => boolean` callback and optional `userContext` information.
2. **`PermissionShield` (`src/custom/permissions.tsx`)**
   - Removed direct dependency on `sessionStorage` (e.g., `sessionStorage.getItem('currentOrg')`). 
   - Now reads `userName`, `orgName`, and `roleNames` directly from `PermissionProvider`'s `userContext`.
3. **Base Components (`Button`, `IconButton`, `MenuItem`, `ListItem`, `ListItemButton`)**
   - Updated components to accept `permissionKey` (from `@meshery/schemas`) and `permissionAction: 'showShield' | 'hide'`.
   - The components automatically evaluate permissions via the provider hook and apply the appropriate action if the user lacks the permission (e.g., automatically rendering the `PermissionShield` tooltip overlay).

##### **[Meshery UI (`/meshery/ui`)](https://github.com/meshery/meshery/pull/20590)**
1. **`_app.tsx`**
   - Mounted the `PermissionProvider` at the root, passing down a CASL adapter (`ability.can`) and feeding `userContext` from the Redux store/queries.
2. **`Navigator.tsx` & `navigatorComponents.tsx`**
   - Converted Navigator item configurations to pass the canonical `Keys` directly.
   - Removed custom `CAN()` imports and calls inside `Navigator.tsx` in favor of declarative `permissionKey` and `permissionAction` props on `ListItemComponent`.

---

#### **Benefits**
- **Decoupled Architecture**: Sistent and its base components are now completely unaware of CASL. Transitioning away from CASL in the future will require changing only one function inside `_app.tsx`.
- **Cleaner Code**: Eliminates redundant `disabled={!CAN(...)}` logic and wrapper elements on the caller's side.
- **No Storage Leakage**: Removed direct dependencies on `sessionStorage` inside the UI library.



<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
