### PR TITLE
chore(skills): hard-rename iterate-pr --full mode to --merge

### DIFF
--- a/.agents/skills/iterate-pr/SKILL.md
+++ b/.agents/skills/iterate-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: iterate-pr
 description: Iterate on a PR until CI passes. Optionally merge or merge and publish a release of the repo. Automates the feedback-fix-push-wait cycle.
-argument-hint: "[--full] [--release]"
+argument-hint: "[--merge] [--release]"
 metadata:
   author: leecalcote
   version: "2.3.0"
@@ -44,9 +44,9 @@ readability - substitute `uv run` per the rule above whenever `uv` is available.
 Invoke as:
 
 - `/iterate-pr`
-- `/iterate-pr --full`
+- `/iterate-pr --merge`
 - `/iterate-pr --release`
-- `/iterate-pr --full --release`
+- `/iterate-pr --merge --release`
 
 In Claude Desktop, arguments are **hints**, not strict CLI parsing. Treat whatever follows `/iterate-pr` as a mode hint string.
 
@@ -55,7 +55,7 @@ In Claude Desktop, arguments are **hints**, not strict CLI parsing. Treat whatev
 Use this deterministic precedence:
 
 1. If hints include `--release` or terms like `release`, `publish`, `ship` → run **release mode**.
-2. Else if hints include `--full` or terms like `full`, `autonomous`, `merge` → run **full mode**.
+2. Else if hints include `--merge` or terms like `autonomous`, `merge` → run **merge mode**.
 3. Else run **default mode**.
 
 Do not fail because hints are missing or unrecognized; default safely.
@@ -63,8 +63,8 @@ Do not fail because hints are missing or unrecognized; default safely.
 | Mode | Behavior |
 |---|---|
 | Default (`/iterate-pr`) | Iterates on CI + high/medium feedback, asks user about low-priority items, then exits without merging. |
-| `--full` | Fully autonomous: handles every non-resolved feedback item, replies to every item, re-requests review (Gemini or Copilot) after each push, iterates until no new feedback and CI is green, then administratively merges the PR without waiting for a required-approval status. |
-| `--release` | Does everything in `--full`, then cuts/publishes a release for the repository. |
+| `--merge` | Fully autonomous: handles every non-resolved feedback item, replies to every item, re-requests review (Gemini or Copilot) after each push, iterates until no new feedback and CI is green, then administratively merges the PR without waiting for a required-approval status. |
+| `--release` | Does everything in `--merge`, then cuts/publishes a release for the repository. |
 
 ## Bundled Scripts
 
@@ -139,7 +139,7 @@ Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` to get cate
 
 ### 3. Handle Feedback by Priority and Mode
 
-Determine mode from invocation (`/iterate-pr`, `/iterate-pr --full`, `/iterate-pr --release`).
+Determine mode from invocation (`/iterate-pr`, `/iterate-pr --merge`, `/iterate-pr --release`).
 
 #### Default mode (`/iterate-pr`)
 
@@ -163,7 +163,7 @@ Which would you like to address? (e.g., "1,3" or "all" or "none")
 - `resolved` threads
 - `bot` comments (informational only — Codecov, Dependabot, etc.)
 
-#### Full modes (`/iterate-pr --full`, `/iterate-pr --full --release`)
+#### Merge modes (`/iterate-pr --merge`, `/iterate-pr --merge --release`)
 
 Operate autonomously. Process every non-resolved feedback item returned by `fetch_pr_feedback.py` (`high`, `medium`, `low`, and `bot`).
 
@@ -189,12 +189,12 @@ After processing feedback, reply to PR comments/threads to acknowledge the actio
 
 **Scope by mode:**
 - Default mode: reply to `high`/`medium`; reply to `low` only when fixed or declined by the user
-- Full modes: reply to every non-resolved feedback item, including informational bot feedback
+- Merge modes: reply to every non-resolved feedback item, including informational bot feedback
 
 **How to reply:**
 - If `thread_id` exists (inline review thread), use `python3 .agents/skills/iterate-pr/scripts/reply_to_thread.py`
 - If no `thread_id` exists, post a PR comment with `gh pr comment <PR_NUMBER> --body "..."`
-- In full modes, a feedback round is incomplete until every item has a corresponding reply
+- In merge modes, a feedback round is incomplete until every item has a corresponding reply
 
 Batch inline replies for a round into a single call:
 
@@ -255,28 +255,28 @@ Poll CI status and review feedback in a loop instead of blocking:
    a. Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` for new review feedback
    b. Address feedback based on mode:
       - Default mode: new `high`/`medium`
-      - Full modes: every new non-resolved item (`high`/`medium`/`low`/`bot`) and reply to each item
+      - Merge modes: every new non-resolved item (`high`/`medium`/`low`/`bot`) and reply to each item
    c. If changes were needed, commit and push (this restarts CI)
-   d. In full modes, after each push, explicitly re-request review:
+   d. In merge modes, after each push, explicitly re-request review:
       - Prefer Gemini review command (`/gemini review`) when available
       - Otherwise request Copilot review by commenting `@copilot review` on the PR
    e. Sleep 30 seconds (don't increase on subsequent iterations), then repeat from sub-step 1
 5. After all checks pass, do a final feedback check: `sleep 10`, then run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py`.
    - Default mode: address any new `high`/`medium` feedback; if changes are needed, return to step 6
-   - Full modes: address any new non-resolved item; if changes are needed, return to step 6 and re-request review
+   - Merge modes: address any new non-resolved item; if changes are needed, return to step 6 and re-request review
 
 ### 8. Repeat
 
 If step 7 required code changes (from new feedback after CI passed), return to step 2 for a fresh cycle. CI failures during monitoring are already handled within step 7's polling loop.
 
-In full modes, continue looping until both conditions are true:
+In merge modes, continue looping until both conditions are true:
 - CI checks are green
 - No new non-resolved feedback is returned after the latest review request
 
 ### 9. Finish by Mode
 
 - Default mode: stop after success conditions are met (do not merge automatically)
-- `full`: once CI is green and no new feedback remains, merge administratively - do not wait for a required-approval status to clear:
+- `merge`: once CI is green and no new feedback remains, merge administratively - do not wait for a required-approval status to clear:
 
 ```bash
 gh pr merge <PR_NUMBER> --admin --delete-branch
@@ -290,7 +290,7 @@ authenticated account lacks admin/maintainer rights on the repo, or a check can'
 bypassed), stop and surface the `gh` error to the user - do not retry under a different
 identity and do not fall back silently.
 
-- `--release`: complete `--full` mode merge, then cut a release:
+- `--release`: complete `--merge` mode merge, then cut a release:
   1. Find the draft release tag:
      ```bash
      gh release list --repo layer5io/meshery-cloud --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName'
@@ -308,9 +308,9 @@ identity and do not fall back silently.
 
 **Success (default):** All checks pass, post-CI feedback re-check is clean (no new unaddressed high/medium feedback including review bot findings), user has decided on low-priority items.
 
-**Success (`full`):** All checks pass, no new non-resolved feedback remains after the latest review request, every feedback item has a reply, and the PR is administratively merged (no wait on a required-approval status).
+**Success (`merge`):** All checks pass, no new non-resolved feedback remains after the latest review request, every feedback item has a reply, and the PR is administratively merged (no wait on a required-approval status).
 
-**Success (`--release`):** `--full` success criteria are met and the draft GitHub release has been published.
+**Success (`--release`):** `--merge` success criteria are met and the draft GitHub release has been published.
 
 **Ask for help:** Same failure after 2 attempts, feedback needs clarification, infrastructure issues, or `gh pr merge --admin` fails (insufficient permissions or an unbypassable check) - surface the error rather than retrying under a different identity or falling back silently.
 


### PR DESCRIPTION
## What

Hard-renames the vendored `iterate-pr` skill's autonomous mode from **`--full`** to **`--merge`** in `.agents/skills/iterate-pr/SKILL.md`.

This is a **hard removal**, not a deprecated alias: `--full` and the positional `full` are no longer recognized triggers. The argument-interpretation precedence now reads `--merge` / `merge` (with `autonomous` retained as a synonym); `--full` and `full` were dropped from the trigger terms.

## Changes

- `--full` flag → `--merge`
- `/iterate-pr --full` (and `/iterate-pr --full --release`) invocation forms → `/iterate-pr --merge`
- Mode name/heading "Full mode(s)" → "Merge mode(s)"
- Trigger terms: dropped `--full` and `full`; kept `--merge`, `merge`, `autonomous`

The default mode and `--release` mode are untouched. No dangling `--full` references remain.

## Scope

Docs-only change to a vendored skill file. Part of a coordinated rename propagated across the ecosystem repos that vendor this skill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the autonomous pull request iteration option from `--full` to `--merge`.
  * Updated usage examples and workflow guidance to reflect the new option.
  * Clarified that merge mode continues addressing unresolved feedback, re-requests reviews after updates, and merges once checks and feedback requirements are satisfied.
  * Documented that release mode builds on merge mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->