### PR TITLE
fix: move permission shield to bottom-left for disabled badge components

### DIFF
--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -390,8 +390,8 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
               isBadge
                 ? {
                     position: 'absolute',
-                    top: -6,
-                    right: -6,
+                    bottom: -6,
+                    left: -6,
                     backgroundColor: 'rgba(30, 30, 30, 0.9)',
                     color: '#808080',
                     borderRadius: '50%',


### PR DESCRIPTION
**Notes for Reviewers**
## Description

Moves the permission shield overlay for the `badge` variant from the top-right corner to the bottom-left corner, matching the expected UI described in #1731.

### Changes
- Updated the `PermissionShield` badge positioning:
  - `top: -6` → `bottom: -6`
  - `right: -6` → `left: -6`


This PR fixes #1731 

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [X] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the permission shield badge overlay positioning to better align visually.  
  * The “badge” variant now uses a different offset direction (moving the overlay to the opposite corner area) for more consistent placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->