### PR TITLE
fix: export BottomSheet types from root index

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,3 +88,5 @@ export {
   type PermissionShieldProps,
   type PermissionUserContext
 } from './custom/permissions';
+
+export { BottomSheet, type BottomSheetProps } from './custom/BottomSheet';


### PR DESCRIPTION
**Notes for Reviewers**
BottomSheet and BottomSheetProps were dropped from the bundled d.ts due to the rollup-plugin-dts nested-barrel re-export quirk. Add an explicit re-export from the leaf module to force both declarations into the published bundle, consistent with FeedbackButton, UniversalFilter, DangerConfirmationModal and other components.

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->
