### PR TITLE
fix(UserInviteModal): guard null `deletedAt` in TeamSearchField renderOption

### DIFF
--- a/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
@@ -15,7 +15,7 @@ interface Team {
   name: string;
   deletedAt: {
     Valid: boolean;
-  };
+  } | null;
 }
 
 interface TeamSearchFieldProps {
@@ -156,7 +156,7 @@ const TeamSearchField: React.FC<TeamSearchFieldProps> = ({
           />
         )}
         renderOption={(props, option) => {
-          if (!option?.deletedAt.Valid) {
+          if (!option?.deletedAt?.Valid) {
             return (
               <Box
                 component="li"

--- a/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
@@ -13,7 +13,7 @@ interface Team {
   id: string;
   ID: string;
   name: string;
-  deletedAt: {
+  deletedAt?: {
     Valid: boolean;
   } | null;
 }
@@ -156,7 +156,7 @@ const TeamSearchField: React.FC<TeamSearchFieldProps> = ({
           />
         )}
         renderOption={(props, option) => {
-          if (!option?.deletedAt?.Valid) {
+          if (!option.deletedAt?.Valid) {
             return (
               <Box
                 component="li"


### PR DESCRIPTION
## Description

Fixes a runtime crash (`Cannot read properties of null (reading 'Valid')`) when selecting a team in the Invite User modal on the Meshery Cloud dashboard.

### Root Cause

The Go backend serializes `sql.NullTime` as `null` for non-deleted teams. `TeamSearchField`'s `renderOption` accessed `option?.deletedAt. Valid '; the optional chaining on `option` does **not** protect against `deletedAt` itself being `null`, causing the crash when any team in the dropdown is rendered.

### Changes

- **`TeamSearchField.tsx`**: Added optional chaining on `deletedAt` (`option?.deletedAt?.Valid`) in `renderOption`
- **`TeamSearchField.tsx`**: Updated the `Team` interface to type `deletedAt` as `{ Valid: boolean } | null` to match the actual API response shape

### Screenshots
##### Before 
<img width="938" height="806" alt="Screenshot 2026-07-14 at 9 25 23 AM" src="https://github.com/user-attachments/assets/19bc69fc-ad2f-4b32-a145-08fc2e8632d9" />


##### After


https://github.com/user-attachments/assets/6d5d1693-baea-4d54-831c-79450447170d


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
