### PR TITLE
fix(icons): CopyLinkIcon now follows theme color via fill prop

### DIFF
--- a/src/icons/Copy/CopyLinkIcon.tsx
+++ b/src/icons/Copy/CopyLinkIcon.tsx
@@ -1,16 +1,18 @@
 import { FC } from 'react';
-import { DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
+import { DEFAULT_FILL_NONE, DEFAULT_HEIGHT, DEFAULT_WIDTH } from '../../constants/constants';
 import { IconProps } from '../types';
 
 export const CopyLinkIcon: FC<IconProps> = ({
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
+  fill = DEFAULT_FILL_NONE,
   ...props
 }) => {
   return (
     <svg
       width={width}
       height={height}
+      fill={fill}
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 18 18"
       {...props}


### PR DESCRIPTION
## Description

**Symptom** - The "Copy link" chain icon renders black regardless of theme, visibly miscolored next to sibling action icons (e.g. `SettingsIcon`) in row-action menus - reported from Meshery's Connections table for established Kubernetes connections.

**Root cause** - `CopyLinkIcon` ignored the `fill` prop entirely and neither of its `<path>`s set a fill, so the SVG default (`#000`) applied. `SettingsIcon` and other correctly-themed icons default `fill` to `currentColor`, which inherits the surrounding text color.

**Fix** - Give `CopyLinkIcon` the same contract as `SettingsIcon`: accept `fill` (default `DEFAULT_FILL_NONE` = `currentColor`), applied on the `<svg>` element so both paths inherit it.

**Consumers** - Only two: Sistent's own `getCopyDeepLinkAction` (`src/custom/TableActions.tsx`) and Meshery's `ConnectionActionMenu`. Both render the icon inside buttons/menu items where `currentColor` is the desired behavior; nothing depends on the black rendering (the black is the bug).

**Watch for** - Several other icons lack any `fill` handling and can exhibit the same defect: `CredentialIcon`, `RightArrowIcon`, `RemoveIcon`, `AccountTreeIcon`, `ChatIcon`, `BusIcon`, `ComponentIcon`, `TriangleIcon`, `OutlinedVisibilityOn/OffIcon`, and more (`grep -rL 'fill' src/icons --include='*Icon.tsx'`). Deliberately not swept here - some may be stroke-based or intentionally fixed-color; they deserve a dedicated audit.

## Tests
- `jest`: 349 passed.
- ESLint clean on the changed file.

A release including this fix is needed by meshery/meshery (Connections table action menu).