### PR TITLE
fix: export ActionButton component from sistent

### DIFF
--- a/src/custom/ActionButton/ActionButton.tsx
+++ b/src/custom/ActionButton/ActionButton.tsx
@@ -10,7 +10,7 @@ import {
   Popper
 } from '../../base';
 import { DropDownIcon } from '../../icons';
-interface Option {
+export interface Option {
   icon: React.ReactNode;
   label: string;
   onClick: (event: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => void;
@@ -18,7 +18,7 @@ interface Option {
   show?: boolean;
 }
 
-interface ActionButtonProps {
+export interface ActionButtonProps {
   defaultActionClick: () => void;
   defaultActionDisabled?: boolean;
   options: Option[];

--- a/src/custom/ActionButton/index.tsx
+++ b/src/custom/ActionButton/index.tsx
@@ -1,3 +1,4 @@
 import ActionButton from './ActionButton';
 
 export { ActionButton };
+export type { ActionButtonProps, Option } from './ActionButton';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -90,3 +90,5 @@ export {
 } from './custom/permissions';
 
 export { BottomSheet, type BottomSheetProps } from './custom/BottomSheet';
+
+export { ActionButton } from './custom/ActionButton';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -91,4 +91,4 @@ export {
 
 export { BottomSheet, type BottomSheetProps } from './custom/BottomSheet';
 
-export { ActionButton } from './custom/ActionButton';
+export { ActionButton, type ActionButtonProps, type Option } from './custom/ActionButton';


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `ActionButton` component to the package’s public exports for use in applications.
  * Added public access to `ActionButtonProps` and `Option` types, improving support for type-safe customization and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->