### PR TITLE
refactor(schemas): consume canonical helm UI schema + bump @meshery/schemas to v1.3.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@emotion/cache": "^11.14.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
-        "@meshery/schemas": "^1.3.25",
+        "@meshery/schemas": "^1.3.35",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@mui/system": "^9.0.0",
@@ -3355,9 +3355,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.25",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.25.tgz",
-      "integrity": "sha512-wsFu2nkIKUtVBLekbDyZ0lesEMOaxEBlyYeqRSa0Y02oMAZ+ubfpnTDPiDEOUvPYxCBQfWx1vYUsbqRaU5odWA==",
+      "version": "1.3.35",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.35.tgz",
+      "integrity": "sha512-YDYETnh/p8kqhiY2PGrmISmXahmGfXGYDSuZcXZt1Np2/24kBcZJ5kPm9HZAMcysRVVBdSjYkA7BO29To++2gQ==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
@@ -3963,9 +3963,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3980,9 +3977,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3997,9 +3991,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4014,9 +4005,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4031,9 +4019,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4048,9 +4033,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4065,9 +4047,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4082,9 +4061,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4099,9 +4075,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4116,9 +4089,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4133,9 +4103,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4150,9 +4117,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4167,9 +4131,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@emotion/cache": "^11.14.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@meshery/schemas": "^1.3.25",
+    "@meshery/schemas": "^1.3.35",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@mui/system": "^9.0.0",

--- a/src/schemas/helmConnection/uiSchema.tsx
+++ b/src/schemas/helmConnection/uiSchema.tsx
@@ -1,5 +1,16 @@
-const helmConnectionUiSchema = {
-  'ui:order': ['name', 'description', 'url']
-};
-
-export default helmConnectionUiSchema;
+/**
+ * UI schema for the create Helm repository connection form.
+ *
+ * Source-of-truth: re-exported from `@meshery/schemas` per the
+ * form-schema canonicalization tracked in
+ * https://github.com/meshery/schemas/issues/866. Sistent consumes the
+ * canonical form UI schemas; it does not define them.
+ *
+ * The published Sistent export name (`helmConnectionUiSchema`) is unchanged.
+ * The canonical UI schema keeps the same `ui:order` (name, description, url),
+ * renders `description` as a textarea, and suppresses the duplicative RJSF
+ * root-object title.
+ *
+ * @see meshery/schemas schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
+ */
+export { ConnectionHelmCreateRjsfUiSchemaV1Beta3 as default } from '@meshery/schemas';


### PR DESCRIPTION
Two related changes that restore and propagate a single source of truth for the RJSF form UI schemas.

## 1. Consume canonical helm connection UI schema (stop defining it)

Sistent must be a pure **consumer** of the canonical form schemas in `meshery/schemas`, never a second source of truth. Every form under `src/schemas/` already re-exports from `@meshery/schemas` except `helmConnection/uiSchema`, which still hand-defined:

```js
const helmConnectionUiSchema = { 'ui:order': ['name', 'description', 'url'] };
```

Re-export `ConnectionHelmCreateRjsfUiSchemaV1Beta3` instead. The canonical schema is a strict superset - same `ui:order`, plus `description` rendered as a `textarea` and the duplicative root-object title suppressed. The published export name `helmConnectionUiSchema` is unchanged, so consumers are unaffected. This was the last remaining locally-defined form UI schema.

## 2. Bump `@meshery/schemas` `^1.3.25` -> `^1.3.35`

Sistent **bundles** `@meshery/schemas` into its published dist (tsup `noExternal: [/^@meshery\/schemas/]`), so the canonical form schemas it re-exports are frozen at Sistent's build-time schemas version. The pinned `^1.3.25` predates the environment/workspace form fix that hides the session-derived Organization field (meshery/schemas#1078, released in **v1.3.35**), so downstream Meshery cannot receive that fix through Sistent until Sistent rebuilds against it.

Bumping to `^1.3.35` and rebuilding makes the next Sistent release bundle the corrected UI schemas (`organizationId -> "ui:widget": "hidden"` for both createOrEdit forms). Verified: the rebuilt `dist/index.mjs` now inlines the hidden-organization uiSchema for both env and workspace.

## Validation

- Full build (ESM/CJS/DTS) succeeds.
- `jest` full suite: **388 tests pass**.
- `eslint` clean on the changed source.

## Release / propagation

Once merged and a Sistent release is published, Meshery picks up both fixes by bumping `@sistent/sistent` (companion PR meshery/meshery#20832 also bumps `@meshery/schemas` to `^1.3.35`). Part of the form-schema single-source-of-truth cleanup (meshery/schemas#866); source-of-truth PR meshery/schemas#1078 (merged, v1.3.35).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Helm connection form to use the standardized, shared UI schema.
  * Kept the same field ordering and form behavior to match the existing user experience.

* **Chores**
  * Updated the schemas library development dependency to the newer version to support the shared UI schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->