### PR TITLE
fix(UserSearchField): fallback to username if email is absent

### DIFF
--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -13,6 +13,7 @@ interface User {
   firstName: string;
   lastName: string;
   email: string;
+  username?: string;
   avatarUrl?: string;
   deletedAt?: { Valid: boolean };
 }
@@ -87,7 +88,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
   };
 
   const filteredOptions = suggestions.filter(
-    (option: User) => !usersToShareWith.concat(usersData).find((u) => u.email === option.email)
+    (option: User) => !usersToShareWith.concat(usersData).find((u) => u.userId === option.userId)
   );
 
   const isShareDisabled = disabled || isSharing || usersToShareWith.length === 0;
@@ -129,7 +130,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           inputValue={inputValue}
           loading={searchUserLoading}
           value={usersToShareWith}
-          getOptionLabel={(user) => user.email}
+          getOptionLabel={(user) => user.email ?? user.username ?? ''}
           noOptionsText={
             searchUserLoading
               ? 'Loading...'
@@ -139,7 +140,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           }
           onChange={handleAdd}
           onInputChange={handleInputChange}
-          isOptionEqualToValue={(option, value) => option.email === value.email}
+          isOptionEqualToValue={(option, value) => option.userId === value.userId}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -184,11 +185,13 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
                     </Typography>
                   ) : (
                     <>
-                      <Typography variant="body2">
-                        {option.firstName} {option.lastName}
-                      </Typography>
+                      {(option.firstName || option.lastName) && (
+                        <Typography variant="body2">
+                          {option.firstName} {option.lastName}
+                        </Typography>
+                      )}
                       <Typography variant="body2" color="text.secondary">
-                        {option.email}
+                        {option.email ?? option.username}
                       </Typography>
                     </>
                   )}


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #


<img width="1280" height="683" alt="Screenshot 2026-07-15 at 7 00 29 PM" src="https://github.com/user-attachments/assets/aaeeec94-71ab-4fea-9be9-3130073b4446" />


**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
