### PR TITLE
[GettingStartedWidget] Fix Invite User widget crash on null deletedAt

### DIFF
--- a/src/__testing__/nullTime.test.ts
+++ b/src/__testing__/nullTime.test.ts
@@ -1,0 +1,46 @@
+import { getDeletedAtTime, isSoftDeleted } from '../utils/nullTime';
+
+describe('isSoftDeleted', () => {
+  it('treats null / undefined as NOT soft-deleted (canonical live-row shape)', () => {
+    expect(isSoftDeleted(null)).toBe(false);
+    expect(isSoftDeleted(undefined)).toBe(false);
+  });
+
+  it('does not throw on null (regression: Invite User widget crash)', () => {
+    // The original crash was `null is not an object (evaluating 't?.deletedAt.Valid')`.
+    expect(() => isSoftDeleted(null)).not.toThrow();
+  });
+
+  it('treats a non-empty timestamp string as soft-deleted (canonical deleted-row shape)', () => {
+    expect(isSoftDeleted('2026-07-14T20:33:05Z')).toBe(true);
+  });
+
+  it('treats an empty / whitespace string as NOT soft-deleted', () => {
+    expect(isSoftDeleted('')).toBe(false);
+    expect(isSoftDeleted('   ')).toBe(false);
+  });
+
+  it('honors the legacy Go sql.NullTime object shape', () => {
+    expect(isSoftDeleted({ Valid: true, Time: '2026-07-14T20:33:05Z' })).toBe(true);
+    expect(isSoftDeleted({ Valid: false, Time: '0001-01-01T00:00:00Z' })).toBe(false);
+    expect(isSoftDeleted({ Valid: false })).toBe(false);
+  });
+});
+
+describe('getDeletedAtTime', () => {
+  it('returns undefined when not soft-deleted', () => {
+    expect(getDeletedAtTime(null)).toBeUndefined();
+    expect(getDeletedAtTime(undefined)).toBeUndefined();
+    expect(getDeletedAtTime({ Valid: false, Time: '0001-01-01T00:00:00Z' })).toBeUndefined();
+  });
+
+  it('returns the string itself for the canonical deleted-row shape', () => {
+    expect(getDeletedAtTime('2026-07-14T20:33:05Z')).toBe('2026-07-14T20:33:05Z');
+  });
+
+  it('returns the .Time member for the legacy object shape', () => {
+    expect(getDeletedAtTime({ Valid: true, Time: '2026-07-14T20:33:05Z' })).toBe(
+      '2026-07-14T20:33:05Z'
+    );
+  });
+});

--- a/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/TeamSearchField.tsx
@@ -8,14 +8,13 @@ import React, { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'r
 import { Chip, CircularProgress, TextField, Tooltip } from '../../../base';
 import { iconSmall } from '../../../constants/iconsSizes';
 import { CloseIcon } from '../../../icons';
+import { DeletedAt, isSoftDeleted } from '../../../utils/nullTime';
 
 interface Team {
   id: string;
   ID: string;
   name: string;
-  deletedAt?: {
-    Valid: boolean;
-  } | null;
+  deletedAt?: DeletedAt;
 }
 
 interface TeamSearchFieldProps {
@@ -156,7 +155,7 @@ const TeamSearchField: React.FC<TeamSearchFieldProps> = ({
           />
         )}
         renderOption={(props, option) => {
-          if (!option.deletedAt?.Valid) {
+          if (!isSoftDeleted(option.deletedAt)) {
             return (
               <Box
                 component="li"

--- a/src/custom/TeamTable/TeamTableConfiguration.tsx
+++ b/src/custom/TeamTable/TeamTableConfiguration.tsx
@@ -211,7 +211,8 @@ export default function TeamTableConfiguration({
         sort: false,
         searchable: false,
         customBodyRender: (_: string, tableMeta: MUIDataTableMeta) => {
-          if (bulkSelect || isSoftDeleted(tableMeta.rowData[4])) {
+          // rowData index 6 is the `deletedAt` column (see colViews/columns order).
+          if (bulkSelect || isSoftDeleted(tableMeta.rowData[6])) {
             return (
               <TableIconsDisabledContainer>
                 <EditIcon
@@ -383,6 +384,7 @@ export default function TeamTableConfiguration({
         };
       }
 
+      // row index 6 is the `deletedAt` column (see colViews/columns order).
       if (isSoftDeleted(row[6])) {
         return {
           style: {

--- a/src/custom/TeamTable/TeamTableConfiguration.tsx
+++ b/src/custom/TeamTable/TeamTableConfiguration.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { DeleteIcon, EditIcon } from '../../icons';
 import LogoutIcon from '../../icons/Logout/LogOutIcon';
 import { CHARCOAL, useTheme } from '../../theme';
+import { isSoftDeleted } from '../../utils/nullTime';
 import { CustomTooltip } from '../CustomTooltip';
 import { FormatId } from '../FormatId';
 import { ConditionalTooltip } from '../Helpers/CondtionalTooltip';
@@ -210,7 +211,7 @@ export default function TeamTableConfiguration({
         sort: false,
         searchable: false,
         customBodyRender: (_: string, tableMeta: MUIDataTableMeta) => {
-          if (bulkSelect || tableMeta.rowData[4].Valid) {
+          if (bulkSelect || isSoftDeleted(tableMeta.rowData[4])) {
             return (
               <TableIconsDisabledContainer>
                 <EditIcon
@@ -367,7 +368,7 @@ export default function TeamTableConfiguration({
       }
     },
     isRowSelectable: (dataIndx: number) => {
-      if (teams[dataIndx]['deletedAt'].Valid === true) return false;
+      if (isSoftDeleted(teams[dataIndx]['deletedAt'])) return false;
       return true;
     },
     setRowProps: (row: any, rowIndex: number, tableState: any) => {
@@ -382,7 +383,7 @@ export default function TeamTableConfiguration({
         };
       }
 
-      if (row[6].Valid) {
+      if (isSoftDeleted(row[6])) {
         return {
           style: {
             backgroundColor: theme.palette.icon.disabled

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -6,6 +6,7 @@ import { useDebounce } from 'use-debounce';
 import { Avatar, Box, Chip, Grid2, TextField, Typography } from '../../base';
 import { PersonIcon } from '../../icons/Person';
 import { useTheme } from '../../theme';
+import { DeletedAt, isSoftDeleted } from '../../utils/nullTime';
 
 interface User {
   id: string;
@@ -14,7 +15,7 @@ interface User {
   lastName: string;
   email: string;
   avatarUrl?: string;
-  deletedAt?: { Valid: boolean };
+  deletedAt?: DeletedAt;
 }
 
 interface UserSearchFieldProps {
@@ -178,7 +179,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
                   </Box>
                 </Grid2>
                 <Grid2 size="grow">
-                  {option.deletedAt?.Valid ? (
+                  {isSoftDeleted(option.deletedAt) ? (
                     <Typography variant="body2" color="text.secondary">
                       {option.email} (deleted)
                     </Typography>

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -16,6 +16,7 @@ import {
 
 import { iconSmall } from '../../constants/iconsSizes';
 import { CloseIcon, PersonIcon } from '../../icons';
+import { DeletedAt, isSoftDeleted } from '../../utils/nullTime';
 
 interface User {
   userId: string;
@@ -23,7 +24,7 @@ interface User {
   lastName: string;
   email: string;
   avatarUrl?: string;
-  deletedAt?: { Valid: boolean };
+  deletedAt?: DeletedAt;
   deleted?: boolean;
 }
 
@@ -110,7 +111,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
       if (!value) return;
 
       const isDuplicate = localUsersData.some((user) => user.userId === value.userId);
-      const isDeleted = value.deletedAt?.Valid === true;
+      const isDeleted = isSoftDeleted(value.deletedAt);
 
       if (isDuplicate || isDeleted) {
         setError(isDuplicate ? 'User already selected' : 'User does not exist');

--- a/src/custom/UsersTable/UsersTable.tsx
+++ b/src/custom/UsersTable/UsersTable.tsx
@@ -8,6 +8,7 @@ import Github from '../../icons/Github/GithubIcon';
 import Google from '../../icons/Google/GoogleIcon';
 import LogoutIcon from '../../icons/Logout/LogOutIcon';
 import { CHARCOAL, SistentThemeProviderWithoutBaseLine } from '../../theme';
+import { isSoftDeleted } from '../../utils/nullTime';
 import { useWindowDimensions } from '../Helpers/Dimension';
 import {
   ColView,
@@ -443,7 +444,7 @@ const UsersTable: React.FC<UsersTableProps> = ({
         sort: false,
         searchable: false,
         customBodyRender: (_: string, tableMeta: MUIDataTableMeta) =>
-          getValidColumnValue(tableMeta.rowData, 'deletedAt', columns).Valid !== false ? (
+          isSoftDeleted(getValidColumnValue(tableMeta.rowData, 'deletedAt', columns)) ? (
             <TableIconsDisabledContainer>
               <EditIcon
                 style={{

--- a/src/custom/Workspaces/WorkspaceCard.tsx
+++ b/src/custom/Workspaces/WorkspaceCard.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@mui/material';
 import { Backdrop, CircularProgress, Grid2 } from '../../base';
 
-import { getRelativeTime } from '../../utils';
+import { DeletedAt, getRelativeTime, isSoftDeleted } from '../../utils';
 import { FlipCard } from '../FlipCard';
 import { RecordRow, RedirectButton, TransferButton } from './WorkspaceTransferButton';
 import {
@@ -30,7 +30,7 @@ interface WorkspaceDetails {
   id: number;
   name: string;
   description: string;
-  deletedAt: { Valid: boolean };
+  deletedAt: DeletedAt;
   updatedAt: string;
   createdAt: string;
 }
@@ -162,7 +162,7 @@ const WorkspaceCard = ({
   isEnvironmentsVisible,
   isTeamsVisible
 }: WorkspaceCardProps) => {
-  const deleted = workspaceDetails.deletedAt.Valid;
+  const deleted = isSoftDeleted(workspaceDetails.deletedAt);
   return (
     <FlipCard
       disableFlip={selectedWorkspaces.includes(workspaceDetails.id) ? true : false}

--- a/src/custom/Workspaces/helper.ts
+++ b/src/custom/Workspaces/helper.ts
@@ -1,4 +1,4 @@
-import { getFormatDate } from '../../utils';
+import { DeletedAt, getDeletedAtTime, getFormatDate } from '../../utils';
 
 /**
  * Helper function to parse and format the value of a field representing a deletion timestamp in the provided data object.
@@ -7,14 +7,9 @@ import { getFormatDate } from '../../utils';
  */
 
 export const DEFAULT_DATE = 'N/A'; // a constant to represent the default date value
-export const parseDeletionTimestamp = (data: {
-  deletedAt: { Valid: boolean; Time: string | number | Date };
-}) => {
-  if (data && data.deletedAt && data.deletedAt.Valid === true) {
-    return getFormatDate(data.deletedAt.Time as string);
-  } else {
-    return DEFAULT_DATE;
-  }
+export const parseDeletionTimestamp = (data: { deletedAt: DeletedAt }) => {
+  const time = getDeletedAtTime(data?.deletedAt);
+  return time != null ? getFormatDate(time as string) : DEFAULT_DATE;
 };
 
 /**

--- a/src/custom/Workspaces/helper.ts
+++ b/src/custom/Workspaces/helper.ts
@@ -9,7 +9,7 @@ import { DeletedAt, getDeletedAtTime, getFormatDate } from '../../utils';
 export const DEFAULT_DATE = 'N/A'; // a constant to represent the default date value
 export const parseDeletionTimestamp = (data: { deletedAt: DeletedAt }) => {
   const time = getDeletedAtTime(data?.deletedAt);
-  return time != null ? getFormatDate(time as string) : DEFAULT_DATE;
+  return time != null ? getFormatDate(time) : DEFAULT_DATE;
 };
 
 /**

--- a/src/custom/Workspaces/types.ts
+++ b/src/custom/Workspaces/types.ts
@@ -1,3 +1,5 @@
+import { DeletedAt } from '../../utils/nullTime';
+
 export interface AssignmentHookResult<T> {
   data: T[];
   workspaceData: T[];
@@ -22,9 +24,7 @@ export interface Workspace {
   metadata?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
-  deletedAt: {
-    Valid: boolean;
-  };
+  deletedAt: DeletedAt;
 }
 
 export interface Environment {
@@ -45,7 +45,5 @@ export interface Team {
   // (currently aliased to `Team.name`; flipping here without the server rename
   // would break the wire contract). Deferred from Phase 2.K cascade.
   team_name: string;
-  deletedAt: {
-    Valid: boolean;
-  };
+  deletedAt: DeletedAt;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './components';
+export * from './nullTime';
 export * from './time.utils';

--- a/src/utils/nullTime.ts
+++ b/src/utils/nullTime.ts
@@ -1,0 +1,56 @@
+/**
+ * Utilities for the soft-delete timestamp (`deletedAt`) that Meshery/Layer5
+ * APIs attach to soft-deletable entities (teams, users, workspaces, ...).
+ *
+ * The value arrives in more than one shape depending on which endpoint and
+ * serializer produced it:
+ *
+ *  - `null` / `undefined` — the entity is NOT soft-deleted. This is the
+ *    canonical `meshery/schemas` wire shape: `core.NullTime` marshals a live
+ *    row to JSON `null`.
+ *  - an ISO-8601 timestamp `string` — the entity IS soft-deleted; the string
+ *    is the deletion time. This is the canonical schema shape for a deleted
+ *    row (`type: string, format: date-time`).
+ *  - a `{ Valid: boolean; Time?: ... }` object — the legacy Go `sql.NullTime`
+ *    JSON shape still emitted by some provider endpoints. Deleted iff `Valid`.
+ *
+ * Reading `.Valid` directly is unsafe: when `deletedAt` is `null` the access
+ * throws `null is not an object (evaluating '…deletedAt.Valid')` — the crash
+ * that took down the Invite User widget's team search. Route every soft-delete
+ * check through these helpers so no shape can crash the UI.
+ */
+
+/** The legacy Go `sql.NullTime` JSON shape. */
+export interface SqlNullTime {
+  Valid: boolean;
+  Time?: string | number | Date | null;
+}
+
+/** Every shape a `deletedAt` value may take on the wire. */
+export type DeletedAt = string | SqlNullTime | null | undefined;
+
+/**
+ * Returns `true` when a `deletedAt` value indicates the entity has been
+ * soft-deleted, tolerating every shape the value may take (null/undefined,
+ * timestamp string, or legacy `{ Valid, Time }` object).
+ */
+export const isSoftDeleted = (deletedAt: DeletedAt): boolean => {
+  if (deletedAt === null || deletedAt === undefined) return false;
+  if (typeof deletedAt === 'string') return deletedAt.trim().length > 0;
+  if (typeof deletedAt === 'object') return deletedAt.Valid === true;
+  return false;
+};
+
+/**
+ * Returns the deletion timestamp suitable for a date formatter when the entity
+ * is soft-deleted, otherwise `undefined`. Handles both the timestamp-string and
+ * legacy `{ Valid, Time }` object shapes.
+ */
+export const getDeletedAtTime = (deletedAt: DeletedAt): string | number | Date | undefined => {
+  if (!isSoftDeleted(deletedAt)) return undefined;
+  if (typeof deletedAt === 'string') return deletedAt;
+  if (deletedAt && typeof deletedAt === 'object') {
+    return deletedAt.Time ?? undefined;
+  }
+  return undefined;
+};

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,4 +1,5 @@
 import { VISIBILITY } from '../constants/constants';
+import { DeletedAt } from './nullTime';
 
 export interface User {
   id: string;
@@ -7,7 +8,7 @@ export interface User {
   lastName: string;
   email: string;
   avatarUrl?: string;
-  deletedAt?: { Valid: boolean };
+  deletedAt?: DeletedAt;
   roleNames?: string[];
 }
 

--- a/src/utils/time.utils.tsx
+++ b/src/utils/time.utils.tsx
@@ -24,7 +24,7 @@ export const getFullFormattedTime = (date: string): string => {
  * @param {string} date - ISO format date string
  * @returns {string} Formatted date in "Month Day, Year" format (e.g. "Jan 1, 2025")
  */
-export const getFormatDate = (date: string) => {
+export const getFormatDate = (date: string | number | Date) => {
   const options = { year: 'numeric' as const, month: 'short' as const, day: 'numeric' as const };
   const formattedDate = new Date(date).toLocaleDateString('en-US', options);
   return formattedDate;


### PR DESCRIPTION
**Notes for Reviewers**

The Invite User widget's team search crashed in production with:

```
Error: null is not an object (evaluating 't?.deletedAt.Valid')
```

**Root cause.** `TeamSearchField.renderOption` (and several sibling components) read `.Valid` directly off `deletedAt`. A soft-delete timestamp reaches the UI in three different shapes depending on the endpoint and serializer:

- `null` / `undefined` — the canonical `meshery/schemas` wire shape for a **live** row (`core.NullTime` marshals a non-deleted row to JSON `null`). This is what the teams API returns, so `null.Valid` threw.
- an ISO-8601 timestamp **string** — the canonical shape for a **deleted** row (`type: string, format: date-time`).
- a legacy Go `sql.NullTime` `{ Valid, Time }` **object** — still emitted by some provider endpoints.

Reading `.Valid` directly is unsafe for the first two shapes, and semantically wrong against the canonical contract (where `.Valid` never exists).

**Fix (at the root, in the shared library).** Add `isSoftDeleted` and `getDeletedAtTime` helpers plus a shared `DeletedAt` union type in `src/utils/nullTime.ts`, and route every soft-delete check through them. This mirrors the multi-shape helper meshery-cloud already maintains (`ui/utility/deletedAt.ts`). Components updated:

- `DashboardWidgets/GettingStartedWidget/TeamSearchField` (the Invite User widget — the reported crash)
- `UserSearchField`, `UserSearchFieldInput`
- `Workspaces/WorkspaceCard`, `Workspaces/helper` (`parseDeletionTimestamp`)
- `TeamTable/TeamTableConfiguration`, `UsersTable`

Several of these (`WorkspaceCard`, `TeamTableConfiguration`, `UsersTable`) read `.Valid` with no guard at all and shared the identical latent crash.

**Tests.** New `src/__testing__/nullTime.test.ts` covers every shape, including the `null` regression. Full suite: 349 passing. `npm run build` and `eslint` clean.

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.
