### PR TITLE
[UI] Fix label mismatch causing oversized outline notch in InviteUser…

### DIFF
--- a/src/custom/DashboardWidgets/GettingStartedWidget/InviteUserModal.tsx
+++ b/src/custom/DashboardWidgets/GettingStartedWidget/InviteUserModal.tsx
@@ -306,7 +306,7 @@ export default function UserInviteModal({
                   labelId="org-select-label"
                   id="outlined-org-select"
                   value={organization}
-                  label="Organization Name"
+                  label="Organization"
                   onChange={handleOrgChange}
                   renderValue={(org: any) => org?.name}
                 >
@@ -341,7 +341,7 @@ export default function UserInviteModal({
                   label="Organization Roles"
                   value={orgRoles}
                   onChange={handleOrgRoleChange}
-                  input={<OutlinedInput id="select-multiple-chip" label="Roles" />}
+                  input={<OutlinedInput id="select-multiple-chip" label="Organization Roles" />}
                   renderValue={(selected) => (
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                       {selected.map((value) => (


### PR DESCRIPTION
## Description
This PR fixes #1769 
Addresses a UI rendering issue in the `InviteUserModal` component where the `InputLabel` text did not match the `label` prop passed to the corresponding `Select` and `OutlinedInput` components. 


When these strings differ, Material UI miscalculates the width of the label for the outlined variant, resulting in a notch that is either too wide (leaving extra blank space on the border) or too narrow (causing the border to intersect with the text). 

**Changes Made:**
- Updated the `label` prop on the Organization `Select` component from `"Organization Name"` to `"Organization"` to match its `<InputLabel>`.
- Updated the `label` prop on the Organization Roles `<OutlinedInput>` from `"Roles"` to `"Organization Roles"` to match its `<InputLabel>`.

### ScreenShots:
**Before**: 
<img width="500" height="658" alt="image" src="https://github.com/user-attachments/assets/6b8b2c0f-a23d-422c-8d5b-f8bdce016c91" />
**After**: 
<img width="500" height="700" alt="Screenshot 2026-08-04 145249" src="https://github.com/user-attachments/assets/fb78172c-fca2-437c-b049-2dc5dfdf9140" />

## Checklist
- [x] I have signed my commits 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated select input labels for clearer organization and role terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->