### PR TITLE
docs: add AGENTS.md with release, optional-peer, and repo-state notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,22 +31,37 @@ An optional dependency must be either used conditionally (`React.lazy` / dynamic
 `src/base/DateTimePicker/DateTimePicker.tsx` does) or declared honestly as a real dependency.
 `import type` is fine - it is erased at runtime.
 
-**CI cannot see this**, because the repo always has its own devDependencies installed. It surfaces
-only in a downstream clean install, so the check has to run from a real consumer install - requiring
-`./dist/index.js` in the repo tree proves nothing, since Node resolves the optional peers out of the
-repo's own `node_modules`. Pack the build and load it from a throwaway consumer:
+Two complementary guards, and you need both:
+
+**1. Source level, in CI.** [`src/__testing__/optionalPeerDependencies.test.ts`](src/__testing__/optionalPeerDependencies.test.ts)
+scans `src/` for every load-time form (`import from`, `export ... from`, bare `import`, `require`)
+of an enforced optional peer, and fails `jest` if one appears. `await import()` is deliberately not
+matched - deferring resolution is the fix, not the defect. That file is also the source of truth for
+*which* optional peers are enforced: `react` / `react-dom` are marked optional in `package.json` but
+exempted there on the record, because every component imports React at module scope and always will.
+
+**2. Built artifact, by hand.** The CI guard reads source, so it cannot speak for what the bundler
+actually emitted or for a tarball already on npm. That only shows up in a downstream clean install -
+and requiring `./dist/index.js` from inside the repo tree does not reproduce one, because Node
+resolves the optional peers out of the repo's own `node_modules`. Pack the build and load it from a
+throwaway consumer:
 
 ```bash
 npm run build
-tgz="$PWD/$(npm pack --silent | tail -1)"      # published build: npm pack @sistent/sistent@<version> --silent
-cd "$(mktemp -d)" && npm init -y >/dev/null
-npm install "$tgz"                             # npm installs required peers, NOT optional ones
-ls node_modules/date-fns >/dev/null 2>&1 && echo "WARNING: optional peer present, check is void"
-node -e "require('@sistent/sistent')"          # throws iff an optional peer is required at module scope
+tgz="$PWD/$(npm pack --silent | tail -1)"   # published build: npm pack @sistent/sistent@<version> --silent
+
+( set -e
+  cd "$(mktemp -d)" && npm init -y >/dev/null
+  npm install "$tgz"                        # npm installs required peers, NOT optional ones
+  for p in @mui/x-date-pickers date-fns; do # fail closed: if one is present the load proves nothing
+    [ ! -e "node_modules/$p" ] || { echo "ABORT: optional peer $p is installed"; exit 1; }
+  done
+  node -e "require('@sistent/sistent')"     # throws iff an optional peer resolves at module scope
+) && echo "clean-consumer load OK"
 ```
 
-The same procedure verifies an already-published version - use the `npm pack @sistent/sistent@<version>`
-form and skip the build. Always confirm the optional peers really are absent before trusting a pass.
+Keep that peer list in step with the enforced set in the test above. Use the
+`npm pack @sistent/sistent@<version>` form to verify a release that is already published.
 
 Known live instance: [#1735](https://github.com/layer5io/sistent/issues/1735) (`date-fns` in
 `src/custom/UniversalFilter.tsx`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Releasing
+
+Automation-driven; do not `npm publish`, `npm version`, or tag by hand. Merge to `master`, let
+Release Drafter update the draft, then publish the draft - `release.yml` does the rest.
+Runbook: [`.claude/skills/cut-release/SKILL.md`](.claude/skills/cut-release/SKILL.md).
+
+## The barrel must not require an optional peer
+
+`src/index.tsx` re-exports nearly everything, so **a module-scope `import` of an optional peer in
+any reachable file makes `import { anything } from '@sistent/sistent'` throw** for consumers who
+did not install it - with a message naming sistent rather than the missing peer. Optional peers
+are listed under `peerDependenciesMeta` in `package.json`.
+
+An optional dependency must be either used conditionally (`React.lazy` / dynamic `import()`, as
+`src/base/DateTimePicker/DateTimePicker.tsx` does) or declared honestly as a real dependency.
+`import type` is fine - it is erased at runtime.
+
+**CI cannot see this**, because the repo always has its own devDependencies installed. It surfaces
+only in a downstream clean install. To check before releasing, import the built barrel from a
+directory that has only the *required* peers:
+
+```bash
+npm run build && node -e "require('./dist/index.js')"   # from a dir without the optional peers
+```
+
+Known live instance: [#1735](https://github.com/layer5io/sistent/issues/1735) (`date-fns` in
+`src/custom/UniversalFilter.tsx`).
+
+## Repo state that looks broken but is pre-existing
+
+`prettier --check` fails on ~82 files and `tsc --noEmit` reports errors across `src/` (including
+missing `@types/jest` wiring for `src/__testing__`). Neither is a CI gate - CI runs
+`.github/workflows/node-checks.yml` (lint + build) and `jest`. Do not assume you caused these;
+do not mass-reformat to "fix" them.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,16 @@ Automation-driven; do not `npm publish`, `npm version`, or tag by hand. Merge to
 Release Drafter update the draft, then publish the draft - `release.yml` does the rest.
 Runbook: [`.claude/skills/cut-release/SKILL.md`](.claude/skills/cut-release/SKILL.md).
 
+Resolve "what is currently released" from the npm `latest` dist-tag and publish timestamps
+(`npm view @sistent/sistent dist-tags time --json`), not by eyeballing semver order.
+
+Verify a published release **by content**, not by the version number moving. Two properties carry
+the three-repo chain, and losing either fails downstream with errors that point nowhere near sistent:
+
+1. `dist/` still exports `MESHERY_EXTENSION_CONTRACT_VERSION` (present in `index.js`, `index.mjs`,
+   and both `.d.ts` files) - meshery-extensions gates compatibility on it.
+2. `dist/` still has no module-scope require of an optional peer - see the check below.
+
 ## The barrel must not require an optional peer
 
 `src/index.tsx` re-exports nearly everything, so **a module-scope `import` of an optional peer in
@@ -22,12 +32,21 @@ An optional dependency must be either used conditionally (`React.lazy` / dynamic
 `import type` is fine - it is erased at runtime.
 
 **CI cannot see this**, because the repo always has its own devDependencies installed. It surfaces
-only in a downstream clean install. To check before releasing, import the built barrel from a
-directory that has only the *required* peers:
+only in a downstream clean install, so the check has to run from a real consumer install - requiring
+`./dist/index.js` in the repo tree proves nothing, since Node resolves the optional peers out of the
+repo's own `node_modules`. Pack the build and load it from a throwaway consumer:
 
 ```bash
-npm run build && node -e "require('./dist/index.js')"   # from a dir without the optional peers
+npm run build
+tgz="$PWD/$(npm pack --silent | tail -1)"      # published build: npm pack @sistent/sistent@<version> --silent
+cd "$(mktemp -d)" && npm init -y >/dev/null
+npm install "$tgz"                             # npm installs required peers, NOT optional ones
+ls node_modules/date-fns >/dev/null 2>&1 && echo "WARNING: optional peer present, check is void"
+node -e "require('@sistent/sistent')"          # throws iff an optional peer is required at module scope
 ```
+
+The same procedure verifies an already-published version - use the `npm pack @sistent/sistent@<version>`
+form and skip the build. Always confirm the optional peers really are absent before trusting a pass.
 
 Known live instance: [#1735](https://github.com/layer5io/sistent/issues/1735) (`date-fns` in
 `src/custom/UniversalFilter.tsx`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adds `AGENTS.md` (with `CLAUDE.md` symlinked to it) capturing knowledge that cost real time to rediscover while cutting v0.21.39.

**The substantive entry** is the barrel/optional-peer trap. `src/index.tsx` re-exports nearly everything, so a module-scope import of an *optional* peer in any reachable file makes `import { anything } from '@sistent/sistent'` throw for consumers who did not install it - naming sistent rather than the missing peer. #1732 fixed this for `@mui/x-date-pickers`; #1735 is the remaining `date-fns` instance.

The reason it is worth writing down: **CI cannot catch it**, because this repo always has its own devDependencies installed. It only appears in a downstream clean install. The note includes the one-line check that does catch it.

Also records:
- a pointer to the existing release runbook at `.claude/skills/cut-release/SKILL.md` rather than restating it
- that `prettier --check` (~82 files) and `tsc --noEmit` fail repo-wide today and are **not** CI gates, so contributors do not assume they broke something or mass-reformat to "fix" it

No code or config change.

Signed-off-by: Ahmed Jamil <197998703+CodeAhmedJamil@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the new root guidance document into a detailed “agent memory” release workflow, including how to determine what’s currently released, how release verification is performed by inspecting the build output, and rules for handling optional peer constraints.
  * Updated the assistant guidance entry to reference the new source of truth via a symbolic link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->