### PR TITLE
fix(share): align user identity and display with the v1beta3 user construct

### DIFF
--- a/src/__testing__/UserSearchFieldInput.test.tsx
+++ b/src/__testing__/UserSearchFieldInput.test.tsx
@@ -116,6 +116,39 @@ describe('UserSearchField v1beta3 user records', () => {
     });
   });
 
+  it('removes only the targeted record when selected users carry no identifier', () => {
+    // Email-only invitees all collapse onto the '' identifier, so filtering
+    // by identifier string deleted every one of them at once. Deletion must
+    // match the record itself (isSameUser, then reference equality).
+    const inviteeOne = { email: 'one@example.com' };
+    const inviteeTwo = { email: 'two@example.com' };
+    const { props, container } = renderField({ usersData: [inviteeOne, inviteeTwo] });
+
+    fireEvent.click(screen.getByText('(+1)'));
+
+    const deleteIcons = container.querySelectorAll('.MuiChip-deleteIcon');
+    expect(deleteIcons).toHaveLength(2);
+    fireEvent.click(deleteIcons[0]);
+
+    expect(props.setUsersData).toHaveBeenCalledWith([inviteeTwo]);
+  });
+
+  it('removes records carrying neither identifier nor email by reference', () => {
+    // isSameUser never matches two records with nothing to compare; reference
+    // equality is the last resort that keeps such rows deletable.
+    const ghost = { username: 'ghost' };
+    const other = { username: 'other' };
+    const { props, container } = renderField({ usersData: [ghost, other] });
+
+    fireEvent.click(screen.getByText('(+1)'));
+
+    const deleteIcons = container.querySelectorAll('.MuiChip-deleteIcon');
+    expect(deleteIcons).toHaveLength(2);
+    fireEvent.click(deleteIcons[0]);
+
+    expect(props.setUsersData).toHaveBeenCalledWith([other]);
+  });
+
   it('keeps MUI-generated option ids so aria-activedescendant resolves', async () => {
     // renderOption must spread the Autocomplete-provided props untouched:
     // overriding the option `id` with the user identifier orphans the

--- a/src/__testing__/UserSearchFieldInput.test.tsx
+++ b/src/__testing__/UserSearchFieldInput.test.tsx
@@ -66,3 +66,33 @@ describe('UserSearchField type-ahead wiring', () => {
     expect(screen.queryByText('Jane Doe')).not.toBeNull();
   });
 });
+
+describe('UserSearchField v1beta3 user records', () => {
+  // The v1beta3 user construct identifies users by `id` (the wire `userId` is
+  // a deprecated alias) and reduced projections may carry only a username.
+  const v1beta3Alex = {
+    id: 'u-alex',
+    username: 'alex',
+    firstName: 'Alex',
+    lastName: 'Rivera',
+    email: 'alex@example.com'
+  };
+  const usernameOnly = { id: 'u-min', username: 'minimal-user' };
+
+  it('renders and matches records that carry only the canonical id', async () => {
+    const { input } = renderField({
+      usersSearch: 'a',
+      searchedUsers: [v1beta3Alex, usernameOnly],
+      // same person as v1beta3Alex, but shaped like a legacy record
+      currentUserData: { userId: 'u-alex' }
+    });
+
+    fireEvent.change(input, { target: { value: 'a' } });
+
+    // current user is filtered out via id<->userId identity matching
+    await waitFor(() => {
+      expect(screen.queryByText('minimal-user')).not.toBeNull();
+    });
+    expect(screen.queryByText('Alex Rivera')).toBeNull();
+  });
+});

--- a/src/__testing__/UserSearchFieldInput.test.tsx
+++ b/src/__testing__/UserSearchFieldInput.test.tsx
@@ -95,4 +95,47 @@ describe('UserSearchField v1beta3 user records', () => {
     });
     expect(screen.queryByText('Alex Rivera')).toBeNull();
   });
+
+  it('renders soft-deleted v1beta3 records (deletedAt) as deleted options', async () => {
+    // v1beta3 signals soft deletion via `deletedAt`, not the component-local
+    // `deleted` boolean; both must render the "(deleted)" treatment.
+    const deletedByTimestamp = {
+      id: 'u-gone',
+      email: 'gone@example.com',
+      deletedAt: '2026-01-01T00:00:00Z'
+    };
+    const { input } = renderField({
+      usersSearch: 'gone',
+      searchedUsers: [deletedByTimestamp]
+    });
+
+    fireEvent.change(input, { target: { value: 'gone' } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('gone@example.com (deleted)')).not.toBeNull();
+    });
+  });
+
+  it('keeps MUI-generated option ids so aria-activedescendant resolves', async () => {
+    // renderOption must spread the Autocomplete-provided props untouched:
+    // overriding the option `id` with the user identifier orphans the
+    // input's aria-activedescendant reference and breaks keyboard focus.
+    const { input } = renderField({
+      usersSearch: 'a',
+      searchedUsers: [v1beta3Alex, usernameOnly]
+    });
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => {
+      expect(screen.getAllByRole('option').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const activeDescendant = input.getAttribute('aria-activedescendant');
+    expect(activeDescendant).toBeTruthy();
+    const highlighted = document.getElementById(activeDescendant as string);
+    expect(highlighted).not.toBeNull();
+    expect(highlighted?.getAttribute('role')).toBe('option');
+  });
 });

--- a/src/__testing__/UserShareSearch.test.tsx
+++ b/src/__testing__/UserShareSearch.test.tsx
@@ -87,6 +87,23 @@ describe('UserShareSearch with v1beta3 user records', () => {
     );
   });
 
+  it('leaves the search field usable before any user is selected', () => {
+    // Only the Share button is gated on having a selection. Rendering the
+    // search field as disabled while it still accepts input tells the user
+    // the picker is unavailable when it is the only way to make a selection.
+    const { input } = renderSearch();
+
+    expect(input.disabled).toBe(false);
+    expect(input.closest('.MuiOutlinedInput-root')?.className).not.toContain('Mui-disabled');
+    expect((screen.getByRole('button', { name: 'Share' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables the search field when the consumer disables the picker', () => {
+    const { input } = renderSearch({ disabled: true });
+
+    expect(input.disabled).toBe(true);
+  });
+
   it('does not resurface users that already have access', async () => {
     // Existing access list arrives as canonical v1beta3 records (id, no
     // userId); the suggestion list must recognize them as the same user.

--- a/src/__testing__/UserShareSearch.test.tsx
+++ b/src/__testing__/UserShareSearch.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import UserShareSearch from '../custom/UserSearchField/UserSearchField';
+import { SistentThemeProvider } from '../theme';
+
+// Regression guard for the Share Design people-picker against the v1beta3
+// user construct. The searchable collaboration projection identifies users by
+// `id` (the wire `userId` is a deprecated alias that newer providers omit)
+// and may omit names/email on reduced projections. The picker must:
+//   - display first/last name and email for searchable-projection rows
+//   - fall back to username when a reduced projection omits names/email
+//   - key selection/identity on `id`, not on the retired `userId`
+
+type SearchProps = React.ComponentProps<typeof UserShareSearch>;
+
+const v1beta3Jane = {
+  id: 'b6e6d123-0000-4000-8000-000000000001',
+  username: 'jdoe',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com'
+};
+
+const publicOnlyUser = {
+  id: 'b6e6d123-0000-4000-8000-000000000003',
+  username: 'publico'
+};
+
+const makeUseGetAllUsersQuery =
+  (users: unknown[]) => (_args: unknown, options?: { skip?: boolean }) => ({
+    data: options?.skip ? undefined : { data: users },
+    isLoading: false
+  });
+
+const renderSearch = (overrides: Partial<SearchProps> = {}) => {
+  const props: SearchProps = {
+    usersData: [],
+    shareWithNewUsers: jest.fn().mockResolvedValue({ error: '' }),
+    useGetAllUsersQuery: makeUseGetAllUsersQuery([v1beta3Jane, publicOnlyUser]),
+    ...overrides
+  };
+  const utils = render(
+    <SistentThemeProvider>
+      <UserShareSearch {...props} />
+    </SistentThemeProvider>
+  );
+  const input = screen.getByRole('combobox') as HTMLInputElement;
+  return { props, input, ...utils };
+};
+
+const typeSearch = async (input: HTMLInputElement, value: string) => {
+  fireEvent.change(input, { target: { value } });
+  // the query is debounced by 300ms
+  await waitFor(() => expect(screen.queryByText('jane@example.com')).not.toBeNull(), {
+    timeout: 2000
+  });
+};
+
+describe('UserShareSearch with v1beta3 user records', () => {
+  it('displays name and email for searchable-projection rows', async () => {
+    const { input } = renderSearch();
+
+    await typeSearch(input, 'jane');
+
+    expect(screen.queryByText('Jane Doe')).not.toBeNull();
+    expect(screen.queryByText('jane@example.com')).not.toBeNull();
+  });
+
+  it('falls back to username for rows from reduced projections', async () => {
+    const { input } = renderSearch();
+
+    await typeSearch(input, 'p');
+
+    expect(screen.queryByText('publico')).not.toBeNull();
+  });
+
+  it('selects and shares by canonical id when the wire userId is absent', async () => {
+    const { props, input } = renderSearch();
+
+    await typeSearch(input, 'jane');
+    fireEvent.click(screen.getByText('Jane Doe'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() =>
+      expect(props.shareWithNewUsers).toHaveBeenCalledWith([expect.objectContaining(v1beta3Jane)])
+    );
+  });
+
+  it('does not resurface users that already have access', async () => {
+    // Existing access list arrives as canonical v1beta3 records (id, no
+    // userId); the suggestion list must recognize them as the same user.
+    const { input } = renderSearch({
+      usersData: [{ id: v1beta3Jane.id, email: v1beta3Jane.email }]
+    });
+
+    fireEvent.change(input, { target: { value: 'jane' } });
+
+    await waitFor(() => expect(screen.queryByText('publico')).not.toBeNull(), { timeout: 2000 });
+    expect(screen.queryByText('Jane Doe')).toBeNull();
+  });
+});

--- a/src/__testing__/permissions.test.ts
+++ b/src/__testing__/permissions.test.ts
@@ -1,0 +1,45 @@
+import { canShareResourceWithNewUsers, canUpdateResource } from '../utils/permissions';
+
+// The permission checks accept nullish users by contract: consumers call them
+// during auth-state transitions (initial load, logout) when currentUser or the
+// owner record is not yet available. No user means no permission.
+
+const privateResource = { visibility: 'private' };
+const publicResource = { visibility: 'public' };
+
+describe('canUpdateResource', () => {
+  it('grants the resource owner, matching canonical id against the deprecated alias', () => {
+    expect(canUpdateResource(privateResource, { id: 'u-1' }, { userId: 'u-1' })).toBe(true);
+  });
+
+  it('grants admins even when they do not own the resource', () => {
+    expect(
+      canUpdateResource(privateResource, { id: 'u-2', roleNames: ['admin'] }, { id: 'u-1' })
+    ).toBe(true);
+  });
+
+  it('denies non-owner non-admin users', () => {
+    expect(canUpdateResource(privateResource, { id: 'u-2' }, { id: 'u-1' })).toBe(false);
+  });
+
+  it('denies when currentUser is nullish (auth-state transitions)', () => {
+    expect(canUpdateResource(privateResource, null, { id: 'u-1' })).toBe(false);
+    expect(canUpdateResource(privateResource, undefined, { id: 'u-1' })).toBe(false);
+  });
+
+  it('never treats an identifier-less owner as matching an identifier-less user', () => {
+    expect(canUpdateResource(privateResource, {}, null)).toBe(false);
+    expect(canUpdateResource(privateResource, {}, {})).toBe(false);
+  });
+});
+
+describe('canShareResourceWithNewUsers', () => {
+  it('always allows sharing public resources', () => {
+    expect(canShareResourceWithNewUsers(publicResource, null, null)).toBe(true);
+  });
+
+  it('falls back to the update permission for private resources', () => {
+    expect(canShareResourceWithNewUsers(privateResource, { id: 'u-1' }, { id: 'u-1' })).toBe(true);
+    expect(canShareResourceWithNewUsers(privateResource, null, { id: 'u-1' })).toBe(false);
+  });
+});

--- a/src/__testing__/permissions.test.ts
+++ b/src/__testing__/permissions.test.ts
@@ -31,6 +31,11 @@ describe('canUpdateResource', () => {
     expect(canUpdateResource(privateResource, {}, null)).toBe(false);
     expect(canUpdateResource(privateResource, {}, {})).toBe(false);
   });
+
+  it('denies when the resource is nullish, even for admins', () => {
+    expect(canUpdateResource(null, { id: 'u-1', roleNames: ['admin'] }, { id: 'u-1' })).toBe(false);
+    expect(canUpdateResource(undefined, { id: 'u-1' }, { id: 'u-1' })).toBe(false);
+  });
 });
 
 describe('canShareResourceWithNewUsers', () => {
@@ -41,5 +46,10 @@ describe('canShareResourceWithNewUsers', () => {
   it('falls back to the update permission for private resources', () => {
     expect(canShareResourceWithNewUsers(privateResource, { id: 'u-1' }, { id: 'u-1' })).toBe(true);
     expect(canShareResourceWithNewUsers(privateResource, null, { id: 'u-1' })).toBe(false);
+  });
+
+  it('denies when the resource is nullish', () => {
+    expect(canShareResourceWithNewUsers(null, { id: 'u-1' }, { id: 'u-1' })).toBe(false);
+    expect(canShareResourceWithNewUsers(undefined, { id: 'u-1' }, { id: 'u-1' })).toBe(false);
   });
 });

--- a/src/__testing__/userIdentity.test.ts
+++ b/src/__testing__/userIdentity.test.ts
@@ -2,6 +2,7 @@ import {
   getUserContactLabel,
   getUserDisplayName,
   getUserIdentifier,
+  getUserLabel,
   isSameUser
 } from '../utils/user';
 
@@ -84,6 +85,21 @@ describe('getUserContactLabel', () => {
 
   it('returns an empty string when neither is present', () => {
     expect(getUserContactLabel({})).toBe('');
+  });
+});
+
+describe('getUserLabel', () => {
+  it('prefers the contact label', () => {
+    expect(getUserLabel(v1beta3SearchableUser)).toBe('jane@example.com');
+  });
+
+  it('falls back to the display name, then the raw identifier', () => {
+    expect(getUserLabel({ id: 'u-1', firstName: 'Jane' })).toBe('Jane');
+    expect(getUserLabel({ id: 'u-1' })).toBe('u-1');
+  });
+
+  it('yields an empty string only for records with no identifier at all', () => {
+    expect(getUserLabel({})).toBe('');
   });
 });
 

--- a/src/__testing__/userIdentity.test.ts
+++ b/src/__testing__/userIdentity.test.ts
@@ -104,6 +104,11 @@ describe('getUserLabel', () => {
 });
 
 describe('isSameUser', () => {
+  it('matches the same object reference even with no comparable fields', () => {
+    const bare = {};
+    expect(isSameUser(bare, bare)).toBe(true);
+  });
+
   it('matches canonical id against the deprecated userId alias', () => {
     expect(isSameUser({ id: 'same' }, { userId: 'same' })).toBe(true);
   });
@@ -118,7 +123,7 @@ describe('isSameUser', () => {
     expect(isSameUser({ email: 'x@example.com' }, { id: 'a', email: 'x@example.com' })).toBe(true);
   });
 
-  it('never matches records with nothing to compare', () => {
+  it('never matches distinct records with nothing to compare', () => {
     expect(isSameUser({}, {})).toBe(false);
     expect(isSameUser({ email: '' }, { email: '' })).toBe(false);
     expect(isSameUser(null, { id: 'a' })).toBe(false);

--- a/src/__testing__/userIdentity.test.ts
+++ b/src/__testing__/userIdentity.test.ts
@@ -1,0 +1,110 @@
+import {
+  getUserContactLabel,
+  getUserDisplayName,
+  getUserIdentifier,
+  isSameUser
+} from '../utils/user';
+
+// The v1beta3 user construct retired the wire `userId` (canonical identifier
+// is `id`) and the hardened cloud endpoints serve reduced projections: the
+// searchable collaboration projection carries names+email, the public
+// directory only username+avatar. These helpers are the single place where
+// display and identity logic absorbs those wire shapes.
+
+const v1beta3SearchableUser = {
+  id: 'b6e6d123-0000-4000-8000-000000000001',
+  username: 'jdoe',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  email: 'jane@example.com',
+  avatarUrl: 'https://example.com/a.png'
+};
+
+const legacyUser = {
+  userId: 'legacy-0000-4000-8000-000000000002',
+  firstName: 'Lee',
+  lastName: 'Smith',
+  email: 'lee@example.com'
+};
+
+const publicDirectoryUser = {
+  id: 'b6e6d123-0000-4000-8000-000000000003',
+  username: 'publico',
+  avatarUrl: 'https://example.com/p.png'
+};
+
+describe('getUserIdentifier', () => {
+  it('prefers the canonical v1beta3 id', () => {
+    expect(getUserIdentifier({ id: 'abc', userId: 'legacy' })).toBe('abc');
+  });
+
+  it('falls back to the deprecated userId alias for pre-cutover records', () => {
+    expect(getUserIdentifier(legacyUser)).toBe('legacy-0000-4000-8000-000000000002');
+  });
+
+  it('returns an empty string when no identifier is present', () => {
+    expect(getUserIdentifier({})).toBe('');
+    expect(getUserIdentifier(null)).toBe('');
+    expect(getUserIdentifier(undefined)).toBe('');
+  });
+});
+
+describe('getUserDisplayName', () => {
+  it('joins first and last name when the projection carries them', () => {
+    expect(getUserDisplayName(v1beta3SearchableUser)).toBe('Jane Doe');
+  });
+
+  it('handles a single name part without stray whitespace', () => {
+    expect(getUserDisplayName({ firstName: 'Jane' })).toBe('Jane');
+    expect(getUserDisplayName({ lastName: 'Doe' })).toBe('Doe');
+  });
+
+  it('falls back to username for reduced projections', () => {
+    expect(getUserDisplayName(publicDirectoryUser)).toBe('publico');
+  });
+
+  it('falls back to email when neither names nor username are present', () => {
+    expect(getUserDisplayName({ email: 'only@example.com' })).toBe('only@example.com');
+  });
+
+  it('returns an empty string for empty records', () => {
+    expect(getUserDisplayName({})).toBe('');
+    expect(getUserDisplayName(null)).toBe('');
+  });
+});
+
+describe('getUserContactLabel', () => {
+  it('prefers email', () => {
+    expect(getUserContactLabel(v1beta3SearchableUser)).toBe('jane@example.com');
+  });
+
+  it('falls back to username when email is not served', () => {
+    expect(getUserContactLabel(publicDirectoryUser)).toBe('publico');
+  });
+
+  it('returns an empty string when neither is present', () => {
+    expect(getUserContactLabel({})).toBe('');
+  });
+});
+
+describe('isSameUser', () => {
+  it('matches canonical id against the deprecated userId alias', () => {
+    expect(isSameUser({ id: 'same' }, { userId: 'same' })).toBe(true);
+  });
+
+  it('does not match different identifiers even when emails collide', () => {
+    expect(
+      isSameUser({ id: 'a', email: 'shared@example.com' }, { id: 'b', email: 'shared@example.com' })
+    ).toBe(false);
+  });
+
+  it('falls back to email when either record has no identifier', () => {
+    expect(isSameUser({ email: 'x@example.com' }, { id: 'a', email: 'x@example.com' })).toBe(true);
+  });
+
+  it('never matches records with nothing to compare', () => {
+    expect(isSameUser({}, {})).toBe(false);
+    expect(isSameUser({ email: '' }, { email: '' })).toBe(false);
+    expect(isSameUser(null, { id: 'a' })).toBe(false);
+  });
+});

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -250,6 +250,17 @@ const ShareModal: React.FC<ShareModalProps> = ({
   const resourceType = dataName === 'design' ? 'pattern' : dataName;
 
   const handleShareWithNewUsers = async (newUsers: User[]) => {
+    // Fail fast on records without a usable identifier: an empty actor_id
+    // would produce an invalid grant_access payload and a confusing
+    // partial-share result.
+    if (newUsers.some((user) => !getUserIdentifier(user))) {
+      notify({
+        message: `Unable to share ${dataName}: a selected user record is missing its identifier`,
+        event_type: 'error'
+      });
+      return { error: 'missing user identifier' };
+    }
+
     const grantAccessList = newUsers.map((user) => ({
       actor_id: getUserIdentifier(user),
       actor_type: 'user'
@@ -320,6 +331,16 @@ const ShareModal: React.FC<ShareModalProps> = ({
   };
 
   const handleRevokeAccess = async (revokedUsers: User[]) => {
+    // Same guard as sharing: never issue a revoke_access entry with an
+    // empty actor_id.
+    if (revokedUsers.some((user) => !getUserIdentifier(user))) {
+      notify({
+        message: `Unable to revoke access to ${dataName}: the user record is missing its identifier`,
+        event_type: 'error'
+      });
+      return { error: 'missing user identifier' };
+    }
+
     const revokeAccessList = revokedUsers.map((user) => ({
       actor_id: getUserIdentifier(user),
       actor_type: 'user'

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -220,8 +220,12 @@ const ShareModal: React.FC<ShareModalProps> = ({
   const theme = useTheme();
   const [openMenu, setMenu] = useState<boolean>(false);
   const [shareUserData, setShareUserData] = useState<User[]>([]);
+  // `?? ''` keeps the visibility Select controlled even when a broken
+  // caller passes a nullish or empty resource selection.
   const [resourceVisibility, setVisibility] = useState(
-    Array.isArray(selectedResource) ? selectedResource[0]?.visibility : selectedResource?.visibility
+    (Array.isArray(selectedResource)
+      ? selectedResource[0]?.visibility
+      : selectedResource?.visibility) ?? ''
   );
   const [isUpdatingVisibility, setUpdatingVisibility] = useState(false);
 

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -229,6 +229,13 @@ const ShareModal: React.FC<ShareModalProps> = ({
   );
   const [isUpdatingVisibility, setUpdatingVisibility] = useState(false);
 
+  // The prop type requires a resource, but this is a published component with
+  // untyped consumers; the access handlers read `.id` off it, so a nullish or
+  // empty selection has to be caught before it reaches a payload.
+  const hasSelectedResource = Array.isArray(selectedResource)
+    ? selectedResource.length > 0
+    : Boolean(selectedResource);
+
   const userCanUpdateVisibility = Array.isArray(selectedResource)
     ? selectedResource.every((resource) =>
         canUpdateResourceVisibility(resource, currentUser, ownerData)
@@ -252,6 +259,14 @@ const ShareModal: React.FC<ShareModalProps> = ({
   const resourceType = dataName === 'design' ? 'pattern' : dataName;
 
   const handleShareWithNewUsers = async (newUsers: User[]) => {
+    if (!hasSelectedResource) {
+      notify({
+        message: `Unable to share ${dataName}: no ${dataName} is selected`,
+        event_type: 'error'
+      });
+      return { error: 'no resource selected' };
+    }
+
     // Fail fast on records without a usable identifier: an empty actor_id
     // would produce an invalid grant_access payload and a confusing
     // partial-share result.
@@ -333,6 +348,14 @@ const ShareModal: React.FC<ShareModalProps> = ({
   };
 
   const handleRevokeAccess = async (revokedUsers: User[]) => {
+    if (!hasSelectedResource) {
+      notify({
+        message: `Unable to revoke access to ${dataName}: no ${dataName} is selected`,
+        event_type: 'error'
+      });
+      return { error: 'no resource selected' };
+    }
+
     // Same guard as sharing: never issue a revoke_access entry with an
     // empty actor_id.
     if (revokedUsers.some((user) => !getUserIdentifier(user))) {

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -16,10 +16,7 @@ import { VISIBILITY } from '../../constants/constants';
 import { ChainIcon, DeleteIcon, LockIcon, PublicIcon } from '../../icons';
 import { useTheme } from '../../theme';
 import { BLACK, WHITE } from '../../theme/colors';
-import {
-  canShareResourceWithNewUsers,
-  canUpdateResourceVisibility
-} from '../../utils/permissions';
+import { canShareResourceWithNewUsers, canUpdateResourceVisibility } from '../../utils/permissions';
 import {
   getUserContactLabel,
   getUserDisplayName,
@@ -84,7 +81,7 @@ const AccessListActor: React.FC<AccessListActorProps> = ({
   };
 
   return (
-    <ListItem key={getUserIdentifier(actorData)} style={{ paddingLeft: '0' }}>
+    <ListItem key={getUserLabel(actorData)} style={{ paddingLeft: '0' }}>
       <ListItemAvatar>
         <Avatar
           alt={getUserDisplayName(actorData)}
@@ -142,7 +139,7 @@ const AccessList: React.FC<AccessListProps> = ({
           {accessList.map((actorData) => (
             <AccessListActor
               hostURL={hostURL}
-              key={getUserIdentifier(actorData)}
+              key={getUserLabel(actorData)}
               actor={actorData}
               handleDelete={handleDelete}
               isOwner={isSameUser(ownerData, actorData)}

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -221,7 +221,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
   const [openMenu, setMenu] = useState<boolean>(false);
   const [shareUserData, setShareUserData] = useState<User[]>([]);
   const [resourceVisibility, setVisibility] = useState(
-    Array.isArray(selectedResource) ? selectedResource[0].visibility : selectedResource.visibility
+    Array.isArray(selectedResource) ? selectedResource[0]?.visibility : selectedResource?.visibility
   );
   const [isUpdatingVisibility, setUpdatingVisibility] = useState(false);
 

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -18,9 +18,15 @@ import { useTheme } from '../../theme';
 import { BLACK, WHITE } from '../../theme/colors';
 import {
   canShareResourceWithNewUsers,
-  canUpdateResourceVisibility,
-  User
+  canUpdateResourceVisibility
 } from '../../utils/permissions';
+import {
+  getUserContactLabel,
+  getUserDisplayName,
+  getUserIdentifier,
+  isSameUser,
+  User
+} from '../../utils/user';
 import { CustomTooltip } from '../CustomTooltip';
 import { Modal, ModalBody, ModalButtonSecondary, ModalFooter } from '../Modal';
 import UserShareSearch from '../UserSearchField/UserSearchField';
@@ -44,7 +50,7 @@ const SHARE_MODE = VISIBILITY;
 interface AccessListProps {
   accessList: User[];
   ownerData: User;
-  handleDelete: (email: string) => Promise<{ error: string }>;
+  handleDelete: (actor: User) => Promise<{ error: string }>;
   hostURL?: string | null;
 }
 
@@ -52,7 +58,7 @@ interface AccessListActorProps {
   actor: User;
   isOwner: boolean;
   hostURL?: string | null;
-  handleDelete: (email: string) => Promise<{ error: string }>;
+  handleDelete: (actor: User) => Promise<{ error: string }>;
 }
 
 const AccessListActor: React.FC<AccessListActorProps> = ({
@@ -63,10 +69,10 @@ const AccessListActor: React.FC<AccessListActorProps> = ({
 }) => {
   const theme = useTheme();
   const [isRevoking, setIsRevoking] = useState(false);
-  const revokeAcess = async () => {
+  const revokeAccess = async () => {
     setIsRevoking(true);
     try {
-      await handleDelete(actorData.email);
+      await handleDelete(actorData);
     } finally {
       setIsRevoking(false);
     }
@@ -77,20 +83,20 @@ const AccessListActor: React.FC<AccessListActorProps> = ({
   };
 
   return (
-    <ListItem key={actorData.id} style={{ paddingLeft: '0' }}>
+    <ListItem key={getUserIdentifier(actorData)} style={{ paddingLeft: '0' }}>
       <ListItemAvatar>
         <Avatar
-          alt={actorData.firstName}
+          alt={getUserDisplayName(actorData)}
           src={actorData.avatarUrl}
           imgProps={{ referrerPolicy: 'no-referrer' }}
           onClick={() => {
-            if (hostURL) openInNewTab(`${hostURL}/user/${actorData.id}`);
+            if (hostURL) openInNewTab(`${hostURL}/user/${getUserIdentifier(actorData)}`);
           }}
         />
       </ListItemAvatar>
       <ListItemText
-        primary={`${actorData.firstName || ''} ${actorData.lastName || ''}`}
-        secondary={actorData.email}
+        primary={getUserDisplayName(actorData)}
+        secondary={getUserContactLabel(actorData)}
         secondaryTypographyProps={{
           sx: {
             color: theme.palette.background.neutral?.pressed
@@ -102,7 +108,7 @@ const AccessListActor: React.FC<AccessListActorProps> = ({
 
         {!isOwner && !isRevoking && (
           <CustomTooltip title="Remove Access" placement="top" arrow>
-            <IconButton edge="end" aria-label="delete" onClick={revokeAcess}>
+            <IconButton edge="end" aria-label="delete" onClick={revokeAccess}>
               <DeleteIcon fill={theme.palette.background.neutral?.default} />
             </IconButton>
           </CustomTooltip>
@@ -135,10 +141,10 @@ const AccessList: React.FC<AccessListProps> = ({
           {accessList.map((actorData) => (
             <AccessListActor
               hostURL={hostURL}
-              key={actorData.id}
+              key={getUserIdentifier(actorData)}
               actor={actorData}
               handleDelete={handleDelete}
-              isOwner={ownerData.id == actorData.id}
+              isOwner={isSameUser(ownerData, actorData)}
             />
           ))}
         </List>
@@ -213,14 +219,12 @@ const ShareModal: React.FC<ShareModalProps> = ({
   useGetAllUsersQuery,
   shareableLink
 }: ShareModalProps): JSX.Element => {
-  console.log('amit selectdResource', selectedResource);
   const theme = useTheme();
   const [openMenu, setMenu] = useState<boolean>(false);
   const [shareUserData, setShareUserData] = useState<User[]>([]);
   const [resourceVisibility, setVisibility] = useState(
     Array.isArray(selectedResource) ? selectedResource[0].visibility : selectedResource.visibility
   );
-  console.log('amit resourceVisibility', resourceVisibility);
   const [isUpdatingVisibility, setUpdatingVisibility] = useState(false);
 
   const userCanUpdateVisibility = Array.isArray(selectedResource)
@@ -247,10 +251,10 @@ const ShareModal: React.FC<ShareModalProps> = ({
 
   const handleShareWithNewUsers = async (newUsers: User[]) => {
     const grantAccessList = newUsers.map((user) => ({
-      actor_id: user.userId,
+      actor_id: getUserIdentifier(user),
       actor_type: 'user'
     }));
-    const emails = newUsers.map((u) => u.email);
+    const recipients = newUsers.map((u) => getUserContactLabel(u) || getUserDisplayName(u));
 
     if (Array.isArray(selectedResource)) {
       const responses = await Promise.all(
@@ -271,7 +275,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
 
       if (!hasError) {
         notify({
-          message: `${dataName}s shared with ${emails.join(', ')}`,
+          message: `${dataName}s shared with ${recipients.join(', ')}`,
           event_type: 'success'
         });
       } else {
@@ -298,7 +302,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
 
     if (!response?.error) {
       notify({
-        message: `${dataName} shared with ${emails.join(', ')}`,
+        message: `${dataName} shared with ${recipients.join(', ')}`,
         event_type: 'success'
       });
     }
@@ -317,10 +321,10 @@ const ShareModal: React.FC<ShareModalProps> = ({
 
   const handleRevokeAccess = async (revokedUsers: User[]) => {
     const revokeAccessList = revokedUsers.map((user) => ({
-      actor_id: user.id,
+      actor_id: getUserIdentifier(user),
       actor_type: 'user'
     }));
-    const emails = revokedUsers.map((u) => u.email);
+    const revokees = revokedUsers.map((u) => getUserContactLabel(u) || getUserDisplayName(u));
 
     const response = await resourceAccessMutator({
       resourceType,
@@ -333,16 +337,15 @@ const ShareModal: React.FC<ShareModalProps> = ({
     });
 
     if (!response?.error) {
-      const msg = `Access to ${dataName} revoked for  ${emails.join(', ')} `;
       notify({
-        message: msg,
+        message: `Access to ${dataName} revoked for ${revokees.join(', ')}`,
         event_type: 'success'
       });
     }
 
     if (response?.error) {
       notify({
-        message: `failed to revokke access to ${dataName}`,
+        message: `Failed to revoke access to ${dataName}`,
         event_type: 'error'
       });
     }
@@ -352,14 +355,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
     };
   };
 
-  const handleDelete = async (email: string) => {
-    const revoked = shareUserData.find((user) => user.email == email);
-    if (!revoked) {
-      console.error('cant revoke user without acesss');
-      return { error: '' };
-    }
-    return handleRevokeAccess([revoked]);
-  };
+  const handleDelete = async (actor: User) => handleRevokeAccess([actor]);
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const notifyVisibilityChange = (res: any, value: any) => {

--- a/src/custom/ShareModal/ShareModal.tsx
+++ b/src/custom/ShareModal/ShareModal.tsx
@@ -24,6 +24,7 @@ import {
   getUserContactLabel,
   getUserDisplayName,
   getUserIdentifier,
+  getUserLabel,
   isSameUser,
   User
 } from '../../utils/user';
@@ -265,7 +266,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
       actor_id: getUserIdentifier(user),
       actor_type: 'user'
     }));
-    const recipients = newUsers.map((u) => getUserContactLabel(u) || getUserDisplayName(u));
+    const recipients = newUsers.map(getUserLabel);
 
     if (Array.isArray(selectedResource)) {
       const responses = await Promise.all(
@@ -345,7 +346,7 @@ const ShareModal: React.FC<ShareModalProps> = ({
       actor_id: getUserIdentifier(user),
       actor_type: 'user'
     }));
-    const revokees = revokedUsers.map((u) => getUserContactLabel(u) || getUserDisplayName(u));
+    const revokees = revokedUsers.map(getUserLabel);
 
     const response = await resourceAccessMutator({
       resourceType,

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -10,7 +10,6 @@ import { isSoftDeleted } from '../../utils/nullTime';
 import {
   getUserContactLabel,
   getUserDisplayName,
-  getUserIdentifier,
   getUserLabel,
   isSameUser,
   User
@@ -96,7 +95,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
 
   const UserChip = ({ avatarObj, ...props }: { avatarObj: User }) => (
     <Chip
-      key={getUserIdentifier(avatarObj)}
+      key={getUserLabel(avatarObj)}
       avatar={
         <Avatar alt={getUserDisplayName(avatarObj)} src={avatarObj.avatarUrl}>
           {avatarObj.avatarUrl ? '' : getUserDisplayName(avatarObj).charAt(0)}

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -6,17 +6,14 @@ import { useDebounce } from 'use-debounce';
 import { Avatar, Box, Chip, Grid2, TextField, Typography } from '../../base';
 import { PersonIcon } from '../../icons/Person';
 import { useTheme } from '../../theme';
-import { DeletedAt, isSoftDeleted } from '../../utils/nullTime';
-
-interface User {
-  id: string;
-  userId: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  avatarUrl?: string;
-  deletedAt?: DeletedAt;
-}
+import { isSoftDeleted } from '../../utils/nullTime';
+import {
+  getUserContactLabel,
+  getUserDisplayName,
+  getUserIdentifier,
+  isSameUser,
+  User
+} from '../../utils/user';
 
 interface UserSearchFieldProps {
   // Array of user objects currently selected.
@@ -54,7 +51,6 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
   // const open = inputValue.trim().length > 0 && suggestions?.length > 0
 
   const handleShareWithNewUsers = async () => {
-    console.log('users to share with', usersToShareWith);
     try {
       setIsSharing(true);
       const result = await shareWithNewUsers(usersToShareWith);
@@ -64,7 +60,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
         setError(result.error);
       }
     } catch (e) {
-      console.log('error while sharing', e);
+      console.error('error while sharing', e);
     } finally {
       setIsSharing(false);
     }
@@ -88,20 +84,20 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
   };
 
   const filteredOptions = suggestions.filter(
-    (option: User) => !usersToShareWith.concat(usersData).find((u) => u.email === option.email)
+    (option: User) => !usersToShareWith.concat(usersData).find((u) => isSameUser(u, option))
   );
 
   const isShareDisabled = disabled || isSharing || usersToShareWith.length === 0;
 
   const UserChip = ({ avatarObj, ...props }: { avatarObj: User }) => (
     <Chip
-      key={avatarObj.userId}
+      key={getUserIdentifier(avatarObj)}
       avatar={
-        <Avatar alt={avatarObj.firstName} src={avatarObj.avatarUrl}>
-          {avatarObj.avatarUrl ? '' : avatarObj.firstName?.charAt(0)}
+        <Avatar alt={getUserDisplayName(avatarObj)} src={avatarObj.avatarUrl}>
+          {avatarObj.avatarUrl ? '' : getUserDisplayName(avatarObj).charAt(0)}
         </Avatar>
       }
-      label={avatarObj.email}
+      label={getUserContactLabel(avatarObj) || getUserDisplayName(avatarObj)}
       size="small"
       {...props}
     />
@@ -130,7 +126,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           inputValue={inputValue}
           loading={searchUserLoading}
           value={usersToShareWith}
-          getOptionLabel={(user) => user.email}
+          getOptionLabel={(user) => getUserContactLabel(user) || getUserDisplayName(user)}
           noOptionsText={
             searchUserLoading
               ? 'Loading...'
@@ -140,7 +136,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           }
           onChange={handleAdd}
           onInputChange={handleInputChange}
-          isOptionEqualToValue={(option, value) => option.email === value.email}
+          isOptionEqualToValue={isSameUser}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -167,36 +163,40 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
               }}
             />
           )}
-          renderOption={(props: React.HTMLAttributes<HTMLLIElement>, option) => (
-            // @ts-expect-error Props need to be passed to BOX component to make sure styles getting updated
-            <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
-              <Grid2 container sx={{ alignItems: 'center' }}>
-                <Grid2>
-                  <Box sx={{ color: 'text.secondary', mr: 2 }}>
-                    <Avatar alt={option.firstName} src={option.avatarUrl}>
-                      {option.avatarUrl ? '' : <PersonIcon />}
-                    </Avatar>
-                  </Box>
-                </Grid2>
-                <Grid2 size="grow">
-                  {isSoftDeleted(option.deletedAt) ? (
-                    <Typography variant="body2" color="text.secondary">
-                      {option.email} (deleted)
-                    </Typography>
-                  ) : (
-                    <>
-                      <Typography variant="body2">
-                        {option.firstName} {option.lastName}
-                      </Typography>
+          renderOption={(props: React.HTMLAttributes<HTMLLIElement>, option) => {
+            const displayName = getUserDisplayName(option);
+            const contactLabel = getUserContactLabel(option);
+            return (
+              // @ts-expect-error Props need to be passed to BOX component to make sure styles getting updated
+              <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
+                <Grid2 container sx={{ alignItems: 'center' }}>
+                  <Grid2>
+                    <Box sx={{ color: 'text.secondary', mr: 2 }}>
+                      <Avatar alt={displayName} src={option.avatarUrl}>
+                        {option.avatarUrl ? '' : <PersonIcon />}
+                      </Avatar>
+                    </Box>
+                  </Grid2>
+                  <Grid2 size="grow">
+                    {isSoftDeleted(option.deletedAt) ? (
                       <Typography variant="body2" color="text.secondary">
-                        {option.email}
+                        {contactLabel || displayName} (deleted)
                       </Typography>
-                    </>
-                  )}
+                    ) : (
+                      <>
+                        <Typography variant="body2">{displayName}</Typography>
+                        {contactLabel && contactLabel !== displayName && (
+                          <Typography variant="body2" color="text.secondary">
+                            {contactLabel}
+                          </Typography>
+                        )}
+                      </>
+                    )}
+                  </Grid2>
                 </Grid2>
-              </Grid2>
-            </Box>
-          )}
+              </Box>
+            );
+          }}
         />
         <Button
           variant="contained"

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -107,7 +107,10 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
     (option: User) => !alreadySelectedUsers.some((u) => isSameUser(u, option))
   );
 
-  const isShareDisabled = disabled || isSharing || usersToShareWith.length === 0;
+  // The picker itself stays usable until the consumer disables it or a share
+  // is in flight; only the Share button additionally requires a selection.
+  const isPickerDisabled = disabled || isSharing;
+  const isShareDisabled = isPickerDisabled || usersToShareWith.length === 0;
 
   return (
     <>
@@ -127,7 +130,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           filterSelectedOptions
           multiple
           disableListWrap
-          disabled={isSharing}
+          disabled={isPickerDisabled}
           // open={open}
           inputValue={inputValue}
           loading={searchUserLoading}
@@ -151,7 +154,6 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
               helperText={error}
               fullWidth
               label=""
-              disabled={isShareDisabled}
               sx={{
                 '& .MuiOutlinedInput-root': {
                   paddingInline: '0.5rem',

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -11,6 +11,7 @@ import {
   getUserContactLabel,
   getUserDisplayName,
   getUserIdentifier,
+  getUserLabel,
   isSameUser,
   User
 } from '../../utils/user';
@@ -98,7 +99,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           {avatarObj.avatarUrl ? '' : getUserDisplayName(avatarObj).charAt(0)}
         </Avatar>
       }
-      label={getUserContactLabel(avatarObj) || getUserDisplayName(avatarObj)}
+      label={getUserLabel(avatarObj)}
       size="small"
       {...props}
     />
@@ -127,7 +128,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
           inputValue={inputValue}
           loading={searchUserLoading}
           value={usersToShareWith}
-          getOptionLabel={(user) => getUserContactLabel(user) || getUserDisplayName(user)}
+          getOptionLabel={(user) => getUserLabel(user)}
           noOptionsText={
             searchUserLoading
               ? 'Loading...'
@@ -181,7 +182,7 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
                   <Grid2 size="grow">
                     {isSoftDeleted(option.deletedAt) ? (
                       <Typography variant="body2" color="text.secondary">
-                        {contactLabel || displayName} (deleted)
+                        {getUserLabel(option)} (deleted)
                       </Typography>
                     ) : (
                       <>

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -83,8 +83,9 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
     }
   };
 
+  const alreadySelectedUsers = usersToShareWith.concat(usersData);
   const filteredOptions = suggestions.filter(
-    (option: User) => !usersToShareWith.concat(usersData).find((u) => isSameUser(u, option))
+    (option: User) => !alreadySelectedUsers.some((u) => isSameUser(u, option))
   );
 
   const isShareDisabled = disabled || isSharing || usersToShareWith.length === 0;

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -24,6 +24,22 @@ interface UserSearchFieldProps {
   useGetAllUsersQuery: any;
 }
 
+// Module scope keeps the component type stable across UserShareSearch
+// renders; defining it inline would remount every chip on each render.
+const UserChip = ({ avatarObj, ...props }: { avatarObj: User }) => (
+  <Chip
+    key={getUserLabel(avatarObj)}
+    avatar={
+      <Avatar alt={getUserDisplayName(avatarObj)} src={avatarObj.avatarUrl}>
+        {avatarObj.avatarUrl ? '' : getUserDisplayName(avatarObj).charAt(0)}
+      </Avatar>
+    }
+    label={getUserLabel(avatarObj)}
+    size="small"
+    {...props}
+  />
+);
+
 const UserShareSearch: React.FC<UserSearchFieldProps> = ({
   usersData,
   disabled = false,
@@ -92,20 +108,6 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
   );
 
   const isShareDisabled = disabled || isSharing || usersToShareWith.length === 0;
-
-  const UserChip = ({ avatarObj, ...props }: { avatarObj: User }) => (
-    <Chip
-      key={getUserLabel(avatarObj)}
-      avatar={
-        <Avatar alt={getUserDisplayName(avatarObj)} src={avatarObj.avatarUrl}>
-          {avatarObj.avatarUrl ? '' : getUserDisplayName(avatarObj).charAt(0)}
-        </Avatar>
-      }
-      label={getUserLabel(avatarObj)}
-      size="small"
-      {...props}
-    />
-  );
 
   return (
     <>

--- a/src/custom/UserSearchField/UserSearchField.tsx
+++ b/src/custom/UserSearchField/UserSearchField.tsx
@@ -84,7 +84,10 @@ const UserShareSearch: React.FC<UserSearchFieldProps> = ({
     }
   };
 
-  const alreadySelectedUsers = usersToShareWith.concat(usersData);
+  // `?? []` tolerates JS consumers of the published package passing a
+  // nullish usersData, mirroring the nullish-currentUser tolerance in
+  // utils/permissions.ts.
+  const alreadySelectedUsers = usersToShareWith.concat(usersData ?? []);
   const filteredOptions = suggestions.filter(
     (option: User) => !alreadySelectedUsers.some((u) => isSameUser(u, option))
   );

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -21,6 +21,7 @@ import {
   getUserContactLabel,
   getUserDisplayName,
   getUserIdentifier,
+  getUserLabel,
   isSameUser,
   User as BaseUser
 } from '../../utils/user';
@@ -224,7 +225,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
                   <Grid2 size="grow">
                     {isDeleted ? (
                       <Typography variant="body2" color="text.secondary">
-                        {contactLabel || displayName} (deleted)
+                        {getUserLabel(option)} (deleted)
                       </Typography>
                     ) : (
                       <>
@@ -276,7 +277,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
                 {!localUsersData[0].avatarUrl && getUserDisplayName(localUsersData[0])[0]}
               </Avatar>
             }
-            label={getUserContactLabel(localUsersData[0]) || getUserDisplayName(localUsersData[0])}
+            label={getUserLabel(localUsersData[0])}
             onDelete={(e) => handleDelete(getUserIdentifier(localUsersData[0]), e)}
             deleteIcon={
               <Tooltip title="Remove user">
@@ -296,7 +297,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
                   {!user.avatarUrl && getUserDisplayName(user)[0]}
                 </Avatar>
               }
-              label={getUserContactLabel(user) || getUserDisplayName(user)}
+              label={getUserLabel(user)}
               onDelete={(e) => handleDelete(getUserIdentifier(user), e)}
               deleteIcon={
                 <Tooltip title="Remove user">

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -21,7 +21,6 @@ import {
   User as BaseUser,
   getUserContactLabel,
   getUserDisplayName,
-  getUserIdentifier,
   getUserLabel,
   isSameUser
 } from '../../utils/user';
@@ -94,10 +93,16 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
   }, [searchedUsers, currentUserData, usersSearch, hasInitialFocus]);
 
   const handleDelete = useCallback(
-    (idToDelete: string, event: React.MouseEvent) => {
+    (userToDelete: User, event: React.MouseEvent) => {
       event.stopPropagation();
 
-      const updatedUsers = localUsersData.filter((user) => getUserIdentifier(user) !== idToDelete);
+      // Identifier-string comparison collapses every identifier-less record
+      // (email-only invitees) onto '' and deletes them all together. isSameUser
+      // matches on identifier or email; reference equality is the last resort
+      // for records carrying neither, which isSameUser never matches.
+      const updatedUsers = localUsersData.filter(
+        (user) => user !== userToDelete && !isSameUser(user, userToDelete)
+      );
       setLocalUsersData(updatedUsers);
       setUsersData(updatedUsers);
 
@@ -105,7 +110,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
         setDisableSave(false);
       }
     },
-    [localUsersData, setUsersData, setDisableSave, fetchSearchedUsers, inputValue]
+    [localUsersData, setUsersData, setDisableSave]
   );
 
   const handleAdd = useCallback(
@@ -271,14 +276,14 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
       >
         {!showAllUsers && localUsersData?.[0] && (
           <Chip
-            key={getUserIdentifier(localUsersData[0])}
+            key={getUserLabel(localUsersData[0])}
             avatar={
               <Avatar alt={getUserDisplayName(localUsersData[0])} src={localUsersData[0].avatarUrl}>
                 {!localUsersData[0].avatarUrl && getUserDisplayName(localUsersData[0]).charAt(0)}
               </Avatar>
             }
             label={getUserLabel(localUsersData[0])}
-            onDelete={(e) => handleDelete(getUserIdentifier(localUsersData[0]), e)}
+            onDelete={(e) => handleDelete(localUsersData[0], e)}
             deleteIcon={
               <Tooltip title="Remove user">
                 <CloseIcon style={iconSmall} />
@@ -291,14 +296,14 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
         {showAllUsers &&
           localUsersData?.map((user) => (
             <Chip
-              key={getUserIdentifier(user)}
+              key={getUserLabel(user)}
               avatar={
                 <Avatar alt={getUserDisplayName(user)} src={user.avatarUrl}>
                   {!user.avatarUrl && getUserDisplayName(user).charAt(0)}
                 </Avatar>
               }
               label={getUserLabel(user)}
-              onDelete={(e) => handleDelete(getUserIdentifier(user), e)}
+              onDelete={(e) => handleDelete(user, e)}
               deleteIcon={
                 <Tooltip title="Remove user">
                   <CloseIcon style={iconSmall} />

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -16,15 +16,16 @@ import {
 
 import { iconSmall } from '../../constants/iconsSizes';
 import { CloseIcon, PersonIcon } from '../../icons';
-import { DeletedAt, isSoftDeleted } from '../../utils/nullTime';
+import { isSoftDeleted } from '../../utils/nullTime';
+import {
+  getUserContactLabel,
+  getUserDisplayName,
+  getUserIdentifier,
+  isSameUser,
+  User as BaseUser
+} from '../../utils/user';
 
-interface User {
-  userId: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  avatarUrl?: string;
-  deletedAt?: DeletedAt;
+interface User extends BaseUser {
   deleted?: boolean;
 }
 
@@ -81,7 +82,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
     }
 
     const filteredResults = searchedUsers.filter(
-      (user: User) => user.userId !== currentUserData?.userId
+      (user: User) => !isSameUser(user, currentUserData)
     );
 
     if (!usersSearch && currentUserData) {
@@ -95,7 +96,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
     (idToDelete: string, event: React.MouseEvent) => {
       event.stopPropagation();
 
-      const updatedUsers = localUsersData.filter((user) => user.userId !== idToDelete);
+      const updatedUsers = localUsersData.filter((user) => getUserIdentifier(user) !== idToDelete);
       setLocalUsersData(updatedUsers);
       setUsersData(updatedUsers);
 
@@ -110,7 +111,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
     (event: React.SyntheticEvent<Element, Event>, value: User | null) => {
       if (!value) return;
 
-      const isDuplicate = localUsersData.some((user) => user.userId === value.userId);
+      const isDuplicate = localUsersData.some((user) => isSameUser(user, value));
       const isDeleted = isSoftDeleted(value.deletedAt);
 
       if (isDuplicate || isDeleted) {
@@ -159,7 +160,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
         open={open}
         options={displayOptions}
         getOptionLabel={() => ''}
-        isOptionEqualToValue={(option, value) => option.userId === value.userId}
+        isOptionEqualToValue={isSameUser}
         onOpen={() => setOpen(true)}
         onClose={() => setOpen(false)}
         inputValue={inputValue}
@@ -202,38 +203,42 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             }}
           />
         )}
-        renderOption={(props, option: User) => (
-          <li {...props} id={option.userId}>
-            <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
-              {' '}
-              <Grid2 container sx={{ alignItems: 'center' }}>
-                <Grid2>
-                  <Box sx={{ color: 'text.secondary', mr: 2 }}>
-                    <Avatar alt={option.firstName} src={option.avatarUrl}>
-                      {option.avatarUrl ? '' : <PersonIcon />}
-                    </Avatar>
-                  </Box>
-                </Grid2>
-                <Grid2 size="grow">
-                  {option.deleted ? (
-                    <Typography variant="body2" color="text.secondary">
-                      {option.email} (deleted)
-                    </Typography>
-                  ) : (
-                    <>
-                      <Typography variant="body2">
-                        {option.firstName} {option.lastName}
-                      </Typography>
+        renderOption={(props, option: User) => {
+          const displayName = getUserDisplayName(option);
+          const contactLabel = getUserContactLabel(option);
+          return (
+            <li {...props} id={getUserIdentifier(option)}>
+              <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
+                {' '}
+                <Grid2 container sx={{ alignItems: 'center' }}>
+                  <Grid2>
+                    <Box sx={{ color: 'text.secondary', mr: 2 }}>
+                      <Avatar alt={displayName} src={option.avatarUrl}>
+                        {option.avatarUrl ? '' : <PersonIcon />}
+                      </Avatar>
+                    </Box>
+                  </Grid2>
+                  <Grid2 size="grow">
+                    {option.deleted ? (
                       <Typography variant="body2" color="text.secondary">
-                        {option.email}
+                        {contactLabel || displayName} (deleted)
                       </Typography>
-                    </>
-                  )}
+                    ) : (
+                      <>
+                        <Typography variant="body2">{displayName}</Typography>
+                        {contactLabel && contactLabel !== displayName && (
+                          <Typography variant="body2" color="text.secondary">
+                            {contactLabel}
+                          </Typography>
+                        )}
+                      </>
+                    )}
+                  </Grid2>
                 </Grid2>
-              </Grid2>
-            </Box>
-          </li>
-        )}
+              </Box>
+            </li>
+          );
+        }}
       />
       {showNotifyCheckbox && !isCreate && handleNotifyPref && (
         <FormGroup row={true}>
@@ -262,14 +267,14 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
       >
         {!showAllUsers && localUsersData?.[0] && (
           <Chip
-            key={localUsersData[0].userId}
+            key={getUserIdentifier(localUsersData[0])}
             avatar={
-              <Avatar alt={localUsersData[0].firstName} src={localUsersData[0].avatarUrl}>
-                {!localUsersData[0].avatarUrl && localUsersData[0].firstName?.[0]}
+              <Avatar alt={getUserDisplayName(localUsersData[0])} src={localUsersData[0].avatarUrl}>
+                {!localUsersData[0].avatarUrl && getUserDisplayName(localUsersData[0])[0]}
               </Avatar>
             }
-            label={localUsersData[0].email}
-            onDelete={(e) => handleDelete(localUsersData[0].userId, e)}
+            label={getUserContactLabel(localUsersData[0]) || getUserDisplayName(localUsersData[0])}
+            onDelete={(e) => handleDelete(getUserIdentifier(localUsersData[0]), e)}
             deleteIcon={
               <Tooltip title="Remove user">
                 <CloseIcon style={iconSmall} />
@@ -282,14 +287,14 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
         {showAllUsers &&
           localUsersData?.map((user) => (
             <Chip
-              key={user.userId}
+              key={getUserIdentifier(user)}
               avatar={
-                <Avatar alt={user.firstName} src={user.avatarUrl}>
-                  {!user.avatarUrl && user.firstName?.[0]}
+                <Avatar alt={getUserDisplayName(user)} src={user.avatarUrl}>
+                  {!user.avatarUrl && getUserDisplayName(user)[0]}
                 </Avatar>
               }
-              label={user.email}
-              onDelete={(e) => handleDelete(user.userId, e)}
+              label={getUserContactLabel(user) || getUserDisplayName(user)}
+              onDelete={(e) => handleDelete(getUserIdentifier(user), e)}
               deleteIcon={
                 <Tooltip title="Remove user">
                   <CloseIcon style={iconSmall} />

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -98,11 +98,9 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
 
       // Identifier-string comparison collapses every identifier-less record
       // (email-only invitees) onto '' and deletes them all together. isSameUser
-      // matches on identifier or email; reference equality is the last resort
-      // for records carrying neither, which isSameUser never matches.
-      const updatedUsers = localUsersData.filter(
-        (user) => user !== userToDelete && !isSameUser(user, userToDelete)
-      );
+      // matches on reference, identifier, or email, so only the selected
+      // record is removed.
+      const updatedUsers = localUsersData.filter((user) => !isSameUser(user, userToDelete));
       setLocalUsersData(updatedUsers);
       setUsersData(updatedUsers);
 

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -18,12 +18,12 @@ import { iconSmall } from '../../constants/iconsSizes';
 import { CloseIcon, PersonIcon } from '../../icons';
 import { isSoftDeleted } from '../../utils/nullTime';
 import {
+  User as BaseUser,
   getUserContactLabel,
   getUserDisplayName,
   getUserIdentifier,
   getUserLabel,
-  isSameUser,
-  User as BaseUser
+  isSameUser
 } from '../../utils/user';
 
 interface User extends BaseUser {
@@ -274,7 +274,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
             key={getUserIdentifier(localUsersData[0])}
             avatar={
               <Avatar alt={getUserDisplayName(localUsersData[0])} src={localUsersData[0].avatarUrl}>
-                {!localUsersData[0].avatarUrl && getUserDisplayName(localUsersData[0])[0]}
+                {!localUsersData[0].avatarUrl && getUserDisplayName(localUsersData[0]).charAt(0)}
               </Avatar>
             }
             label={getUserLabel(localUsersData[0])}
@@ -294,7 +294,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
               key={getUserIdentifier(user)}
               avatar={
                 <Avatar alt={getUserDisplayName(user)} src={user.avatarUrl}>
-                  {!user.avatarUrl && getUserDisplayName(user)[0]}
+                  {!user.avatarUrl && getUserDisplayName(user).charAt(0)}
                 </Avatar>
               }
               label={getUserLabel(user)}

--- a/src/custom/UserSearchField/UserSearchFieldInput.tsx
+++ b/src/custom/UserSearchField/UserSearchFieldInput.tsx
@@ -206,8 +206,11 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
         renderOption={(props, option: User) => {
           const displayName = getUserDisplayName(option);
           const contactLabel = getUserContactLabel(option);
+          const isDeleted = option.deleted || isSoftDeleted(option.deletedAt);
           return (
-            <li {...props} id={getUserIdentifier(option)}>
+            // Spread MUI's props untouched: Autocomplete's generated option id
+            // wires up aria-activedescendant and keyboard navigation.
+            <li {...props}>
               <Box sx={{ '& > img': { mr: 2, flexShrink: 0 } }}>
                 {' '}
                 <Grid2 container sx={{ alignItems: 'center' }}>
@@ -219,7 +222,7 @@ const UserSearchField: React.FC<UserSearchFieldProps> = ({
                     </Box>
                   </Grid2>
                   <Grid2 size="grow">
-                    {option.deleted ? (
+                    {isDeleted ? (
                       <Typography variant="body2" color="text.secondary">
                         {contactLabel || displayName} (deleted)
                       </Typography>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './nullTime';
 export * from './time.utils';
+export * from './user';

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -5,8 +5,8 @@ export type { User };
 
 export const canUpdateResource = (
   selectedResource: { visibility: string },
-  currentUser: User,
-  resourceOwner: User
+  currentUser: User | null | undefined,
+  resourceOwner: User | null | undefined
 ) => {
   const ownerIdentifier = getUserIdentifier(resourceOwner);
   const isOwner = Boolean(ownerIdentifier) && ownerIdentifier === getUserIdentifier(currentUser);
@@ -20,8 +20,8 @@ export const canUpdateResourceVisibility = canUpdateResource;
 
 export const canShareResourceWithNewUsers = (
   selectedResource: { visibility: string },
-  currentUser: User,
-  resourceOwner: User
+  currentUser: User | null | undefined,
+  resourceOwner: User | null | undefined
 ) => {
   if (selectedResource.visibility == VISIBILITY.PUBLIC) {
     return true;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,23 +1,15 @@
 import { VISIBILITY } from '../constants/constants';
-import { DeletedAt } from './nullTime';
+import { getUserIdentifier, User } from './user';
 
-export interface User {
-  id: string;
-  userId: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  avatarUrl?: string;
-  deletedAt?: DeletedAt;
-  roleNames?: string[];
-}
+export type { User };
 
 export const canUpdateResource = (
   selectedResource: { visibility: string },
   currentUser: User,
   resourceOwner: User
 ) => {
-  const isOwner = resourceOwner.userId == currentUser.userId;
+  const ownerIdentifier = getUserIdentifier(resourceOwner);
+  const isOwner = Boolean(ownerIdentifier) && ownerIdentifier === getUserIdentifier(currentUser);
   const isAdmin = currentUser.roleNames?.includes('admin');
   return isOwner || isAdmin;
 };

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -10,7 +10,9 @@ export const canUpdateResource = (
 ) => {
   const ownerIdentifier = getUserIdentifier(resourceOwner);
   const isOwner = Boolean(ownerIdentifier) && ownerIdentifier === getUserIdentifier(currentUser);
-  const isAdmin = currentUser.roleNames?.includes('admin');
+  // Tolerate a nullish currentUser (auth-state transitions in JS consumers):
+  // no user means no permission, consistent with getUserIdentifier above.
+  const isAdmin = currentUser?.roleNames?.includes('admin') ?? false;
   return isOwner || isAdmin;
 };
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -4,10 +4,13 @@ import { getUserIdentifier, User } from './user';
 export type { User };
 
 export const canUpdateResource = (
-  selectedResource: { visibility: string },
+  selectedResource: { visibility: string } | null | undefined,
   currentUser: User | null | undefined,
   resourceOwner: User | null | undefined
 ) => {
+  // Deny-by-default on a nullish resource (JS consumers, initial load
+  // states): there is nothing to grant permission on.
+  if (!selectedResource) return false;
   const ownerIdentifier = getUserIdentifier(resourceOwner);
   const isOwner = Boolean(ownerIdentifier) && ownerIdentifier === getUserIdentifier(currentUser);
   // Tolerate a nullish currentUser (auth-state transitions in JS consumers):
@@ -19,11 +22,11 @@ export const canUpdateResource = (
 export const canUpdateResourceVisibility = canUpdateResource;
 
 export const canShareResourceWithNewUsers = (
-  selectedResource: { visibility: string },
+  selectedResource: { visibility: string } | null | undefined,
   currentUser: User | null | undefined,
   resourceOwner: User | null | undefined
 ) => {
-  if (selectedResource.visibility == VISIBILITY.PUBLIC) {
+  if (selectedResource?.visibility == VISIBILITY.PUBLIC) {
     return true;
   }
   return canUpdateResource(selectedResource, currentUser, resourceOwner);

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,0 +1,62 @@
+import { DeletedAt } from './nullTime';
+
+/**
+ * Collaboration-facing user record, aligned with the v1beta3 `user` construct
+ * of @meshery/schemas. The canonical identifier is `id`; `userId` survives
+ * only as a deprecated wire alias emitted by providers that predate the
+ * users.user_id column retirement. Reduced projections (the public users
+ * directory, the searchable collaboration projection) omit some or all of the
+ * name/email fields, so everything except the identifiers is optional and
+ * display code must go through the fallback helpers below.
+ */
+export interface User {
+  /** Canonical unique identifier of the user (v1beta3 `id`). */
+  id?: string;
+  /** @deprecated Legacy duplicate of `id`; read via {@link getUserIdentifier}. */
+  userId?: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  avatarUrl?: string;
+  deletedAt?: DeletedAt;
+  roleNames?: string[];
+}
+
+/**
+ * Resolves the canonical identifier of a user record: v1beta3 `id` first,
+ * falling back to the deprecated `userId` alias for records produced by
+ * pre-cutover providers. Returns an empty string when neither is present.
+ */
+export const getUserIdentifier = (user: User | null | undefined): string =>
+  user?.id || user?.userId || '';
+
+/**
+ * Human-readable name with wire-shape fallbacks: "First Last" when the
+ * projection carries names, else username, else email, else empty string.
+ */
+export const getUserDisplayName = (user: User | null | undefined): string => {
+  if (!user) return '';
+  const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ').trim();
+  return fullName || user.username || user.email || '';
+};
+
+/**
+ * Contact line shown under or instead of the display name: email when the
+ * projection carries it, else username. Empty string when neither is present.
+ */
+export const getUserContactLabel = (user: User | null | undefined): string =>
+  user?.email || user?.username || '';
+
+/**
+ * Identity comparison across wire shapes: canonical/legacy identifiers when
+ * both records carry one, else email. Two records with no comparable field
+ * are never considered the same user.
+ */
+export const isSameUser = (a: User | null | undefined, b: User | null | undefined): boolean => {
+  const idA = getUserIdentifier(a);
+  const idB = getUserIdentifier(b);
+  if (idA && idB) return idA === idB;
+  if (a?.email && b?.email) return a.email === b.email;
+  return false;
+};

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -58,11 +58,13 @@ export const getUserLabel = (user: User | null | undefined): string =>
   getUserContactLabel(user) || getUserDisplayName(user) || getUserIdentifier(user);
 
 /**
- * Identity comparison across wire shapes: canonical/legacy identifiers when
- * both records carry one, else email. Two records with no comparable field
- * are never considered the same user.
+ * Identity comparison across wire shapes: the same object reference is
+ * trivially the same user, then canonical/legacy identifiers when both
+ * records carry one, else email. Two distinct records with no comparable
+ * field are never considered the same user.
  */
 export const isSameUser = (a: User | null | undefined, b: User | null | undefined): boolean => {
+  if (a && b && a === b) return true;
   const idA = getUserIdentifier(a);
   const idB = getUserIdentifier(b);
   if (idA && idB) return idA === idB;

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -49,6 +49,15 @@ export const getUserContactLabel = (user: User | null | undefined): string =>
   user?.email || user?.username || '';
 
 /**
+ * Guaranteed-non-empty label for chips, option labels, and notification
+ * text: contact label first (email, then username), then display name, then
+ * the raw identifier. Only a record with no identifier at all yields an
+ * empty string, and such records are rejected by the share/revoke guards.
+ */
+export const getUserLabel = (user: User | null | undefined): string =>
+  getUserContactLabel(user) || getUserDisplayName(user) || getUserIdentifier(user);
+
+/**
  * Identity comparison across wire shapes: canonical/legacy identifiers when
  * both records carry one, else email. Two records with no comparable field
  * are never considered the same user.


### PR DESCRIPTION
## Symptom
The Share Design people-picker shows no email address and no first/last name while searching for and selecting existing users (Layer5 Cloud, Meshery, and Kanvas all embed these components).

## Root cause
The components hard-coded a pre-cutover user shape. The v1beta3 user construct in meshery/schemas retired the wire `userId` (canonical identifier is `id`), and meshery-cloud's hardened user endpoints serve reduced projections that can omit names/email. Concretely:

- Option rows rendered `firstName lastName` / `email` directly - blank when a projection omits them, with no username fallback.
- `isOptionEqualToValue` compared emails; with emails absent, `undefined === undefined` made every option "equal" once one user was selected, emptying the suggestion list.
- `grant_access` payloads sent `actor_id: user.userId` - `undefined` for canonical v1beta3 records.
- The ownership check in `utils/permissions.ts` compared `userId` on both sides, so two canonical records never matched (and two records missing the field always matched).

## Fix
New `src/utils/user.ts` is the single place that absorbs wire shapes, aligned with the v1beta3 `user` construct:
- `getUserIdentifier` - `id` with deprecated `userId` fallback
- `getUserDisplayName` - `firstName lastName` -> `username` -> `email`
- `getUserContactLabel` - `email` -> `username`
- `isSameUser` - identifier match with email fallback, never matches empty records

`UserShareSearch`, `ShareModal`, `UserSearchFieldInput`, and the permissions ownership check now route through these helpers. Revocation passes the actor record instead of round-tripping through email.

## Out-of-scope fixes included
- Removed leftover debug `console.log`s in ShareModal/UserShareSearch (including personal-name debug tags).
- User-facing message typos: "revokke", double spaces in revoke notifications.

## Watch for
`UsersTable`, `CollaboratorAvatarGroup`, and catalog tables still read `userId` from other constructs (org-users projection, Kanvas awareness state, design-owner FK). Those wires still carry `userId` today and are unaffected by this defect, but will need the same treatment if/when their contracts move to v1beta3 identity.

## Coordinated changes
- meshery/schemas#1060 adds the canonical `SearchableUser` projection + search operations these components consume.
- Follow-up PRs point meshery-cloud's share search at the authenticated searchable projection and bump sistent in meshery and meshery-extensions.

## Test plan
- [x] `npx jest` - 369/369 pass, including new `userIdentity.test.ts` (helper matrix across v1beta3/legacy/public shapes) and `UserShareSearch.test.tsx` (name+email render, username fallback, id-based selection/grant, access-list dedup)
- [x] `npm run build` (tsup + DTS)
- [x] `eslint` on touched paths