### PR TITLE
Bump @meshery/schemas to ^1.3.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@layer5/meshery-design-embed": "^0.6.0",
-        "@meshery/schemas": "^1.3.35",
+        "@meshery/schemas": "^1.3.44",
         "@sistent/mui-datatables": "^8.0.0",
         "@types/mui-datatables": "*",
         "billboard.js": "^4.0.3",
@@ -3395,9 +3395,9 @@
       }
     },
     "node_modules/@meshery/schemas": {
-      "version": "1.3.35",
-      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.35.tgz",
-      "integrity": "sha512-YDYETnh/p8kqhiY2PGrmISmXahmGfXGYDSuZcXZt1Np2/24kBcZJ5kPm9HZAMcysRVVBdSjYkA7BO29To++2gQ==",
+      "version": "1.3.44",
+      "resolved": "https://registry.npmjs.org/@meshery/schemas/-/schemas-1.3.44.tgz",
+      "integrity": "sha512-4pDQCF6Cswatk6sP9+2GqtyPubBZnyjZHvZnBBBPrw0CEXAy4S7ByD3A6rQLzcGDEBV6IM4cm5wDdKDal0xYCA==",
       "license": "ISC",
       "peerDependencies": {
         "@reduxjs/toolkit": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@layer5/meshery-design-embed": "^0.6.0",
-    "@meshery/schemas": "^1.3.35",
+    "@meshery/schemas": "^1.3.44",
     "@sistent/mui-datatables": "^8.0.0",
     "@types/mui-datatables": "*",
     "billboard.js": "^4.0.3",


### PR DESCRIPTION
## Description

Bumps `@meshery/schemas` dependency to `^1.3.44`.

This updates the exported `createAndEditWorkspaceUiSchema` form UI schema to set `"organizationId": { "ui:widget": "hidden" }` (matching canonical forms in `meshery/schemas`), resolving the empty Organization dropdown issue in workspace creation modals.

## Changes
- Bump `@meshery/schemas` to `^1.3.44` in `package.json` & `package-lock.json`
- Rebuild bundle (`dist/`)

## Checklist
- [x] Tested build locally (`npm run build`)

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schema package dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->