### PR TITLE
refactor: move useAccessibleOrgs from custom to hooks

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useRoomActivity';
+export * from './useAccessibleOrgs';

--- a/src/hooks/useAccessibleOrgs.ts
+++ b/src/hooks/useAccessibleOrgs.ts
@@ -1,6 +1,6 @@
 import { Key } from '@meshery/schemas/permissions';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { getPermissionKeys, isPermissionKeySet, PermissionKeySpec } from './PermissionProvider';
+import { getPermissionKeys, isPermissionKeySet, PermissionKeySpec } from '../custom/PermissionProvider';
 
 /**
  * For a given set of user keys (as returned by `getUserKeys`), check whether

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,7 +101,7 @@ export {
   useAccessibleOrgs,
   type UseAccessibleOrgsOptions,
   type TriggerGetKeys
-} from './custom/useAccessibleOrgs';
+} from './hooks/useAccessibleOrgs';
 
 export {
   WidgetPicker,


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1811 
This PR refactors `useAccessibleOrgs` by relocating it to the `src/hooks` directory to ensure it is properly bundled and exported as a reusable React hook for external consumers.

**Verified changes:**
- Moved `src/custom/useAccessibleOrgs.ts` to `src/hooks/useAccessibleOrgs.ts` (recorded cleanly as a Git rename).
- Corrected the internal `PermissionProvider` import to `../custom/PermissionProvider`.
- Added the standard `export * from './useAccessibleOrgs';` to the `src/hooks/index.ts` barrel file.

No behavior changes are intended. Local verification:
- The generated `dist/index.d.ts` successfully retains the fully typed `useAccessibleOrgs` signature.
- All 515 tests across 30 suites pass (`npm run test`).
- The bundle builds successfully without resolution errors (`npm run build`).

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for accessing the accessible organizations hook through the shared hooks interface.

* **Bug Fixes**
  * Corrected permission provider resolution to improve hook reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->