### PR TITLE
fix(NavigationNavbar): widen NavigationItem.title to React.ReactNode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Two complementary guards, and you need both:
 scans `src/` for every load-time form (`import from`, `export ... from`, bare `import`, `require`)
 of an enforced optional peer, and fails `jest` if one appears. `await import()` is deliberately not
 matched - deferring resolution is the fix, not the defect. That file is also the source of truth for
-*which* optional peers are enforced: `react` / `react-dom` are marked optional in `package.json` but
+_which_ optional peers are enforced: `react` / `react-dom` are marked optional in `package.json` but
 exempted there on the record, because every component imports React at module scope and always will.
 
 **2. Built artifact, by hand.** The CI guard reads source, so it cannot speak for what the bundler
@@ -83,6 +83,12 @@ of examples there, e.g. `FeedbackButton`, `NavigationItem`). Verify by building 
 missing `@types/jest` wiring for `src/__testing__`). Neither is a CI gate - CI runs
 `.github/workflows/node-checks.yml` (lint + build) and `jest`. Do not assume you caused these;
 do not mass-reformat to "fix" them.
+
+A type contract can still be gated, just not by a type-only assertion file: jest transforms with
+`@swc/jest`, which strips types without checking them, so such a file passes no matter what it
+asserts. Shell out to `tsc` over a scoped fixture and filter the diagnostics to that fixture -
+[`src/__testing__/navigationItemTitleTypes.test.ts`](src/__testing__/navigationItemTitleTypes.test.ts)
+is the worked pattern, including the checks that keep the filter from turning the guard vacuous.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,21 @@ asserts. Shell out to `tsc` over a scoped fixture and filter the diagnostics to 
 [`src/__testing__/navigationItemTitleTypes.test.ts`](src/__testing__/navigationItemTitleTypes.test.ts)
 is the worked pattern, including the checks that keep the filter from turning the guard vacuous.
 
+## Every commit needs a sign-off matching its own author
+
+DCO is a blocking required check, enforced by the [probot/dco](https://github.com/probot/dco) GitHub
+App - there is no workflow file for it under `.github/`, so it is invisible from the tree until a PR
+fails. Policy is in [`CONTRIBUTING.md`](CONTRIBUTING.md#commit-signing); the sharp edges are:
+
+- The trailer must match that commit's **author** identity, so `git commit -s` under a
+  `user.email` that differs from the author still fails. `.husky/commit-msg` is deliberately empty
+  (commit `612608be`) - nothing catches this locally.
+- The usual offender is a follow-up commit (review fix, doc update, rebase fixup), not the first one.
+  Sign every commit you add, including the ones an automated pass makes for you.
+- To repair, rebase only your own commits: `git rebase --signoff <last-correctly-signed-sha>`, then
+  force-push. Rebasing the whole branch grafts your sign-off onto a co-author's commit as a second
+  trailer.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,18 +93,13 @@ is the worked pattern, including the checks that keep the filter from turning th
 
 ## Every commit needs a sign-off matching its own author
 
-DCO is a blocking required check, enforced by the [probot/dco](https://github.com/probot/dco) GitHub
-App - there is no workflow file for it under `.github/`, so it is invisible from the tree until a PR
-fails. Policy is in [`CONTRIBUTING.md`](CONTRIBUTING.md#commit-signing); the sharp edges are:
+DCO is a blocking required check with nothing enforcing it locally, and the trailer must match that
+commit's own author identity. The rule, the enforcement, and the repair recipe live in
+[`CONTRIBUTING.md`](CONTRIBUTING.md#commit-signing) - read it before rewriting history.
 
-- The trailer must match that commit's **author** identity, so `git commit -s` under a
-  `user.email` that differs from the author still fails. `.husky/commit-msg` is deliberately empty
-  (commit `612608be`) - nothing catches this locally.
-- The usual offender is a follow-up commit (review fix, doc update, rebase fixup), not the first one.
-  Sign every commit you add, including the ones an automated pass makes for you.
-- To repair, rebase only your own commits: `git rebase --signoff <last-correctly-signed-sha>`, then
-  force-push. Rebasing the whole branch grafts your sign-off onto a co-author's commit as a second
-  trailer.
+The agent-specific trap: the usual offender is a follow-up commit (review fix, doc update, rebase
+fixup), not the first one. Sign every commit you add, including the ones an automated pass makes
+for you.
 
 ## Maintaining this file
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,15 +79,16 @@ of examples there, e.g. `FeedbackButton`, `NavigationItem`). Verify by building 
 
 ## Repo state that looks broken but is pre-existing
 
-`prettier --check` fails on ~82 files and `tsc --noEmit` reports errors across `src/` (including
-missing `@types/jest` wiring for `src/__testing__`). Neither is a CI gate - CI runs
+`prettier --check` fails on dozens of files and `tsc --noEmit` reports errors across `src/`
+(including missing `@types/jest` wiring for `src/__testing__`). Neither is a CI gate - CI runs
 `.github/workflows/node-checks.yml` (lint + build) and `jest`. Do not assume you caused these;
 do not mass-reformat to "fix" them.
 
 A type contract can still be gated, just not by a type-only assertion file: jest transforms with
 `@swc/jest`, which strips types without checking them, so such a file passes no matter what it
-asserts. Shell out to `tsc` over a scoped fixture and filter the diagnostics to that fixture -
-[`src/__testing__/navigationItemTitleTypes.test.ts`](src/__testing__/navigationItemTitleTypes.test.ts)
+asserts. Shell out to `tsc` over a scoped fixture, assert the fixture is in the compiled program
+(`--listFiles`) before trusting an empty diagnostic list, then filter the diagnostics to that
+fixture - [`src/__testing__/navigationItemTitleTypes.test.ts`](src/__testing__/navigationItemTitleTypes.test.ts)
 is the worked pattern, including the checks that keep the filter from turning the guard vacuous.
 
 ## Every commit needs a sign-off matching its own author

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ address (sorry, no pseudonyms or anonymous contributions). An example of signing
 $ commit -s -m “my commit message w/signoff”
 ```
 
+The trailer must match that commit's **own author identity**. `-s` copies your current
+`user.name` / `user.email` into the trailer, so a commit authored under a different identity - a
+repo-local override, a second machine, a co-author's commit you replayed - still fails the check
+even though a `Signed-off-by:` line is present.
+
 To ensure all your commits are signed, you may choose to add this alias to your global `.gitconfig`:
 
 _~/.gitconfig_
@@ -54,6 +59,23 @@ _~/.gitconfig_
 Or you may configure your IDE, for example, Visual Studio Code to automatically sign-off commits for you:
 
 <a href="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" ><img src="https://user-images.githubusercontent.com/7570704/64490167-98906400-d25a-11e9-8b8a-5f465b854d49.png" width="50%"><a>
+
+### Repairing a failed DCO check
+
+DCO is a blocking required check, enforced by the [probot/dco](https://github.com/probot/dco)
+GitHub App rather than by a workflow - there is no file for it under `.github/`, so it is invisible
+from the repository tree until a pull request fails. `.husky/commit-msg` is deliberately empty
+(commit `612608be`), so nothing catches a missing or mismatched sign-off locally either.
+
+To repair, rebase only the commits you authored, then force-push:
+
+```
+git rebase --signoff <last-correctly-signed-sha>
+git push --force-with-lease
+```
+
+Pick that starting point deliberately. `--signoff` adds your trailer to every commit it replays, so
+rebasing the whole branch grafts your sign-off onto a co-author's commit as a second trailer.
 
 ## <a name="contributing-docs">Documentation Contribution Flow</a>
 
@@ -155,10 +177,10 @@ make lint
 
 `src/custom/ResponsiveDataTable.tsx` wraps `@mui/x-data-grid` (via `@layer5/mui-datatables`) with responsive column visibility and a standardised row action menu. Key exports:
 
-| Export | Description |
-|---|---|
-| `ResponsiveDataTable` | The main table component |
-| `TableAction` | Type for items in the per-row action menu |
+| Export                  | Description                                    |
+| ----------------------- | ---------------------------------------------- |
+| `ResponsiveDataTable`   | The main table component                       |
+| `TableAction`           | Type for items in the per-row action menu      |
 | `getCopyDeepLinkAction` | Helper that builds a "Copy link" `TableAction` |
 
 **`getCopyDeepLinkAction`**
@@ -171,7 +193,7 @@ import { getCopyDeepLinkAction, TableAction } from '@sistent/sistent';
 const rowActions: TableAction[] = [
   getCopyDeepLinkAction(() => copyRowDeepLink(row.id)),
   // or, with a custom title:
-  getCopyDeepLinkAction(() => copyRowDeepLink(row.id), t('Copy link')),
+  getCopyDeepLinkAction(() => copyRowDeepLink(row.id), t('Copy link'))
 ];
 ```
 

--- a/src/__testing__/fixtures/navigationItemTitle.tsx
+++ b/src/__testing__/fixtures/navigationItemTitle.tsx
@@ -1,0 +1,54 @@
+// Type-level fixture for `NavigationItem['title']`. It is compiled by
+// `navigationItemTitleTypes.test.ts` via `tsc --noEmit`, never executed, and is
+// deliberately outside jest's `*.test.*` glob so jest does not collect it.
+//
+// `NavigationNavbar` renders `title` into MUI's `ListItemText` `primary` slot,
+// which is typed `React.ReactNode`. Declaring `title` as `string` therefore
+// rejected composed labels that already rendered correctly - see
+// https://github.com/layer5io/sistent/issues/1746.
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import type { NavigationItem } from '../../custom/NavigationNavbar';
+
+// A plain string still compiles - the widening is source-compatible.
+export const plainStringTitle: NavigationItem = {
+  id: 'settings',
+  title: 'Settings',
+  onClick: () => {}
+};
+
+// A composed ReactNode title compiles: the exact shape that previously forced
+// consumers into an `as unknown as string` assertion.
+export const composedNodeTitle: NavigationItem = {
+  id: 'api-docs',
+  title: (
+    <span>
+      API Docs
+      <OpenInNewIcon fontSize="small" />
+    </span>
+  ),
+  onClick: () => {}
+};
+
+// Sub-items share the type, so they gain the same latitude.
+export const composedSubItemTitle: NavigationItem = {
+  id: 'docs',
+  title: 'Docs',
+  onClick: () => {},
+  subItems: [
+    {
+      id: 'docs-api',
+      title: <span>API</span>,
+      onClick: () => {}
+    }
+  ]
+};
+
+// Self-check: if the compiler ever stops type-checking this fixture, the
+// suppression below goes unused and tsc reports TS2578 here, failing the test
+// rather than letting it pass vacuously. A plain object is not a `ReactNode`.
+export const rejectsNonNode: NavigationItem = {
+  id: 'bad',
+  // @ts-expect-error - a plain object is not assignable to React.ReactNode
+  title: { label: 'not a node' },
+  onClick: () => {}
+};

--- a/src/__testing__/fixtures/tsconfig.navigationItemTitle.json
+++ b/src/__testing__/fixtures/tsconfig.navigationItemTitle.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./navigationItemTitle.tsx"]
+}

--- a/src/__testing__/navigationItemTitleTypes.test.ts
+++ b/src/__testing__/navigationItemTitleTypes.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import path from 'path';
 
 // Type-level regression guard for https://github.com/layer5io/sistent/issues/1746.
@@ -18,35 +18,83 @@ import path from 'path';
 // to this contract (see CLAUDE.md, "Repo state that looks broken but is
 // pre-existing"). The fixture's own `@ts-expect-error` self-check fails loudly if
 // the compiler ever stops checking it, so filtering cannot make this vacuous.
+//
+// Everything below the filter exists so that the guard fails closed. Filtering
+// is the one place a compiler check can quietly turn into a no-op: every outcome
+// that is not "tsc ran, compiled the fixture, and reported on it" has to be made
+// to fail rather than collapse into an empty, green list of diagnostics.
 
 const FIXTURE = 'src/__testing__/fixtures/navigationItemTitle.tsx';
 const PROJECT = 'src/__testing__/fixtures/tsconfig.navigationItemTitle.json';
 const repoRoot = path.resolve(__dirname, '..', '..');
 
-const typeCheckFixture = (): string[] => {
-  let output: string;
-  try {
-    output = execFileSync('npx', ['tsc', '-p', PROJECT], {
+// `<file>(<line>,<col>): error TS….` The file part is what scopes a diagnostic,
+// so it is parsed rather than prefix-matched: tsc prints paths relative to its
+// cwd only while the fixture stays under it, and a bare `startsWith` would read
+// any other emission as "the fixture is clean".
+const FILE_SCOPED_DIAGNOSTIC = /^(.+?)\(\d+,\d+\): error TS\d+/;
+
+// `error TS…` with no file part is a config-level failure - TS18003 "No inputs
+// were found in config file", TS5083 "Cannot read file" - and means the fixture
+// was never compiled at all. The fixture filter drops these on the floor, and
+// the fixture's `@ts-expect-error` self-check cannot see them either, because
+// neither fires unless the compiler had the fixture in its program.
+const CONFIG_SCOPED_DIAGNOSTIC = /^error TS\d+/;
+
+type Diagnostics = { fixture: string[]; config: string[] };
+
+const typeCheckFixture = (): Diagnostics => {
+  // Spawned through `process.execPath` rather than `npx`: no shell, no PATH
+  // lookup, and no `npx` vs `npx.cmd` divergence on Windows, where an ENOENT
+  // would otherwise be caught and laundered into the diagnostic output.
+  const tsc = spawnSync(
+    process.execPath,
+    [require.resolve('typescript/bin/tsc'), '-p', PROJECT, '--pretty', 'false'],
+    {
       cwd: repoRoot,
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe']
-    });
-  } catch (error) {
-    // tsc exits non-zero whenever any file in the program has an error, including
-    // the pre-existing ones outside the fixture. Read its stdout rather than
-    // treating the exit code as the verdict.
-    const spawned = error as { stdout?: string; stderr?: string; message?: string };
-    output = spawned.stdout ?? spawned.stderr ?? spawned.message ?? '';
+      // tsc reports on every file in the program, and the fixture's transitive
+      // dependencies are a large share of `src/`. The 1 MB default would kill
+      // the child mid-stream and truncate stdout - and the fixture is a root
+      // file, so its diagnostics are emitted last and lost first.
+      maxBuffer: 32 * 1024 * 1024
+    }
+  );
+
+  // A compiler that never ran is not a compiler that found nothing.
+  if (tsc.error) throw tsc.error;
+  if (tsc.status === null) {
+    throw new Error(`tsc was killed by ${tsc.signal ?? 'an unknown signal'} before reporting`);
   }
 
-  return output
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith(FIXTURE));
+  // tsc exits non-zero whenever any file in the program has an error, including
+  // the pre-existing ones outside the fixture, so the exit code is not the
+  // verdict here - the diagnostics are.
+  const lines = `${tsc.stdout}\n${tsc.stderr}`.split('\n').map((line) => line.trim());
+
+  const belongsToFixture = (line: string): boolean => {
+    const file = FILE_SCOPED_DIAGNOSTIC.exec(line)?.[1];
+    return file !== undefined && file.replace(/\\/g, '/').endsWith(FIXTURE);
+  };
+
+  return {
+    fixture: lines.filter(belongsToFixture),
+    config: lines.filter((line) => CONFIG_SCOPED_DIAGNOSTIC.test(line))
+  };
 };
 
 describe('NavigationItem title type contract', () => {
-  it('accepts both a plain string and a composed ReactNode title', () => {
-    expect(typeCheckFixture()).toEqual([]);
+  let diagnostics: Diagnostics;
+
+  beforeAll(() => {
+    diagnostics = typeCheckFixture();
   }, 180_000);
+
+  it('compiles the fixture at all', () => {
+    expect(diagnostics.config).toEqual([]);
+  });
+
+  it('accepts both a plain string and a composed ReactNode title', () => {
+    expect(diagnostics.fixture).toEqual([]);
+  });
 });

--- a/src/__testing__/navigationItemTitleTypes.test.ts
+++ b/src/__testing__/navigationItemTitleTypes.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// Type-level regression guard for https://github.com/layer5io/sistent/issues/1746.
+//
+// `NavigationNavbar` renders `NavigationItem['title']` into MUI's `ListItemText`
+// `primary` slot, which is typed `React.ReactNode`. While `title` was declared
+// `string`, composed labels rendered correctly but did not type-check, and
+// consumers reached for `as unknown as string`.
+//
+// jest transforms with @swc/jest, which strips types without checking them, so a
+// plain type-only assertion file would pass no matter what `title` is declared
+// as. This test therefore shells out to `tsc` over a fixture that exercises both
+// a plain string and a composed `ReactNode` title.
+//
+// Diagnostics are filtered to the fixture itself: type-checking it pulls in the
+// component's transitive dependencies, which carry pre-existing errors unrelated
+// to this contract (see CLAUDE.md, "Repo state that looks broken but is
+// pre-existing"). The fixture's own `@ts-expect-error` self-check fails loudly if
+// the compiler ever stops checking it, so filtering cannot make this vacuous.
+
+const FIXTURE = 'src/__testing__/fixtures/navigationItemTitle.tsx';
+const PROJECT = 'src/__testing__/fixtures/tsconfig.navigationItemTitle.json';
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const typeCheckFixture = (): string[] => {
+  let output: string;
+  try {
+    output = execFileSync('npx', ['tsc', '-p', PROJECT], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+  } catch (error) {
+    // tsc exits non-zero whenever any file in the program has an error, including
+    // the pre-existing ones outside the fixture. Read its stdout rather than
+    // treating the exit code as the verdict.
+    const spawned = error as { stdout?: string; stderr?: string; message?: string };
+    output = spawned.stdout ?? spawned.stderr ?? spawned.message ?? '';
+  }
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(FIXTURE));
+};
+
+describe('NavigationItem title type contract', () => {
+  it('accepts both a plain string and a composed ReactNode title', () => {
+    expect(typeCheckFixture()).toEqual([]);
+  }, 180_000);
+});

--- a/src/__testing__/navigationItemTitleTypes.test.ts
+++ b/src/__testing__/navigationItemTitleTypes.test.ts
@@ -41,7 +41,21 @@ const FILE_SCOPED_DIAGNOSTIC = /^(.+?)\(\d+,\d+\): error TS\d+/;
 // neither fires unless the compiler had the fixture in its program.
 const CONFIG_SCOPED_DIAGNOSTIC = /^error TS\d+/;
 
-type Diagnostics = { fixture: string[]; config: string[] };
+// Absence of diagnostics only means "nothing was wrong with what tsc compiled" -
+// it says nothing about *what* tsc compiled. A project whose `include` resolves
+// to some other existing file emits no diagnostic at all, so both lists above
+// come back empty and the guard passes without ever having looked at the
+// fixture. `--listFiles` closes that by making the program's contents an
+// assertable fact instead of an assumption.
+const asPosix = (value: string): string => value.replace(/\\/g, '/');
+
+type Diagnostics = { fixture: string[]; config: string[]; compiledFixture: boolean };
+
+// Below the 180s `beforeAll` budget. `spawnSync` blocks the jest worker outright,
+// and jest's own timeout cannot preempt a synchronous child, so a wedged tsc
+// would otherwise hold the worker until the whole run is killed. Node's timeout
+// signals the child, which surfaces as the `status === null` throw below.
+const TSC_TIMEOUT_MS = 150_000;
 
 const typeCheckFixture = (): Diagnostics => {
   // Spawned through `process.execPath` rather than `npx`: no shell, no PATH
@@ -49,14 +63,15 @@ const typeCheckFixture = (): Diagnostics => {
   // would otherwise be caught and laundered into the diagnostic output.
   const tsc = spawnSync(
     process.execPath,
-    [require.resolve('typescript/bin/tsc'), '-p', PROJECT, '--pretty', 'false'],
+    [require.resolve('typescript/bin/tsc'), '-p', PROJECT, '--pretty', 'false', '--listFiles'],
     {
       cwd: repoRoot,
       encoding: 'utf8',
-      // tsc reports on every file in the program, and the fixture's transitive
-      // dependencies are a large share of `src/`. The 1 MB default would kill
-      // the child mid-stream and truncate stdout - and the fixture is a root
-      // file, so its diagnostics are emitted last and lost first.
+      timeout: TSC_TIMEOUT_MS,
+      // tsc reports on every file in the program, and `--listFiles` prints each
+      // one, so this runs to several MB. The 1 MB default would kill the child
+      // mid-stream and truncate stdout - and the fixture is a root file, so its
+      // diagnostics are emitted last and lost first.
       maxBuffer: 32 * 1024 * 1024
     }
   );
@@ -74,12 +89,16 @@ const typeCheckFixture = (): Diagnostics => {
 
   const belongsToFixture = (line: string): boolean => {
     const file = FILE_SCOPED_DIAGNOSTIC.exec(line)?.[1];
-    return file !== undefined && file.replace(/\\/g, '/').endsWith(FIXTURE);
+    return file !== undefined && asPosix(file).endsWith(FIXTURE);
   };
 
   return {
     fixture: lines.filter(belongsToFixture),
-    config: lines.filter((line) => CONFIG_SCOPED_DIAGNOSTIC.test(line))
+    config: lines.filter((line) => CONFIG_SCOPED_DIAGNOSTIC.test(line)),
+    // `--listFiles` prints one absolute path per program file, diagnostics aside.
+    compiledFixture: lines.some(
+      (line) => !FILE_SCOPED_DIAGNOSTIC.test(line) && asPosix(line).endsWith(FIXTURE)
+    )
   };
 };
 
@@ -90,7 +109,13 @@ describe('NavigationItem title type contract', () => {
     diagnostics = typeCheckFixture();
   }, 180_000);
 
-  it('compiles the fixture at all', () => {
+  // Ordered deliberately: the two assertions below are only meaningful once the
+  // fixture is known to have been compiled, so prove that first.
+  it('compiles the fixture', () => {
+    expect(diagnostics.compiledFixture).toBe(true);
+  });
+
+  it('reports no config-level failure that would skip the fixture', () => {
     expect(diagnostics.config).toEqual([]);
   });
 

--- a/src/custom/NavigationNavbar/navigationNavbar.tsx
+++ b/src/custom/NavigationNavbar/navigationNavbar.tsx
@@ -9,7 +9,14 @@ import { IconWrapper, MenuItemList, MenuItemSubList, MenuListStyle, SubIconWrapp
 
 export type NavigationItem = {
   id: string;
-  title: string;
+  /**
+   * Label rendered into `ListItemText`'s `primary` slot.
+   *
+   * Accepts any `React.ReactNode`, not just a string, so composed labels -
+   * a label plus a trailing external-link glyph, a `<Chip>` badge, a count -
+   * type-check as well as they already render.
+   */
+  title: React.ReactNode;
   icon?: React.ReactNode;
   /**
    * Legacy boolean permission flag.


### PR DESCRIPTION
## Intent

Fix layer5io/sistent issue #1746: NavigationItem.title is declared `string`, but NavigationNavbar renders it into MUI ListItemText's `primary` slot, which is typed React.ReactNode. Composed nav labels render correctly at runtime but do not type-check, forcing consumers into an `as unknown as string` assertion (concrete victim: Meshery Cloud PR #5757's 'API Docs' nav entry). The goal is to widen NavigationItem.title to React.ReactNode. PR #1748 already reached checks-passed on this branch; this run validates a follow-up commit.

FOLLOW-UP COMMIT UNDER VALIDATION (b9161afb): hardens the type guard in response to two CodeRabbit review findings on PR #1748. Both were real defects in code I authored, and I verified each empirically rather than accepting them on faith:

(a) The guard could pass without ever compiling the fixture. An empty diagnostic list only means nothing was wrong with what tsc compiled - it says nothing about WHAT it compiled. I reproduced this: pointing the fixture tsconfig's `include` at a different existing file made the suite pass green in 1.6s with the fixture never entering the program. Neither the fixture-scoped filter nor the config-scoped filter nor the fixture's own @ts-expect-error self-check can see that case, because none of them fire unless the fixture was in the program. Fix: run tsc with --listFiles and assert the fixture appears in the emitted program, making its presence a checked fact. The two diagnostic assertions are deliberately ordered after it because they are only meaningful once the fixture is known to have compiled. I chose --listFiles over CodeRabbit's literal suggestion ('treat every unmatched output line as a failure') because tsc emits non-diagnostic chatter and that rule would be brittle; --listFiles is positive proof rather than negative filtering.

(b) spawnSync could wedge a jest worker indefinitely. spawnSync blocks the worker outright and jest's beforeAll timeout cannot preempt a synchronous child. Fix: a 150s child timeout, below the 180s beforeAll budget; Node signals the child on timeout, which surfaces through the pre-existing `status === null` throw, so failure handling is unchanged.

Verification of the follow-up: the guard now FAILS when the fixture is absent from the program (previously passed), and STILL FAILS when the widening is reverted (title: React.ReactNode -> string), which is the regression it exists to catch. Full suite 446/446 across 25 suites, eslint clean, prettier clean.

STANDING CONTEXT FROM THE ORIGINAL RUN, all still true:

1. SOURCE-COMPATIBLE WIDENING ONLY is an explicit scope guard from the user. `string` is assignable to `ReactNode`, so no existing consumer breaks. I was explicitly instructed NOT to restructure the navigation API, rename props, or improve adjacent components. Please do not suggest broadening this into an API redesign - that is out of scope by instruction, not oversight.

2. The guard shells out to tsc from a jest test rather than being a type-only assertion file because jest transforms with @swc/jest (see jest.config.js), which strips types WITHOUT checking them - any pure type-assertion file would pass regardless of what `title` is declared as. This is the only way to make it a real gate in this repo.

3. The guard filters tsc diagnostics to the fixture because this repo has 711 pre-existing `tsc --noEmit` errors (mostly missing @types/jest wiring), documented in CLAUDE.md/AGENTS.md under 'Repo state that looks broken but is pre-existing'. tsc is not a CI gate here. An unfiltered assertion would be permanently red. The --listFiles check added in this commit is what keeps that filtering from making the guard vacuous.

4. The fixture at src/__testing__/fixtures/navigationItemTitle.tsx is deliberately outside jest's *.test.* glob - it is compiled, never executed. package.json `files: ["dist"]` keeps it out of the published tarball.

5. Sibling check was performed and is intentionally narrow. Within the navigation family there are no other instances: `icon` is already ReactNode, `id` is genuinely a string (React key and data-testid), and NavigationNavbarProps has no other text slot. The same design decision exists in src/custom/CatalogDetail/CollapsibleSection.tsx (title/emptyState/tooltip declared string while rendered into ListItemText primary and InfoTooltip helpText), but it is NOT reachable from the root barrel, so no published consumer is affected; I deliberately left it alone under the scope guard and noted it as a follow-up. Please do not flag its omission as an oversight.

6. Verification went beyond source because this repo has a live history of built dist/*.d.ts diverging from source intent. dist/index.d.ts and dist/index.d.mts both emit `title: React__default.ReactNode`; MESHERY_EXTENSION_CONTRACT_VERSION is present in all four dist files; the CLAUDE.md clean-consumer optional-peer check passes; and a real consumer type-checked against the packed tarball accepts both a plain string and a composed <span> + OpenInNewIcon title, whereas the same consumer against published v0.21.42 errors with "Type 'Element' is not assignable to type 'string'".

7. No package.json or packaging changes, deliberately - a teammate is concurrently shipping a separate sistent change moving @meshery/schemas from devDependencies to dependencies, and we agreed not to overlap on packaging.

This change feeds a sistent release and must NOT be merged by the pipeline - a human merges it. The PR references 'Fixes #1746'.

## What Changed

- `NavigationItem['title']` in `src/custom/NavigationNavbar/navigationNavbar.tsx` is now `React.ReactNode` instead of `string`, matching the MUI `ListItemText` `primary` slot it is rendered into. Composed labels (a label plus a trailing external-link glyph, a `<Chip>`, a count) now type-check as well as they already rendered, so consumers no longer need an `as unknown as string` assertion. `string` is assignable to `ReactNode`, so this is a source-compatible widening - no existing consumer breaks, and no other prop, name, or component was touched. Fixes #1746.
- Adds a type-level regression guard: `src/__testing__/navigationItemTitleTypes.test.ts` shells out to `tsc` over a scoped fixture (`fixtures/navigationItemTitle.tsx` plus its own tsconfig) rather than asserting types inline, because jest transforms with `@swc/jest` and strips types without checking them. The guard is built to fail closed - it asserts via `--listFiles` that the fixture actually entered the compiled program before trusting an empty diagnostic list, treats file-less `error TS…` config failures as fatal, spawns `tsc` through `process.execPath` with a 150s child timeout under the 180s `beforeAll` budget, and only then filters diagnostics to the fixture (this repo's `tsc --noEmit` is not a CI gate and is red on pre-existing errors). The fixture carries a `@ts-expect-error` self-check so the filter cannot go vacuous.
- Documentation: `AGENTS.md` records the tsc-over-a-fixture pattern for gating a type contract in a repo where `tsc` is not a CI gate, and refreshes the stale pre-existing-`prettier` count. `CONTRIBUTING.md#commit-signing` gains the rule that the DCO trailer must match each commit's own author identity, plus a repair recipe (`git rebase --signoff <last-good-sha>` scoped to your own commits); `AGENTS.md` points at it and keeps only the agent-specific note that follow-up commits are the usual offender.

Notes for reviewers: two review infos are documented judgment calls, not open defects - the `compiles the fixture` assertion is ordered first rather than enforced as a `beforeAll` throw, and the timeout comment attributes the failure to the `status === null` branch when `tsc.error` fires first (both paths still throw). The nested-`<li>` DOM warning surfaced while capturing visual evidence originates in `NavigationNavbar/style.tsx`, predates this change, and was left alone under the source-compatible-widening scope guard. `CollapsibleSection.tsx` has the same `string`-vs-`ReactNode` shape but is not reachable from the root barrel, so no published consumer is affected; deliberately deferred. No `package.json` or packaging changes, to avoid overlapping a concurrent dependency move.

This feeds a sistent release and should be merged by a human, not by automation.

## Risk Assessment

✅ Low: The functional change is a one-line, additive, source-compatible type widening that matches the slot type it renders into and breaks no consumer in the repo or in the two locally-clonable downstream apps; everything else is a self-contained test guard and documentation, and both findings are informational polish to that guard's failure reporting rather than defects in the fix.

## Testing

Ran the targeted type-contract guard (green), then proved both halves of its value by mutation: excluding the fixture from the tsc program makes the pre-follow-up guard pass vacuously while the hardened guard at HEAD fails on `compiles the fixture`, and reverting the widening still trips it with the expected TS2322 diagnostics. For end-user evidence I bundled and rendered a consumer-shaped NavigationNavbar with a composed `API Docs` label and a badge-bearing sub-item - no `as unknown as string` in the source - captured screenshots of both states, type-checked that same source clean, and confirmed the built `dist` declarations carry `title: React__default.ReactNode` with no fixture leakage. All checks passed; the only note is a pre-existing React DOM-nesting warning in NavigationNavbar's markup, unrelated to this change.

- Evidence: NavigationNavbar with composed ReactNode &#39;API Docs&#39; title (text + external-link glyph) (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01KY9NSATANZHVPSGPG1NX6TNE/navbar-composed-title-collapsed.png</code>)
- Evidence: Expanded sub-item with composed ReactNode title (Tokens + count badge) (local file: <code>/var/folders/rq/t0hm8n1s2wd7tz2npfz1brqm0000gp/T/no-mistakes-evidence/01KY9NSATANZHVPSGPG1NX6TNE/navbar-composed-title-expanded.png</code>)
<details>
<summary>Evidence: Evidence transcript: guard mutations, demo type-check, dist verification</summary>

```text
# sistent#1746 - evidence transcript

## 1. Guard is green as shipped

`` `
$ npx jest src/__testing__/navigationItemTitleTypes.test.ts
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Time:        6.064 s
`` `

## 2. Follow-up commit b9161afb closes a hole that was open before it

Mutation: point the fixture project's `include` at a different existing file, so the fixture
never enters the tsc program (`"include": ["../../custom/NavigationNavbar/index.tsx"]`).

Guard as of the parent commit 7bbd7973 (no `--listFiles`, no `compiledFixture`):

`` `
--- guard BEFORE follow-up commit b9161afb (parent 7bbd7973) ---
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total          <-- passes green, fixture never compiled
`` `

Guard at HEAD (b9161afb):

`` `
--- guard AFTER follow-up commit b9161afb (HEAD) ---
FAIL src/__testing__/navigationItemTitleTypes.test.ts
  ● NavigationItem title type contract › compiles the fixture
    expect(received).toBe(expected) // Object.is equality
    Expected: true
    Received: false
      > 115 |     expect(diagnostics.compiledFixture).toBe(true);
Tests:       1 failed, 2 passed, 3 total
`` `

## 3. The guard still catches the regression it exists for

Mutation: revert the widening in `src/custom/NavigationNavbar/navigationNavbar.tsx`
(`title: React.ReactNode;` -> `title: string;`).

`` `
FAIL src/__testing__/navigationItemTitleTypes.test.ts
  ● NavigationItem title type contract › accepts both a plain string and a composed ReactNode title
    - Expected  - 1
    + Received  + 4
    - Array []
    + Array [
    +   "src/__testing__/fixtures/navigationItemTitle.tsx(23,3): error TS2322: Type 'Element' is not assignable to type 'string'.",
    +   "src/__testing__/fixtures/navigationItemTitle.tsx(40,7): error TS2322: Type 'Element' is not assignable to type 'string'.",
    + ]
`` `

Both mutations were reverted afterwards; `git status` is clean.

## 4. The consumer code behind the screenshots type-checks with no cast

`navdemo-consumer-source.tsx` (the exact source bundled for the screenshots) declares an
`API Docs` entry as a composed `<span>API Docs <OpenInNewIcon/></span>` and a sub-item as
`<span>Tokens <Chip label="3"/></span>`. The only two occurrences of `as unknown as` in it
are comments:

`` `
$ grep -n "as unknown as" navdemo.tmp.tsx
3:// `title: (<span>...</span>) as unknown as string`.
23:    // Composed ReactNode label: no `as unknown as string` anywhere in this file.
`` `

`tsc --noEmit` over that file, scoped to it:

`` `
$ npx tsc -p tsconfig.navdemo.tmp.json --pretty false --listFiles | grep navdemo.tmp.tsx
navdemo.tmp.tsx                          <-- it really was in the program
$ npx tsc -p tsconfig.navdemo.tmp.json --pretty false | grep '^navdemo.tmp.tsx('
                                         <-- zero diagnostics for the demo file
`` `

## 5. Published type surface carries the widening; the fixture does not leak into it

`` `
$ npm run build
DTS dist/index.d.ts  137.36 KB
DTS dist/index.d.mts 137.36 KB

=== NavigationItem declaration in the published type surface ===
--- dist/index.d.ts ---
1:type NavigationItem = {
10:    title: React__default.ReactNode;
--- dist/index.d.mts ---
1:type NavigationItem = {
10:    title: React__default.ReactNode;

=== fixture must NOT leak into the built artifacts ===
no build artifact references the test fixture

=== MESHERY_EXTENSION_CONTRACT_VERSION present in all four dist files ===
dist/index.js: 2
dist/index.mjs: 1
dist/index.d.ts: 3
dist/index.d.mts: 3
`` `

`dist/` was removed after the check.

## 6. Repo invariants the new `src/` fixture could have disturbed

`` `
$ npx jest src/__testing__/optionalPeerDependencies.test.ts src/__testing__/mesheryExtensionContract.test.ts
Test Suites: 2 passed, 2 total
Tests:       42 passed, 42 total
`` `
```
</details>
<details>
<summary>Evidence: Consumer source behind the screenshots (no `as unknown as string`)</summary>

```text
// Consumer-shaped demo of layer5io/sistent#1746: NavigationItem.title as React.ReactNode.
// Mirrors the Meshery Cloud PR #5757 'API Docs' nav entry that previously required
// `title: (<span>...</span>) as unknown as string`.
import OpenInNewIcon from '@mui/icons-material/OpenInNew';
import SettingsIcon from '@mui/icons-material/Settings';
import DashboardIcon from '@mui/icons-material/Dashboard';
import MenuBookIcon from '@mui/icons-material/MenuBook';
import { Chip } from '@mui/material';
import * as React from 'react';
import { createRoot } from 'react-dom/client';
import { NavigationNavbar, type NavigationItem } from './src/custom/NavigationNavbar';
import { SistentThemeProvider } from './src/theme';

const items: NavigationItem[] = [
  {
    id: 'dashboard',
    title: 'Dashboard', // plain string - the widening is source-compatible
    icon: <DashboardIcon />,
    onClick: () => {}
  },
  {
    id: 'api-docs',
    // Composed ReactNode label: no `as unknown as string` anywhere in this file.
    title: (
      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
        API Docs
        <OpenInNewIcon fontSize="small" />
      </span>
    ),
    icon: <MenuBookIcon />,
    onClick: () => {}
  },
  {
    id: 'settings',
    title: 'Settings',
    icon: <SettingsIcon />,
    onClick: () => {},
    subItems: [
      {
        id: 'settings-tokens',
        // Composed sub-item label with a count badge.
        title: (
          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.4rem' }}>
            Tokens
            <Chip label="3" size="small" />
          </span>
        ),
        onClick: () => {}
      }
    ]
  }
];

const App = () => (
  <SistentThemeProvider>
    <div style={{ width: 300, padding: '1rem', fontFamily: 'sans-serif' }}>
      <NavigationNavbar navigationItems={items} />
    </div>
  </SistentThemeProvider>
);

createRoot(document.getElementById('root')!).render(<App />);
```
</details>
<details>
<summary>Evidence: Self-contained rendered demo page (open navdemo.html to reproduce the screenshots)</summary>

```text
<!doctype html>
<html>
  <head>
    <meta charset="utf-8" />
    <title>sistent#1746 - NavigationItem.title as React.ReactNode</title>
    <style>
      body { margin: 0; background: #fff; }
      #root { display: inline-block; }
    </style>
  </head>
  <body>
    <div id="root"></div>
    <script src="./navdemo.js"></script>
  </body>
</html>
```
</details>
<details>
<summary>Evidence: Guard before vs after the follow-up commit, fixture excluded from the tsc program</summary>

```text
--- guard BEFORE follow-up commit b9161afb (parent 7bbd7973) ---
Test Suites: 1 passed, 1 total
Tests: 2 passed, 2 total

--- guard AFTER follow-up commit b9161afb (HEAD) ---
FAIL src/__testing__/navigationItemTitleTypes.test.ts
● NavigationItem title type contract › compiles the fixture
Expected: true
Received: false
> 115 | expect(diagnostics.compiledFixture).toBe(true);
Tests: 1 failed, 2 passed, 3 total
```
</details>
<details>
<summary>Evidence: Guard output when the widening is reverted (title: React.ReactNode -&gt; string)</summary>

```text
FAIL src/__testing__/navigationItemTitleTypes.test.ts
● NavigationItem title type contract › accepts both a plain string and a composed ReactNode title
- Array []
+ Array [
+ "src/__testing__/fixtures/navigationItemTitle.tsx(23,3): error TS2322: Type 'Element' is not assignable to type 'string'.",
+ "src/__testing__/fixtures/navigationItemTitle.tsx(40,7): error TS2322: Type 'Element' is not assignable to type 'string'.",
+ ]
```
</details>
<details>
<summary>Evidence: Published type surface carries the widening; fixture does not leak</summary>

```text
--- dist/index.d.ts ---
1:type NavigationItem = {
10: title: React__default.ReactNode;
--- dist/index.d.mts ---
1:type NavigationItem = {
10: title: React__default.ReactNode;

=== fixture must NOT leak into the built artifacts ===
no build artifact references the test fixture

=== MESHERY_EXTENSION_CONTRACT_VERSION present in all four dist files ===
dist/index.js: 2
dist/index.mjs: 1
dist/index.d.ts: 3
dist/index.d.mts: 3
```
</details>
- Outcome: ⚠️ 1 info across 1 run (7m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `src/__testing__/navigationItemTitleTypes.test.ts:114` - The `compiles the fixture` assertion does not actually gate the two assertions it is documented to gate. Jest has no `bail` configured, so all three `it` blocks run regardless: when the fixture is absent from the tsc program, `diagnostics.fixture` and `diagnostics.config` are both empty and their assertions report green next to the one red. The comment at line 112-113 (&#34;the two assertions below are only meaningful once the fixture is known to have been compiled, so prove that first&#34;) describes ordering, not enforcement. Moving the check into `typeCheckFixture`/`beforeAll` as a throw would make the diagnostics assertions unreachable unless the fixture is provably in the program, matching the file&#39;s stated fail-closed design.
- ℹ️ `src/__testing__/navigationItemTitleTypes.test.ts:57` - The comment states Node&#39;s child timeout &#34;surfaces as the `status === null` throw below&#34;, but `spawnSync` also populates `result.error` on timeout (Node documents `error` as set when the child &#34;failed or timed out&#34;), so line 80&#39;s `if (tsc.error) throw tsc.error` fires first and the `status === null` branch is never reached for this case. The guard still fails closed - both paths throw - but the thrown message is a bare `spawnSync ... ETIMEDOUT` with no mention of tsc or the 150s budget, and a future maintainer trusting the comment could remove the wrong guard. Correct the comment and optionally wrap the ETIMEDOUT rethrow with the budget in the message.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/custom/NavigationNavbar/navigationNavbar.tsx:95` - Pre-existing and out of scope for this change: rendering NavigationNavbar logs a React DOM-nesting error - `MenuItemList` (a MUI `ListItem`, i.e. `&lt;li&gt;`) is rendered inside `MenuItem`&#39;s own `&lt;li&gt;`, producing `&lt;li&gt; cannot contain a nested &lt;li&gt;`. It comes from src/custom/NavigationNavbar/style.tsx and is independent of the title type widening, so I left it alone under the author&#39;s explicit scope guard. Noting it only because it surfaced in the browser console while capturing visual evidence.
- `npx jest src/__testing__/navigationItemTitleTypes.test.ts`
- <code>Mutation A: fixture excluded from tsc program - parent-commit guard passed 2/2, HEAD guard failed on `compiles the fixture`</code>
- <code>Mutation B: `title: React.ReactNode` -&gt; `title: string` - HEAD guard failed with two fixture-scoped TS2322 diagnostics</code>
- `esbuild-bundled consumer demo rendered in Chromium via Playwright, screenshots captured collapsed and expanded`
- <code>`npx tsc -p tsconfig.navdemo.tmp.json --pretty false --listFiles` over the demo consumer source</code>
- <code>`npm run build` + `dist/index.d.ts` / `dist/index.d.mts` NavigationItem declaration and MESHERY_EXTENSION_CONTRACT_VERSION checks</code>
- `npx jest src/__testing__/optionalPeerDependencies.test.ts src/__testing__/mesheryExtensionContract.test.ts`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `AGENTS.md:94` - Judgment call, left as-is: the DCO section added by 7bbd7973 carries contribution mechanics (the trailer must match the commit&#39;s author identity; the targeted `git rebase --signoff &lt;last-good-sha&gt;` repair) that per placement policy are owned by CONTRIBUTING.md, whose commit-signing section only says to pass `-s` and never states the author-identity rule - the actual failure mode. The content is not duplicated, and it is genuinely agent-facing (&#34;sign every commit an automated pass makes for you&#34;), so I did not move it: the constraint would be lost from AGENTS.md for a benefit that only shows up for human contributors. Worth a follow-up that puts the author-identity rule and repair recipe in CONTRIBUTING.md#commit-signing and reduces the AGENTS.md entry to a pointer plus the agent-specific &#34;follow-up commits are the usual offender&#34; note. Out of scope here - it edits a contributor-facing doc this change never touched.

🔧 Fix: move DCO sign-off mechanics to CONTRIBUTING.md, pointer in AGENTS.md
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation item labels now support composed React content in addition to plain text.

* **Bug Fixes**
  * Added automated type-contract checks to help prevent invalid navigation item labels.

* **Documentation**
  * Clarified contribution requirements for commit sign-offs and DCO corrections.
  * Expanded guidance for verifying TypeScript contracts.
  * Improved documentation and examples for responsive data table helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->