### PR TITLE
fix(BottomSheet): replace surface.tint with background.default

### DIFF
--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -59,54 +59,50 @@ const BottomSheet = ({
       })}
     >
       {title && (
-        <>
-          <Box
+        <Box
+          sx={(theme) => ({
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '1rem',
+            textAlign: 'center',
+            background: headerBackgroundColor || theme.palette.background.default,
+            color: headerTextColor || theme.palette.text.primary
+          })}
+        >
+          <Typography
+            id={titleId}
+            variant="subtitle1"
+            sx={{
+              fontWeight: 600,
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              color: 'inherit'
+            }}
+          >
+            {title}
+          </Typography>
+          <IconButton
+            aria-label={closeButtonAriaLabel}
+            onClick={onClose}
+            size="small"
+            edge="end"
             sx={(theme) => ({
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              padding: '1rem',
-              textAlign: 'center',
-              background: headerBackgroundColor || theme.palette.surface.tint,
-              color: headerTextColor || theme.palette.text.primary
+              color: headerTextColor || theme.palette.text.primary,
+              transform: 'rotate(-90deg)',
+              '&:hover': {
+                transform: 'rotate(90deg)',
+                transition: 'all 0.3s ease-in',
+                cursor: 'pointer'
+              }
             })}
           >
-            <Typography
-              id={titleId}
-              variant="subtitle1"
-              sx={{
-                fontWeight: 600,
-                flex: 1,
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                color: 'inherit'
-              }}
-            >
-              {title}
-            </Typography>
-            <IconButton
-              aria-label={closeButtonAriaLabel}
-              onClick={onClose}
-              size="small"
-              edge="end"
-              sx={(theme) => ({
-                '& svg': {
-                  fill: headerTextColor || theme.palette.text.primary
-                },
-                transform: 'rotate(-90deg)',
-                '&:hover': {
-                  transform: 'rotate(90deg)',
-                  transition: 'all 0.3s ease-in',
-                  cursor: 'pointer'
-                }
-              })}
-            >
-              <CloseIcon />
-            </IconButton>
-          </Box>
-        </>
+            <CloseIcon />
+          </IconButton>
+        </Box>
       )}
       <DialogContent sx={{ px: 2, py: 1.5, overflowY: 'auto' }}>{children}</DialogContent>
     </Dialog>

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -66,7 +66,9 @@ const BottomSheet = ({
             alignItems: 'center',
             padding: '1rem',
             textAlign: 'center',
-            background: headerBackgroundColor || theme.palette.background.default,
+            // Use surface.tint (Sistent token) when available, fall back to
+            // background.default (standard MUI token) for repos without SistentThemeProvider.
+            background: headerBackgroundColor || theme.palette.surface?.tint || theme.palette.background.default,
             color: headerTextColor || theme.palette.text.primary
           })}
         >


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #

**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Bottom Sheet header background fallback for more consistent theming.
  * Improved close button color handling to ensure the icon displays correctly across themes.
  * Enhanced compatibility with themes that provide customized surface colors while retaining a reliable default background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->