### PR TITLE
fix: prevent PermissionShield tooltip from getting clipped

### DIFF
--- a/src/custom/permissions.tsx
+++ b/src/custom/permissions.tsx
@@ -418,6 +418,26 @@ export const PermissionShield: React.FC<PermissionShieldProps> = ({
           disableFocusListener
           disableTouchListener
           slotProps={{
+            popper: {
+              modifiers: [
+                {
+                  name: 'flip',
+                  enabled: true,
+                  options: {
+                    fallbackPlacements: ['bottom', 'right', 'left']
+                  }
+                },
+                {
+                  name: 'preventOverflow',
+                  enabled: true,
+                  options: {
+                    boundary: 'viewport',
+                    altAxis: true,
+                    padding: 8
+                  }
+                }
+              ]
+            },
             tooltip: {
               sx: {
                 background: '#1A1A1A',


### PR DESCRIPTION
## Description

The PermissionShield tooltip gets clipped when rendered near viewport edges — especially on zoomed screens or when the shield icon is near the top/bottom of the screen (e.g. Identity section in the navigation menu with many sub-items).

## Changes

Added Popper flip and preventOverflow modifiers to the PermissionShield tooltip:

- **flip**: automatically repositions the tooltip from top to bottom, right, or left when there isn't enough space in the default placement direction
- **preventOverflow**: constrains the tooltip within the viewport boundary with 8px padding on all axes

## Testing

- Tested locally with a zoomed-in screen where the Identity section PermissionShield tooltip was being cut off at both top and bottom
- Tooltip now flips and stays fully visible within the viewport
- All 492 existing tests pass

### Before 
<img width="257" height="299" alt="Screenshot 2026-08-04 at 11 23 03 PM" src="https://github.com/user-attachments/assets/f54b5fe2-b638-48b2-b49e-29f997f3c746" />

### After 



https://github.com/user-attachments/assets/59a5608d-b64b-48c2-81c9-815dde68a5f8


