### PR TITLE
chore(release): bump package.json to v0.21.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.21.42",
+  "version": "0.21.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sistent/sistent",
-      "version": "0.21.42",
+      "version": "0.21.43",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sistent/sistent",
-  "version": "0.21.42",
+  "version": "0.21.43",
   "description": "Reusable React Components and SVG Icons library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` to `v0.21.43` to match the version just published to npm.

This PR is normally auto-generated by the `Publish Node.js Package` workflow. On the `v0.21.43` publish
([run 30108402937](https://github.com/layer5io/sistent/actions/runs/30108402937)) the publish itself
succeeded, but `peter-evans/create-pull-request` failed to push the branch:

```
remote: Internal Server Error
 ! [remote rejected]   release/version-bump/v0.21.43 -> release/version-bump/v0.21.43 (Internal Server Error)
```

That was a transient GitHub-side fault during a broader incident window - the same minute,
`notify-dependents.yml`'s `bump-layer5` job hit an identical `Internal Server Error` on push and other
jobs saw `429 Too Many Requests` fetching actions. Because the failing step is inside the same job as
`npm publish --provenance`, the job cannot be re-run without attempting to republish an already-published
version, so this PR reproduces the automation's commit by hand: same two files, same content, same
`[skip ci]` commit message.

The commit message includes `[skip ci]` so merging this PR does not re-trigger workflows against the bump
commit - the content was already CI-gated by the PR that merged into the tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.21.43.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->