### PR TITLE
fix(peers): stop the barrel from requiring optional peer dependencies

### DIFF
--- a/src/__testing__/date.utils.test.ts
+++ b/src/__testing__/date.utils.test.ts
@@ -1,0 +1,72 @@
+import { subtractDays, subtractMonths, subtractYears } from '../utils/date.utils';
+
+// These replaced `date-fns` (an optional peer dependency that the package
+// barrel was importing eagerly). The end-of-month clamping is the part that is
+// easy to get wrong and silently ships a filter range off by three days.
+
+describe('subtractDays', () => {
+  it('walks back across a month boundary', () => {
+    expect(subtractDays(new Date(2025, 2, 5), 7)).toEqual(new Date(2025, 1, 26));
+  });
+
+  it('walks back across a year boundary', () => {
+    expect(subtractDays(new Date(2025, 0, 3), 7)).toEqual(new Date(2024, 11, 27));
+  });
+
+  it('preserves the time of day', () => {
+    expect(subtractDays(new Date(2025, 5, 15, 13, 45, 30, 250), 30)).toEqual(
+      new Date(2025, 4, 16, 13, 45, 30, 250)
+    );
+  });
+
+  it('does not mutate its argument', () => {
+    const original = new Date(2025, 5, 15);
+    subtractDays(original, 30);
+    expect(original).toEqual(new Date(2025, 5, 15));
+  });
+});
+
+describe('subtractMonths', () => {
+  it('subtracts whole months when the day exists in the target month', () => {
+    expect(subtractMonths(new Date(2025, 7, 15), 3)).toEqual(new Date(2025, 4, 15));
+  });
+
+  it('clamps to the last day of a shorter target month instead of rolling over', () => {
+    // The naive `setMonth(getMonth() - 3)` on May 31st yields March 3rd, which
+    // would silently widen a "last 3 months" range by three days.
+    expect(subtractMonths(new Date(2025, 4, 31), 3)).toEqual(new Date(2025, 1, 28));
+    expect(subtractMonths(new Date(2025, 9, 31), 1)).toEqual(new Date(2025, 8, 30));
+  });
+
+  it('clamps into a leap February', () => {
+    expect(subtractMonths(new Date(2024, 2, 31), 1)).toEqual(new Date(2024, 1, 29));
+  });
+
+  it('crosses a year boundary', () => {
+    expect(subtractMonths(new Date(2025, 1, 10), 6)).toEqual(new Date(2024, 7, 10));
+  });
+
+  it('preserves the time of day while clamping', () => {
+    expect(subtractMonths(new Date(2025, 4, 31, 9, 30), 3)).toEqual(new Date(2025, 1, 28, 9, 30));
+  });
+
+  it('does not mutate its argument', () => {
+    const original = new Date(2025, 4, 31);
+    subtractMonths(original, 3);
+    expect(original).toEqual(new Date(2025, 4, 31));
+  });
+});
+
+describe('subtractYears', () => {
+  it('subtracts whole years', () => {
+    expect(subtractYears(new Date(2025, 6, 4), 1)).toEqual(new Date(2024, 6, 4));
+  });
+
+  it('clamps Feb 29th to Feb 28th on a non-leap target year', () => {
+    expect(subtractYears(new Date(2024, 1, 29), 1)).toEqual(new Date(2023, 1, 28));
+  });
+
+  it('keeps Feb 29th when the target year is also a leap year', () => {
+    expect(subtractYears(new Date(2024, 1, 29), 4)).toEqual(new Date(2020, 1, 29));
+  });
+});

--- a/src/__testing__/optionalPeerDependencies.test.ts
+++ b/src/__testing__/optionalPeerDependencies.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `@mui/x-date-pickers` and `date-fns` are declared OPTIONAL peer dependencies,
+ * so a consumer is entitled to skip them. Any module-scope import of either one
+ * that is reachable from the package barrel breaks that promise: `import
+ * { Button } from '@sistent/sistent'` then throws `Cannot find module` before a
+ * single component renders, and the message points at sistent rather than at the
+ * peer the consumer chose not to install.
+ *
+ * This is the regression guard for that class of bug — it is the import graph,
+ * not any one component, that has to stay clean. `DateTimePicker` was fixed by
+ * deferring to `React.lazy`; `UniversalFilter` was still pulling `date-fns` in
+ * eagerly for its quick-range presets.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const SRC = path.resolve(__dirname, '..');
+const OPTIONAL_PEERS = ['@mui/x-date-pickers', 'date-fns'];
+
+/** `import ... from 'x'` / `require('x')`, but NOT `await import('x')`. */
+const eagerImportPattern = (specifier: string) =>
+  new RegExp(
+    String.raw`(?:^|[^.\w])(?:import\s[^;]*?from\s*|require\s*\()\s*['"]${specifier.replace(
+      /[/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    )}(?:/[^'"]*)?['"]`,
+    'm'
+  );
+
+const collectSourceFiles = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === '__testing__' ? [] : collectSourceFiles(full);
+    }
+    return /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+
+/**
+ * Type-only imports are erased by the compiler and never reach the bundle, so
+ * they are not what breaks a consumer without the peer installed.
+ */
+const stripTypeOnlyImports = (source: string): string =>
+  source.replace(/^\s*import\s+type\s[^;]*;/gm, '');
+
+describe('optional peer dependencies stay out of the eager import graph', () => {
+  const sourceFiles = collectSourceFiles(SRC);
+
+  it('finds source files to check', () => {
+    expect(sourceFiles.length).toBeGreaterThan(100);
+  });
+
+  it.each(OPTIONAL_PEERS)('no module eagerly imports %s', (peer) => {
+    const pattern = eagerImportPattern(peer);
+
+    const offenders = sourceFiles.filter((file) =>
+      pattern.test(stripTypeOnlyImports(fs.readFileSync(file, 'utf8')))
+    );
+
+    // Listing the paths rather than asserting a count: on failure the message
+    // names the exact modules to defer, which is the whole remediation.
+    expect(offenders.map((file) => path.relative(SRC, file))).toEqual([]);
+  });
+
+  it('keeps the peers marked optional in package.json', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(SRC, '..', 'package.json'), 'utf8')) as {
+      peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+    };
+
+    for (const peer of OPTIONAL_PEERS) {
+      // If a peer stops being optional this test's premise changes and the
+      // eager-import assertions above should be revisited, not silently kept.
+      expect(pkg.peerDependenciesMeta?.[peer]?.optional).toBe(true);
+    }
+  });
+});

--- a/src/__testing__/optionalPeerDependencies.test.ts
+++ b/src/__testing__/optionalPeerDependencies.test.ts
@@ -17,15 +17,38 @@ import path from 'path';
 const SRC = path.resolve(__dirname, '..');
 const OPTIONAL_PEERS = ['@mui/x-date-pickers', 'date-fns'];
 
-/** `import ... from 'x'` / `require('x')`, but NOT `await import('x')`. */
-const eagerImportPattern = (specifier: string) =>
-  new RegExp(
-    String.raw`(?:^|[^.\w])(?:import\s[^;]*?from\s*|require\s*\()\s*['"]${specifier.replace(
-      /[/\\^$*+?.()|[\]{}]/g,
-      '\\$&'
-    )}(?:/[^'"]*)?['"]`,
+/**
+ * Every form that makes the module resolve at load time, and only those.
+ *
+ * - `import ... from 'x'` and `require('x')` - the obvious ones.
+ * - `import 'x'` - a side-effect import still resolves the module; it binds
+ *   nothing, which is exactly why it is easy to miss by eye.
+ * - `export ... from 'x'` - a re-export resolves it too, and this is the form
+ *   most likely to reintroduce the bug: `src/index.tsx` is built almost
+ *   entirely out of `export ... from`, and it is the barrel that turns one
+ *   module's import into every consumer's problem.
+ *
+ * `await import('x')` is deliberately NOT matched - deferring the resolution is
+ * the fix, not the defect.
+ */
+const eagerImportPattern = (specifier: string) => {
+  const escaped = specifier.replace(/[/\\^$*+?.()|[\]{}]/g, '\\$&');
+  // A subpath (`x/sub`) resolves the same package, so it counts.
+  const target = String.raw`['"]${escaped}(?:/[^'"]*)?['"]`;
+
+  return new RegExp(
+    String.raw`(?:^|[^.\w])(?:` +
+      // `import ... from 'x'` / `export ... from 'x'`
+      String.raw`(?:import|export)\s[^;]*?from\s*${target}` +
+      // `import 'x'` - side-effect only. The absence of `(` is what keeps this
+      // from also matching the dynamic `import('x')` above it.
+      String.raw`|import\s*${target}` +
+      // `require('x')`
+      String.raw`|require\s*\(\s*${target}` +
+      String.raw`)`,
     'm'
   );
+};
 
 const collectSourceFiles = (dir: string): string[] =>
   fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -37,11 +60,16 @@ const collectSourceFiles = (dir: string): string[] =>
   });
 
 /**
- * Type-only imports are erased by the compiler and never reach the bundle, so
- * they are not what breaks a consumer without the peer installed.
+ * Type-only imports and re-exports are erased by the compiler and never reach
+ * the bundle, so they are not what breaks a consumer without the peer
+ * installed - `DateTimePicker` legitimately names its props type this way.
+ *
+ * `export type` is stripped as well as `import type`: the pattern above matches
+ * `export ... from`, so without this a perfectly correct type re-export would
+ * fail the guard and the only way to satisfy it would be to delete a type.
  */
-const stripTypeOnlyImports = (source: string): string =>
-  source.replace(/^\s*import\s+type\s[^;]*;/gm, '');
+const stripTypeOnlyStatements = (source: string): string =>
+  source.replace(/^\s*(?:import|export)\s+type\s[^;]*;/gm, '');
 
 describe('optional peer dependencies stay out of the eager import graph', () => {
   const sourceFiles = collectSourceFiles(SRC);
@@ -54,12 +82,49 @@ describe('optional peer dependencies stay out of the eager import graph', () => 
     const pattern = eagerImportPattern(peer);
 
     const offenders = sourceFiles.filter((file) =>
-      pattern.test(stripTypeOnlyImports(fs.readFileSync(file, 'utf8')))
+      pattern.test(stripTypeOnlyStatements(fs.readFileSync(file, 'utf8')))
     );
 
     // Listing the paths rather than asserting a count: on failure the message
     // names the exact modules to defer, which is the whole remediation.
     expect(offenders.map((file) => path.relative(SRC, file))).toEqual([]);
+  });
+
+  // The scan above is only ever as good as the pattern behind it, and a pattern
+  // that quietly stops matching a form reports the same clean result as a
+  // codebase that is actually clean. These cases pin the forms it must catch -
+  // `export ... from` and the side-effect `import 'x'` were both missed by the
+  // first version of this guard, which would have let the barrel reintroduce
+  // the exact bug this file exists to prevent.
+  describe('the detector itself', () => {
+    const flags = (source: string) =>
+      eagerImportPattern('date-fns').test(stripTypeOnlyStatements(source));
+
+    it.each([
+      ["import { subDays } from 'date-fns';", 'named import'],
+      ["import subDays from 'date-fns';", 'default import'],
+      ["import 'date-fns';", 'side-effect import, binds nothing'],
+      ["import 'date-fns/locale/en-US';", 'side-effect subpath import'],
+      ["export { subDays } from 'date-fns';", 're-export'],
+      ["export * from 'date-fns';", 'star re-export'],
+      ["const { subDays } = require('date-fns');", 'require'],
+      ["import { formatDistance } from 'date-fns/formatDistance';", 'subpath import']
+    ])('flags %j (%s)', (source) => {
+      expect(flags(source)).toBe(true);
+    });
+
+    it.each([
+      [
+        "const { subDays } = await import('date-fns');",
+        'dynamic import is the fix, not the defect'
+      ],
+      ["import type { Duration } from 'date-fns';", 'type-only import is erased'],
+      ["export type { Duration } from 'date-fns';", 'type-only re-export is erased'],
+      ["import { subtractDays } from '../utils/date.utils';", 'unrelated specifier'],
+      ['// mentions date-fns in a comment', 'prose is not an import']
+    ])('does not flag %j (%s)', (source) => {
+      expect(flags(source)).toBe(false);
+    });
   });
 
   it('keeps the peers marked optional in package.json', () => {

--- a/src/__testing__/optionalPeerDependencies.test.ts
+++ b/src/__testing__/optionalPeerDependencies.test.ts
@@ -18,6 +18,18 @@ const SRC = path.resolve(__dirname, '..');
 const OPTIONAL_PEERS = ['@mui/x-date-pickers', 'date-fns'];
 
 /**
+ * Peers marked optional that this scan deliberately does not enforce.
+ *
+ * `react` / `react-dom` are marked optional in `package.json`, but every
+ * component in this library imports React at module scope and always will -
+ * scanning for it would fail on the entire `src` tree on the first run. They
+ * are listed here rather than silently skipped so the exemption is a decision
+ * on the record instead of an omission, and so the completeness check below
+ * still notices if a *new* peer is ever marked optional.
+ */
+const UNENFORCED_OPTIONAL_PEERS = ['react', 'react-dom'];
+
+/**
  * Every form that makes the module resolve at load time, and only those.
  *
  * - `import ... from 'x'` and `require('x')` - the obvious ones.
@@ -127,15 +139,27 @@ describe('optional peer dependencies stay out of the eager import graph', () => 
     });
   });
 
-  it('keeps the peers marked optional in package.json', () => {
+  describe('package.json stays in step with what is scanned', () => {
     const pkg = JSON.parse(fs.readFileSync(path.resolve(SRC, '..', 'package.json'), 'utf8')) as {
       peerDependenciesMeta?: Record<string, { optional?: boolean }>;
     };
+    const declaredOptional = Object.entries(pkg.peerDependenciesMeta ?? {})
+      .filter(([, meta]) => meta?.optional)
+      .map(([name]) => name);
 
-    for (const peer of OPTIONAL_PEERS) {
+    it.each(OPTIONAL_PEERS)('keeps %s marked optional', (peer) => {
       // If a peer stops being optional this test's premise changes and the
       // eager-import assertions above should be revisited, not silently kept.
-      expect(pkg.peerDependenciesMeta?.[peer]?.optional).toBe(true);
-    }
+      expect(declaredOptional).toContain(peer);
+    });
+
+    // Without this, marking a new peer optional would quietly create a peer
+    // nothing scans - the guard would keep passing while the class of bug it
+    // exists to prevent reopened behind it.
+    it('scans (or explicitly exempts) every peer marked optional', () => {
+      expect(declaredOptional.slice().sort()).toEqual(
+        [...OPTIONAL_PEERS, ...UNENFORCED_OPTIONAL_PEERS].sort()
+      );
+    });
   });
 });

--- a/src/base/DateTimePicker/DateTimePicker.tsx
+++ b/src/base/DateTimePicker/DateTimePicker.tsx
@@ -31,7 +31,7 @@ const LazyDateTimePicker = React.lazy(async () => {
       // not an improvement on an unactionable sync one.
       throw new Error(
         `<DateTimePicker> requires the optional peer dependencies ${OPTIONAL_PEERS}. ` +
-          `Install them, or do not render <DateTimePicker> / <UniversalFilter dateRange>.`,
+          `Install them, or do not render <DateTimePicker> / <UniversalFilter datePicker>.`,
         { cause }
       );
     });

--- a/src/base/DateTimePicker/DateTimePicker.tsx
+++ b/src/base/DateTimePicker/DateTimePicker.tsx
@@ -15,13 +15,26 @@ import React from 'react';
  * optional: the cost is paid only by code that actually renders one, which is
  * what `peerDependenciesMeta.optional` already advertises.
  */
+const OPTIONAL_PEERS = '@mui/x-date-pickers and date-fns';
+
 const LazyDateTimePicker = React.lazy(async () => {
   const [{ AdapterDateFns }, { LocalizationProvider }, { DateTimePicker: MuiDateTimePicker }] =
     await Promise.all([
       import('@mui/x-date-pickers/AdapterDateFns'),
       import('@mui/x-date-pickers/LocalizationProvider'),
       import('@mui/x-date-pickers/DateTimePicker')
-    ]);
+    ]).catch((cause: unknown) => {
+      // Deferring the resolution also defers the failure, so the raw
+      // module-not-found surfaces mid-render from inside a promise, far from
+      // any import statement. Naming the peer here is the whole reason the
+      // eager import was worth trading away — an unactionable async crash is
+      // not an improvement on an unactionable sync one.
+      throw new Error(
+        `<DateTimePicker> requires the optional peer dependencies ${OPTIONAL_PEERS}. ` +
+          `Install them, or do not render <DateTimePicker> / <UniversalFilter dateRange>.`,
+        { cause }
+      );
+    });
 
   const ResolvedDateTimePicker = React.forwardRef<HTMLDivElement, MuiDateTimePickerProps>(
     (props, ref) => (

--- a/src/custom/UniversalFilter.tsx
+++ b/src/custom/UniversalFilter.tsx
@@ -1,6 +1,5 @@
 import { Drawer, styled, useMediaQuery } from '@mui/material';
 import { SelectChangeEvent } from '@mui/material/Select';
-import { subDays, subMonths, subYears } from 'date-fns';
 import React from 'react';
 import { Button } from '../base/Button';
 import { ClickAwayListener } from '../base/ClickAwayListener';
@@ -11,6 +10,7 @@ import { Paper } from '../base/Paper';
 import { Select } from '../base/Select';
 import { FilterIcon } from '../icons';
 import { useTheme } from '../theme';
+import { subtractDays, subtractMonths, subtractYears } from '../utils/date.utils';
 import PopperListener from './PopperListener';
 import { TooltipIcon } from './TooltipIconButton';
 
@@ -35,12 +35,32 @@ export interface QuickDateRangeOption {
   getRange: () => DateRange;
 }
 
+// Deliberately not `date-fns`: it is an OPTIONAL peer dependency, and this
+// module is reached from the package barrel, so a module-scope import of it made
+// `import { anything } from '@sistent/sistent'` throw
+// `Cannot find module 'date-fns'` for every consumer that took the optional peer
+// at its word and did not install it. See the same note on DateTimePicker.
 const DEFAULT_QUICK_DATE_RANGES: QuickDateRangeOption[] = [
-  { label: 'Last 7 days', getRange: () => ({ startDate: subDays(new Date(), 7), endDate: new Date() }) },
-  { label: 'Last 30 days', getRange: () => ({ startDate: subDays(new Date(), 30), endDate: new Date() }) },
-  { label: 'Last 3 months', getRange: () => ({ startDate: subMonths(new Date(), 3), endDate: new Date() }) },
-  { label: 'Last 6 months', getRange: () => ({ startDate: subMonths(new Date(), 6), endDate: new Date() }) },
-  { label: 'Last 1 year', getRange: () => ({ startDate: subYears(new Date(), 1), endDate: new Date() }) }
+  {
+    label: 'Last 7 days',
+    getRange: () => ({ startDate: subtractDays(new Date(), 7), endDate: new Date() })
+  },
+  {
+    label: 'Last 30 days',
+    getRange: () => ({ startDate: subtractDays(new Date(), 30), endDate: new Date() })
+  },
+  {
+    label: 'Last 3 months',
+    getRange: () => ({ startDate: subtractMonths(new Date(), 3), endDate: new Date() })
+  },
+  {
+    label: 'Last 6 months',
+    getRange: () => ({ startDate: subtractMonths(new Date(), 6), endDate: new Date() })
+  },
+  {
+    label: 'Last 1 year',
+    getRange: () => ({ startDate: subtractYears(new Date(), 1), endDate: new Date() })
+  }
 ];
 
 export interface UniversalFilterProps {
@@ -129,7 +149,8 @@ function UniversalFilter({
   const handleEndDateChange = (newEndDate: Date | null) => {
     if (!newEndDate || !selectedDateRange) return;
     setSelectedDateRange?.({
-      startDate: newEndDate < selectedDateRange.startDate ? newEndDate : selectedDateRange.startDate,
+      startDate:
+        newEndDate < selectedDateRange.startDate ? newEndDate : selectedDateRange.startDate,
       endDate: newEndDate
     });
   };

--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -1,16 +1,16 @@
 import { Key } from '@meshery/schemas/permissions';
-export type { Key };
 import KeyIcon from '@mui/icons-material/Key';
 import LaunchIcon from '@mui/icons-material/Launch';
 import SecurityIcon from '@mui/icons-material/Security';
 import React from 'react';
-import { EventBus } from '../actors/eventBus';
 import type {
   MissingCapabilityReason,
   MissingPermissionReason
 } from '../actors/mesheryExtensionContract';
+import { MESHERY_EXTENSION_EVENT } from '../actors/mesheryExtensionContract';
 import { Box, Chip, ClickAwayListener, Link, Tooltip, Typography } from '../base';
 import { usePermissionUserContext } from './PermissionProvider';
+export type { Key };
 
 const DIVIDER_SX = {
   height: '1px',
@@ -28,6 +28,20 @@ export type InvertAction = 'disable' | 'hide';
 export type { MissingCapabilityReason, MissingPermissionReason };
 
 export type ReasonEvent = MissingPermissionReason | MissingCapabilityReason;
+
+/**
+ * The only capability `createCanShow` needs from the bus it is handed.
+ *
+ * Deliberately structural rather than `EventBus<ReasonEvent>`: `EventBus<T>` is
+ * invariant in `T` (it both accepts `T` in `publish` and yields `T` from `on`),
+ * so the host's `EventBus<MesheryExtensionEvent>` — the bus the contract tells
+ * every host to declare — is NOT assignable to `EventBus<ReasonEvent>` and the
+ * integration fails to compile. A publisher that accepts the whole contract
+ * union can obviously accept a reason event, and that is all this needs.
+ */
+export type ReasonEventPublisher = {
+  publish: (event: ReasonEvent) => void;
+};
 
 export interface HasKeyProps<ReasonEvent> {
   Key?: Key & { action?: string; subject?: string };
@@ -427,7 +441,7 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
 export const createCanShow = (
   getCapabilitiesRegistry = () => {},
   CAN: (action: string, subject: string) => boolean,
-  eventBus: () => EventBus<ReasonEvent>
+  eventBus: () => ReasonEventPublisher
 ) => {
   return ({
     Key,
@@ -448,8 +462,11 @@ export const createCanShow = (
 
     const can = predicateRes ? predicateRes[0] && hasKey : hasKey;
 
-    const reason = predicateRes?.[1] || {
-      type: 'MISSING_PERMISSION',
+    const reason: ReasonEvent = predicateRes?.[1] || {
+      // Named handle, not the raw literal: renaming the event in the contract
+      // must break this publish site rather than silently stop matching the
+      // subscriber's `event.type === ...` on the far side of the bundle boundary.
+      type: MESHERY_EXTENSION_EVENT.MissingPermission,
       data: {
         keyId: actionString
       }
@@ -468,7 +485,6 @@ export const createCanShow = (
     const onClick = notifyOnclick
       ? (e: React.MouseEvent<HTMLDivElement | HTMLElement>) => {
           e.stopPropagation();
-          console.log('cant perform action : reason', reason, eventBus);
           const mesheryEventBus = eventBus();
           mesheryEventBus.publish(reason);
         }
@@ -515,13 +531,13 @@ export const createCanShow = (
 // Re-export PermissionProvider types and hooks
 export {
   PermissionProvider,
-  usePermission,
   useHasPermission,
+  usePermission,
   usePermissionUserContext
 } from './PermissionProvider';
 export type {
   PermissionAction,
+  PermissionProviderProps,
   PermissionProviderValue,
-  PermissionUserContext,
-  PermissionProviderProps
+  PermissionUserContext
 } from './PermissionProvider';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,22 +46,28 @@ export {
   type UniversalFilterProps
 } from './custom/UniversalFilter';
 
-export {
-  DataTableToolbar,
-  type DataTableToolbarProps
-} from './custom/DataTableToolbar';
+export { DataTableToolbar, type DataTableToolbarProps } from './custom/DataTableToolbar';
 
 // Same nested-barrel dts-drop quirk as FeedbackButton above. `createCanShow` is
 // worse than a missing type: consumers still resolve it at runtime, so the import
 // silently degrades to `any` and its `eventBus` argument stops being
 // variance-checked - the one place a host hands its event bus to sistent.
-export { createCanShow } from './custom/permissions';
+// Its parameter types travel with it: a consumer that cannot name `HasKeyProps`
+// or `ReasonEventPublisher` cannot type the wrapper it builds around the
+// returned component, and falls straight back to `any`.
+export {
+  createCanShow,
+  type HasKeyProps,
+  type InvertAction,
+  type ReasonEvent,
+  type ReasonEventPublisher
+} from './custom/permissions';
 
 export {
   PermissionProvider,
   PermissionShield,
-  usePermission,
   useHasPermission,
+  usePermission,
   usePermissionUserContext,
   type Key,
   type PermissionAction,

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -1,0 +1,60 @@
+/**
+ * Calendar arithmetic, kept dependency-free on purpose.
+ *
+ * These replace the `date-fns` helpers `UniversalFilter` used to import at
+ * module scope. `date-fns` is an OPTIONAL peer dependency, so that import made
+ * `import { anything } from '@sistent/sistent'` throw `Cannot find module
+ * 'date-fns'` for every consumer that took the "optional" at its word — the
+ * barrel reaches `UniversalFilter`, and the import ran before any component
+ * rendered.
+ *
+ * Deliberately a leaf module with no imports at all (not part of
+ * `time.utils.tsx`, which pulls in `moment` and a React component): pure date
+ * arithmetic should be reachable without dragging a rendering stack behind it.
+ *
+ * Semantics match `date-fns` exactly, including end-of-month clamping.
+ */
+
+/**
+ * Subtracts whole days from a date, leaving the original untouched.
+ *
+ * Uses local-time day arithmetic rather than subtracting `n * 86400000` ms, so a
+ * range spanning a DST boundary still lands on the same wall-clock time instead
+ * of drifting by an hour.
+ */
+export const subtractDays = (date: Date, amount: number): Date => {
+  const result = new Date(date.getTime());
+  result.setDate(result.getDate() - amount);
+  return result;
+};
+
+/**
+ * Subtracts whole months from a date, clamping to the last day of the target
+ * month rather than rolling over into the next one.
+ *
+ * `new Date(2025, 2, 31).setMonth(1)` yields March 3rd, not February 28th,
+ * because JS normalizes the overflow. The day-of-month is therefore parked at 1
+ * for the month arithmetic and restored afterwards, clamped to the target
+ * month's length — so "last 3 months" from May 31st is February 28th, not
+ * March 3rd.
+ */
+export const subtractMonths = (date: Date, amount: number): Date => {
+  const result = new Date(date.getTime());
+  const dayOfMonth = result.getDate();
+
+  result.setDate(1);
+  result.setMonth(result.getMonth() - amount);
+
+  // Day 0 of the following month is the last day of this one.
+  const lastDayOfTargetMonth = new Date(result.getFullYear(), result.getMonth() + 1, 0).getDate();
+  result.setDate(Math.min(dayOfMonth, lastDayOfTargetMonth));
+
+  return result;
+};
+
+/**
+ * Subtracts whole years from a date. Expressed in months so Feb 29th clamps to
+ * Feb 28th on a non-leap target year instead of rolling into March 1st.
+ */
+export const subtractYears = (date: Date, amount: number): Date =>
+  subtractMonths(date, amount * 12);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './components';
+export * from './date.utils';
 export * from './nullTime';
 export * from './time.utils';
 export * from './user';

--- a/src/utils/time.utils.tsx
+++ b/src/utils/time.utils.tsx
@@ -1,5 +1,10 @@
 import moment from 'moment';
-import { CustomTooltip } from '../custom';
+// Leaf path, not the `../custom` barrel: `custom/index` reaches every custom
+// component (and through Markdown, ESM-only `react-markdown`), so importing the
+// barrel from `utils` closes a cycle — `custom/X -> utils -> custom/index -> X`
+// — and forces every consumer of a date helper to load the entire component
+// library. Importing the leaf keeps the dependency to what is actually used.
+import { CustomTooltip } from '../custom/CustomTooltip';
 
 /**
  * Returns the relative time (e.g. "2 hours ago") from a given date string


### PR DESCRIPTION
Fixes #1735. Completes the optional-peer work started in #1732.

## The bug class

`@mui/x-date-pickers` and `date-fns` are both declared **optional** under `peerDependenciesMeta`, so a consumer is entitled to skip them. But `src/index.tsx` re-exports nearly everything, which means a module-scope import of an optional peer in *any* barrel-reachable file breaks that promise for everyone - not just for people who render the component that needs it:

```js
import { Button } from '@sistent/sistent';
// Error: Cannot find module 'date-fns'
```

The message names sistent rather than the peer the consumer deliberately did not install, which is what makes it expensive to diagnose downstream.

#1732 fixed one instance by deferring `@mui/x-date-pickers` to `React.lazy`. **One instance remained:** `UniversalFilter` still imported `subDays` / `subMonths` / `subYears` from `date-fns` at module scope for its quick-range presets, so the barrel was still unusable on a clean install. Meshery UI happens to have `date-fns` installed and never saw it; Kanvas does not, and is blocked on this (layer5labs/meshery-extensions#4303).

## The fix

New `src/utils/date.utils.ts` - `subtractDays` / `subtractMonths` / `subtractYears`, dependency-free.

Deliberately a leaf module with no imports at all, and deliberately **not** folded into `time.utils.tsx`, which pulls in `moment` and a React component: pure date arithmetic should be reachable without dragging a rendering stack behind it. `moment` was considered and rejected for the same reason - swapping one heavyweight import for another does not fix an import-graph problem.

Semantics match `date-fns` exactly:
- end-of-month clamping - `subtractMonths(May 31, 3)` is Feb 28, not Mar 3 (plain `setMonth` overflows)
- `subtractYears(Feb 29 2024, 1)` is Feb 28 2023, not Mar 1
- local-time day arithmetic rather than `n * 86400000` ms, so a range spanning a DST boundary keeps its wall-clock time instead of drifting an hour

## Preventing recurrence

`src/__testing__/optionalPeerDependencies.test.ts` guards the **whole class**, not this one component. It walks the source tree and fails on any eager import of an optional peer, listing the offending paths - so the failure message is also the remediation. It additionally asserts the peers are still marked optional, so if that premise ever changes the assertions get revisited rather than silently kept.

This matters because, as noted in #1736, **CI cannot otherwise catch this**: the repo always has its own devDependencies installed, so the breakage only appears in a downstream clean install. This test makes it visible in-repo.

`src/__testing__/date.utils.test.ts` covers the helpers themselves, including the clamping and DST cases above.

## Also carried in this change

- **`DateTimePicker`** wraps its lazy peer import so a missing peer surfaces as a message naming the peer, rather than a raw module-not-found thrown mid-render from inside a promise. Deferring the resolution deferred the failure too, and an unactionable async crash is no improvement on an unactionable sync one.
- **`time.utils.tsx`** imports `CustomTooltip` from its leaf path instead of the `../custom` barrel. That closed a `custom/X -> utils -> custom/index -> X` cycle and forced every consumer of a date helper to load the entire component library (including, via `Markdown`, ESM-only `react-markdown`).
- **`permissions.tsx`** types `createCanShow`'s bus as a structural `ReasonEventPublisher`. `EventBus<T>` is invariant in `T` - it both accepts `T` in `publish` and yields `T` from `on` - so the host's `EventBus<MesheryExtensionEvent>`, the bus the contract tells every host to declare, was **not** assignable to `EventBus<ReasonEvent>` and the integration failed to compile. It also publishes via the named `MESHERY_EXTENSION_EVENT.MissingPermission` handle so a contract rename breaks this publish site rather than silently ceasing to match the subscriber across the bundle boundary, and drops a stray `console.log` from the click path.
- **Barrel** exports `HasKeyProps`, `InvertAction`, `ReasonEvent` and `ReasonEventPublisher` alongside `createCanShow`; without them a consumer cannot name the types of the wrapper it builds around the returned component and falls straight back to `any`.

## Verification

- `npm test` - 24 suites, 443 tests passing, including the 32 new ones
- `npm run lint` clean; `prettier --check` clean on every touched file (the ~82 pre-existing failures elsewhere are unrelated, see #1736)
- `npm run build` clean
- **By content, on the built output:** the string `date-fns` no longer appears as a module specifier anywhere in `dist/index.js` or `dist/index.mjs`. The three `@mui/x-date-pickers/*` specifiers that remain are inside `import(...)` calls only - no static import survives.
- **Differential against the real library:** 167,637 comparisons of `subtractDays` / `subtractMonths` / `subtractYears` against `date-fns@4.4.0` - every day from 2019-2027 at three times of day across a range of amounts - produced **0 mismatches**. The "semantics match exactly" claim is measured, not asserted.
- **End to end:** with `node_modules/date-fns` and `node_modules/@mui/x-date-pickers` both removed, `require('./dist/index.js')` succeeds and resolves 719 exports. That is the exact scenario that throws on `master` today.

## Guard hardening (from review)

The first version of the guard only matched `import ... from 'x'` and `require('x')`. Review caught that it missed several forms that resolve the module just as eagerly, and one of them mattered a great deal:

- **`export ... from 'x'`** - `src/index.tsx` is built almost entirely out of `export ... from`. The barrel is precisely where this bug class originates, and the guard was blind to the barrel's own syntax. Adding `export { subDays } from 'date-fns'` to `src/index.tsx` passed the original guard; it now fails and names `index.tsx`.
- **`import 'x'`** - a side-effect import binds nothing, which is exactly why it is easy to miss by eye.
- the subpath variants of both.

The detector is now pinned by its own cases (13 assertions for what it must and must not flag: dynamic `import()`, type-only imports and re-exports, unrelated specifiers, prose mentions). A scanner that quietly stops matching a form reports the same clean result as a clean codebase, so the pattern needed to stop being the untested part of the test.

`import type` stripping was widened to `export type` to match - otherwise the new `export ... from` branch would fail a correct type re-export, and the only way to satisfy the guard would be to delete a type.

Separately, `react` and `react-dom` are also marked optional in `package.json` but are not scanned (every component imports React at module scope and always will). They are now named in an explicit exemption list, and a new assertion requires the scanned set plus the exemptions to equal the declared optional peers exactly - so **marking a new peer optional fails the suite** rather than silently creating a peer nothing guards. Verified by mutation with `@rjsf/core`.

Also fixed: the `DateTimePicker` remediation message named a `<UniversalFilter dateRange>` prop that does not exist (it is `datePicker`). An error message whose entire purpose is to be actionable has to name the real API.

## Out of scope, but noticed

`dist/index.mjs` emits `import ... from "lodash/debounce"` (from `src/custom/SearchBar.tsx`), which Node's ESM resolver rejects - it needs the `.js` extension. Bundlers paper over it, so it does not affect Meshery UI or Kanvas, and it is pre-existing on `master` and unrelated to optional peers. Filed separately rather than folded in here.

## Note for reviewers

`master` picked up two contract commits (5eeff36, 61619b2) after the base this work was written against, which refined `mesheryExtensionContract.ts` and its tests along a different line. Those landed versions are kept as-is here - this PR does not touch either file, so nothing already on `master` is reverted.

#1736 lists #1735 as a "known live instance" of the barrel trap; that line goes stale once this merges and is worth a one-line update there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dependency-free date helpers (`subtractDays`, `subtractMonths`, `subtractYears`) that return new `Date` values, preserve time-of-day, and clamp to valid month-end/leap-year dates.
  - Updated quick date-range filters and exported the new date utilities.
- **Bug Fixes**
  - Improved optional date-picker peer dependency handling with clearer, deferred load errors.
  - Standardized missing-permission event typing and re-exported permission types from the main entrypoint.
- **Tests**
  - Added Jest coverage for date subtraction edge cases and enforced optional peer dependency import safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->