### PR TITLE
fix(BottomSheet): fallback to background.default and adapt text color

### DIFF
--- a/src/__testing__/BottomSheet.test.tsx
+++ b/src/__testing__/BottomSheet.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BottomSheet from '../custom/BottomSheet/BottomSheet';
+import {
+  createCustomTheme,
+  readableTextColor,
+  SistentThemeProvider,
+  ThemeProvider
+} from '../theme';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noop = () => {};
+
+const rgb = (hex: string | undefined) => {
+  let h = String(hex).replace('#', '');
+  if (h.length === 3)
+    h = h
+      .split('')
+      .map((c) => c + c)
+      .join('');
+  const int = parseInt(h, 16);
+  return `rgb(${(int >> 16) & 255}, ${(int >> 8) & 255}, ${int & 255})`;
+};
+
+/** The flex container that carries the resolved header `background`/`color`. */
+const getHeader = () => screen.getByText('Test Title').parentElement as HTMLElement;
+
+function renderSheet(
+  props: Partial<React.ComponentProps<typeof BottomSheet>> = {},
+  { mode = 'light' }: { mode?: 'light' | 'dark' } = {}
+) {
+  return render(
+    <SistentThemeProvider initialMode={mode}>
+      <BottomSheet open title="Test Title" onClose={noop} {...props}>
+        <p>content</p>
+      </BottomSheet>
+    </SistentThemeProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BottomSheet header color resolution', () => {
+  it('falls back to surface.tint for the background and light ink for the text', () => {
+    const theme = createCustomTheme('light');
+    renderSheet();
+
+    const header = getHeader();
+    expect(getComputedStyle(header).background).toContain('gradient');
+    expect(getComputedStyle(header).color).toBe(rgb(theme.palette.common.white));
+  });
+
+  it('keeps the surface.tint header readable in dark mode (light ink, not text.inverse)', () => {
+    const theme = createCustomTheme('dark');
+    // In the dark palette text.inverse is near-black, which would be invisible
+    // on the dark surface.tint gradient — the tint header must stay light.
+    expect(rgb(theme.palette.text.inverse)).not.toBe(rgb(theme.palette.common.white));
+
+    renderSheet({}, { mode: 'dark' });
+
+    const header = getHeader();
+    expect(getComputedStyle(header).background).toContain('gradient');
+    expect(getComputedStyle(header).color).toBe(rgb(theme.palette.common.white));
+  });
+
+  it('falls back to background.default when the palette has no surface.tint', () => {
+    const theme = createCustomTheme('light');
+    delete (theme.palette.surface as { tint?: string }).tint;
+
+    render(
+      <ThemeProvider theme={theme}>
+        <BottomSheet open title="Test Title" onClose={noop}>
+          <p>content</p>
+        </BottomSheet>
+      </ThemeProvider>
+    );
+
+    const header = getHeader();
+    expect(getComputedStyle(header).background).toBe(rgb(theme.palette.background.default));
+    expect(getComputedStyle(header).color).toBe(rgb(theme.palette.text.default));
+  });
+
+  it('picks the light (inverse) ink for a dark custom background', () => {
+    const theme = createCustomTheme('light');
+    renderSheet({ headerBackgroundColor: '#121212' });
+
+    const expected = readableTextColor(
+      '#121212',
+      theme.palette.text.inverse,
+      theme.palette.text.default
+    );
+    expect(expected).toBe(theme.palette.text.inverse);
+    expect(getComputedStyle(getHeader()).color).toBe(rgb(expected));
+  });
+
+  it('picks the dark (default) ink for a light custom background', () => {
+    const theme = createCustomTheme('light');
+    renderSheet({ headerBackgroundColor: '#f5f5f5' });
+
+    const expected = readableTextColor(
+      '#f5f5f5',
+      theme.palette.text.inverse,
+      theme.palette.text.default
+    );
+    expect(expected).toBe(theme.palette.text.default);
+    expect(getComputedStyle(getHeader()).color).toBe(rgb(expected));
+  });
+
+  it('lets an explicit headerTextColor win over the computed ink', () => {
+    renderSheet({ headerBackgroundColor: '#121212', headerTextColor: '#ff0000' });
+
+    expect(getComputedStyle(getHeader()).color).toBe('rgb(255, 0, 0)');
+  });
+
+  it('applies the same resolved ink to the close-button icon', () => {
+    renderSheet({ headerBackgroundColor: '#121212', headerTextColor: '#ff0000' });
+
+    const icon = screen.getByLabelText('Close').querySelector('svg') as SVGElement;
+    expect(getComputedStyle(icon).fill).toBe('#ff0000');
+  });
+});

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -67,8 +67,8 @@ const BottomSheet = ({
               alignItems: 'center',
               padding: '1rem',
               textAlign: 'center',
-              background: headerBackgroundColor || theme.palette.surface.tint,
-              color: headerTextColor || theme.palette.text.primary
+              background: headerBackgroundColor || theme.palette.surface?.tint || theme.palette.background.default,
+              color: headerTextColor || (theme.palette.surface?.tint ? theme.palette.common.white : theme.palette.text.primary)
             })}
           >
             <Typography
@@ -93,7 +93,7 @@ const BottomSheet = ({
               edge="end"
               sx={(theme) => ({
                 '& svg': {
-                  fill: headerTextColor || theme.palette.text.primary
+                  fill: headerTextColor || (theme.palette.surface?.tint ? theme.palette.common.white : theme.palette.text.primary)
                 },
                 transform: 'rotate(-90deg)',
                 '&:hover': {

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -43,7 +43,7 @@ const BottomSheet = ({
 
   const tint = theme.palette.surface?.tint;
   const finalHeaderBackgroundColor =
-    headerBackgroundColor ?? tint ?? theme.palette.background.default;
+    headerBackgroundColor || tint || theme.palette.background.default;
 
   const defaultForeground = headerBackgroundColor
     ? readableTextColor(

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -1,4 +1,5 @@
 import Slide, { SlideProps } from '@mui/material/Slide';
+import { useTheme } from '@mui/material/styles';
 import React, { useId } from 'react';
 import { Box } from '../../base/Box';
 import { Dialog } from '../../base/Dialog';
@@ -38,6 +39,14 @@ const BottomSheet = ({
   headerTextColor
 }: BottomSheetProps) => {
   const titleId = useId();
+  const theme = useTheme();
+
+  const tint = theme.palette.surface?.tint;
+  const finalHeaderBackgroundColor =
+    headerBackgroundColor || tint || theme.palette.background.default;
+  const usingTint = !headerBackgroundColor && Boolean(tint);
+  const finalHeaderTextColor =
+    headerTextColor || (usingTint ? theme.palette.common.white : theme.palette.text.primary);
 
   return (
     <Dialog
@@ -61,15 +70,15 @@ const BottomSheet = ({
       {title && (
         <>
           <Box
-            sx={(theme) => ({
+            sx={{
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'center',
               padding: '1rem',
               textAlign: 'center',
-              background: headerBackgroundColor || theme.palette.surface?.tint || theme.palette.background.default,
-              color: headerTextColor || (theme.palette.surface?.tint ? theme.palette.common.white : theme.palette.text.primary)
-            })}
+              background: finalHeaderBackgroundColor,
+              color: finalHeaderTextColor
+            }}
           >
             <Typography
               id={titleId}
@@ -91,9 +100,9 @@ const BottomSheet = ({
               onClick={onClose}
               size="small"
               edge="end"
-              sx={(theme) => ({
+              sx={{
                 '& svg': {
-                  fill: headerTextColor || (theme.palette.surface?.tint ? theme.palette.common.white : theme.palette.text.primary)
+                  fill: finalHeaderTextColor
                 },
                 transform: 'rotate(-90deg)',
                 '&:hover': {
@@ -101,7 +110,7 @@ const BottomSheet = ({
                   transition: 'all 0.3s ease-in',
                   cursor: 'pointer'
                 }
-              })}
+              }}
             >
               <CloseIcon />
             </IconButton>

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import Slide, { SlideProps } from '@mui/material/Slide';
-import { useTheme } from '../../theme';
+import { readableTextColor, useTheme } from '../../theme';
 import React, { useId } from 'react';
 import { Box } from '../../base/Box';
 import { Dialog } from '../../base/Dialog';
@@ -43,10 +43,21 @@ const BottomSheet = ({
 
   const tint = theme.palette.surface?.tint;
   const finalHeaderBackgroundColor =
-    headerBackgroundColor || tint || theme.palette.background.default;
-  const usingTint = !headerBackgroundColor && Boolean(tint);
-  const finalHeaderTextColor =
-    headerTextColor || (usingTint ? theme.palette.text.inverse : theme.palette.text.default);
+    headerBackgroundColor ?? tint ?? theme.palette.background.default;
+
+  const defaultForeground = headerBackgroundColor
+    ? readableTextColor(
+        headerBackgroundColor,
+        theme.palette.text.inverse,
+        theme.palette.text.default
+      )
+    : tint
+      ? // surface.tint is a dark gradient in both palettes, so always light ink
+        // (matches Modal / UniversalFilter tinted headers).
+        theme.palette.common.white
+      : theme.palette.text.default;
+
+  const finalHeaderTextColor = headerTextColor ?? defaultForeground;
 
   return (
     <Dialog

--- a/src/custom/BottomSheet/BottomSheet.tsx
+++ b/src/custom/BottomSheet/BottomSheet.tsx
@@ -1,5 +1,5 @@
 import Slide, { SlideProps } from '@mui/material/Slide';
-import { useTheme } from '@mui/material/styles';
+import { useTheme } from '../../theme';
 import React, { useId } from 'react';
 import { Box } from '../../base/Box';
 import { Dialog } from '../../base/Dialog';
@@ -46,7 +46,7 @@ const BottomSheet = ({
     headerBackgroundColor || tint || theme.palette.background.default;
   const usingTint = !headerBackgroundColor && Boolean(tint);
   const finalHeaderTextColor =
-    headerTextColor || (usingTint ? theme.palette.common.white : theme.palette.text.primary);
+    headerTextColor || (usingTint ? theme.palette.text.inverse : theme.palette.text.default);
 
   return (
     <Dialog

--- a/src/custom/DashboardLayout/DashboardLayout.tsx
+++ b/src/custom/DashboardLayout/DashboardLayout.tsx
@@ -27,6 +27,12 @@ export interface DashboardLayoutProps {
 
   /** Optional fixed height for the sticky sidebar. Defaults to 100vh */
   sidebarHeight?: string | number;
+
+  /** Background color for the mobile bottom sheet header */
+  headerBackgroundColor?: string;
+
+  /** Text color for the mobile bottom sheet header */
+  headerTextColor?: string;
 }
 
 export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
@@ -36,7 +42,9 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   sidebarTitle = 'Widget Picker',
   sidebarWidth = { xs: '100%', md: '350px' },
   sidebarTopOffset = '0',
-  sidebarHeight = '100vh'
+  sidebarHeight = '100vh',
+  headerBackgroundColor,
+  headerTextColor
 }) => {
   const theme = useTheme();
   // We use the 'md' breakpoint (900px default) to switch between mobile and desktop layout
@@ -76,6 +84,8 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
             onClose={() => setIsSheetVisible(false)}
             title={sidebarTitle}
             maxHeight="50vh"
+            headerBackgroundColor={headerBackgroundColor}
+            headerTextColor={headerTextColor}
           >
             {sidebarContent}
           </BottomSheet>


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #


<img width="414" height="642" alt="Screenshot 2026-08-28 at 8 57 58 PM" src="https://github.com/user-attachments/assets/88aaf393-5703-4903-90b7-f801a1faa6fb" />



**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery!

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR.
3. Sign your commits

By following the community's contribution conventions upfront, the review process will
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable header background and text colors for dashboard layouts and mobile bottom sheets.
  * Bottom Sheet headers now use the theme’s surface tint when no custom background is provided.

* **Bug Fixes**
  * Improved header text and close-button contrast across light and dark themes.
  * Corrected fallback behavior for empty or unavailable header backgrounds.
  * Updated default header colors to align with application theme settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->