### PR TITLE
 feat(useAccessibleOrgs): accept triggerGetKeys as parameter for multi-app support

### DIFF
--- a/src/custom/useAccessibleOrgs.ts
+++ b/src/custom/useAccessibleOrgs.ts
@@ -1,4 +1,3 @@
-import { useLazyGetUserKeysQuery } from '@meshery/schemas/cloudApi';
 import { Key } from '@meshery/schemas/permissions';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getPermissionKeys, isPermissionKeySet, PermissionKeySpec } from './PermissionProvider';
@@ -38,10 +37,20 @@ const hasDefiniteId = <T extends { id?: string }>(org: T): org is T & { id: stri
   Boolean(org.id);
 
 /**
+ * The shape of the trigger function returned by RTK Query's
+ * `useLazyGetUserKeysQuery`. Both `cloudApi` and `mesheryApi` export one
+ * with the same signature — callers pass whichever is appropriate.
+ */
+export type TriggerGetKeys = (
+  arg: { orgId: string }
+) => { unwrap: () => Promise<{ keys?: Array<{ id: string; function: string }> }> };
+
+/**
  * Configuration for `useAccessibleOrgs`.
  *
- * The hook does NOT read orgs or the current org from any global store — both
- * are supplied by the host application so the hook stays framework-agnostic.
+ * The hook does NOT read orgs, the current org, or the keys endpoint from any
+ * global store — all are supplied by the host application so the hook stays
+ * framework-agnostic.
  *
  * Generic over `T` so the element type of `allOrgs` flows through to
  * `accessibleOrgs` — callers keep `org.name`, `org.avatar`, etc. typed.
@@ -58,6 +67,16 @@ export interface UseAccessibleOrgsOptions<T extends { id?: string } = { id?: str
 
   /** The permission key (or key set) to check each org against. */
   permissionKey?: PermissionKeySpec;
+
+  /**
+   * The lazy trigger returned by RTK Query's `useLazyGetUserKeysQuery`.
+   *
+   * - meshery-cloud passes the one from `@meshery/schemas/cloudApi`
+   * - meshery passes the one from `@meshery/schemas/mesheryApi`
+   *
+   * This avoids hardcoding a transport layer so the same logic works in both.
+   */
+  triggerGetKeys: TriggerGetKeys;
 }
 
 /**
@@ -65,20 +84,30 @@ export interface UseAccessibleOrgsOptions<T extends { id?: string } = { id?: str
  * described by `permissionKey`. The current org is excluded from the result
  * since the user is already on the 403 page for it.
  *
- * Queries `/api/identity/orgs/:orgId/users/keys` for each org in parallel
- * via `useLazyGetUserKeysQuery`. This is a 403-page-only hook — the N
- * parallel requests are acceptable because this page is not a hot path.
+ * Queries `/api/identity/orgs/:orgId/users/keys` for each org in parallel.
+ * This is a 403-page-only hook — the N parallel requests are acceptable
+ * because this page is not a hot path.
  *
  * @example
  * ```tsx
  * // In meshery-cloud
- * const { data: allOrgs, isSuccess } = useGetActiveOrgs();
- * const currentOrg = useSelector(selectCurrentOrg);
+ * const [triggerGetKeys] = useLazyGetUserKeysQuery(); // from cloudApi
  * const { accessibleOrgs, isLoading } = useAccessibleOrgs({
  *   allOrgs,
  *   currentOrgId: currentOrg?.id,
  *   orgsLoaded: isSuccess,
  *   permissionKey,
+ *   triggerGetKeys,
+ * });
+ *
+ * // In meshery
+ * const [triggerGetKeys] = useLazyGetUserKeysQuery(); // from mesheryApi
+ * const { accessibleOrgs, isLoading } = useAccessibleOrgs({
+ *   allOrgs,
+ *   currentOrgId: selectedOrg?.id,
+ *   orgsLoaded: !isLoading,
+ *   permissionKey,
+ *   triggerGetKeys,
  * });
  * ```
  */
@@ -86,10 +115,9 @@ export const useAccessibleOrgs = <T extends { id?: string }>({
   allOrgs,
   currentOrgId,
   orgsLoaded,
-  permissionKey
+  permissionKey,
+  triggerGetKeys
 }: UseAccessibleOrgsOptions<T>) => {
-  const [triggerGetKeys] = useLazyGetUserKeysQuery();
-
   // Track which orgs have been checked and their results.
   // Map<orgId, hasPermission>
   const [checkedOrgs, setCheckedOrgs] = useState<Map<string, boolean>>(new Map());

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,8 @@ export {
 
 export {
   useAccessibleOrgs,
-  type UseAccessibleOrgsOptions
+  type UseAccessibleOrgsOptions,
+  type TriggerGetKeys
 } from './custom/useAccessibleOrgs';
 export { BottomSheet, type BottomSheetProps } from './custom/BottomSheet';
 


### PR DESCRIPTION
### Description

The `useAccessibleOrgs` hook needs to work in both meshery-cloud and meshery. These two apps use different API layers to fetch user keys — meshery-cloud uses `@meshery/schemas/cloudApi` (direct cloud server) while meshery uses `@meshery/schemas/mesheryApi` (meshery server). 

Previously, the hook hardcoded the `cloudApi` import, which meant Meshery could not reuse it without duplicating the entire logic. This PR makes `triggerGetKeys` a required parameter so each app passes its own RTK Query lazy trigger, keeping all the permission-checking, caching, and parallel-query logic in one place.

Changes:
- Removed internal `useLazyGetUserKeysQuery` import from `cloudApi.`
- Added `triggerGetKeys` to `UseAccessibleOrgsOptions`
- Exported new `TriggerGetKeys` type for consumer convenience

### Realated PRs
Meshery-Cloud - https://github.com/layer5io/meshery-cloud/pull/5971
Meshery - https://github.com/meshery/meshery/pull/21366

### Meshery-Cloud

https://github.com/user-attachments/assets/9de1972a-c0bf-4b07-83b1-23d061ba5678

### Meshery 


https://github.com/user-attachments/assets/906e2316-67f1-4887-906a-759514d1f06e



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring organization accessibility checks with either cloud or Meshery API connections.
  * Exposed a reusable trigger type for fetching organization keys.
* **Documentation**
  * Updated usage guidance and examples to demonstrate configuration for both supported API environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->